### PR TITLE
Allow  investment option for MILP via quadratic term transformation

### DIFF
--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -147,6 +147,9 @@ class GenericStorage(network.Transformer):
             if (flow.nominal_value is not None and
                     self.nominal_input_capacity_ratio is not None):
                 raise AttributeError(e_duplicate)
+            if (flow.invesmtnet and flow.nonconvex is not None):
+                raise AttributeError("Can't combine nonconvex with"
+                                     " investment for storage optimization!")
             if (not self.investment and
                     self.nominal_input_capacity_ratio is not None):
                 flow.nominal_value = (self.nominal_input_capacity_ratio *
@@ -161,6 +164,9 @@ class GenericStorage(network.Transformer):
             if (flow.nominal_value is not None and
                     self.nominal_output_capacity_ratio is not None):
                 raise AttributeError(e_duplicate)
+            if (flow.invesmtnet and flow.nonconvex is not None):
+                raise AttributeError("Can't combine nonconvex with"
+                                     " investment for storage optimization!")
             if (not self.investment and
                     self.nominal_output_capacity_ratio is not None):
                 flow.nominal_value = (self.nominal_output_capacity_ratio *

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -10,6 +10,8 @@ connected.
 __copyright__ = "oemof developer group"
 __license__ = "GPLv3"
 
+import logging
+
 import oemof.network as on
 import oemof.energy_system as es
 from oemof.solph.plumbing import sequence
@@ -163,8 +165,11 @@ class Flow:
             raise ValueError("Using the investment object the nominal_value"
                              " has to be set to None.")
         if self.investment and self.nonconvex:
-            raise ValueError("Investment flows cannot be combined with " +
-                             "nonconvex flows!")
+            logging.warning(
+                "Combining flows with investment attribute"
+                " and nonconvex attribute can increase runtime"
+                " significantly. Your problem may not be solvalble! If so,"
+                " try to reduce model complexity, e.g. aggregate timesteps")
 
 
 class Bus(on.Bus):


### PR DESCRIPTION
* Added a transformation to convert quadratic expression to linear ones
  in NonConvexBlock
* Adapted Flow API and Storage API accordingly

@mloenneberga : We talked about this feature for micro grid optimization. Maybe you can test with your examples. 

This does not work for storages so far, but could be implemented analogously. 

* [ ] Speed up Pmin/Pmax   model creation by replacing pyomo rule with for-loop and BuildAction
* [ ] Check functionality
* [ ] Adapt docstrings
* [ ] Think about internal naming and location.
* [ ] Check if this actually does not affect up/down, startup etc. stuff, but it should not so far...