### PR TITLE
Allow conversion factor of zero for transformer

### DIFF
--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -553,10 +553,10 @@ class Transformer(SimpleBlock):
                     for o in out_flows[n]:
                         for i in in_flows[n]:
                             try:
-                                lhs = (m.flow[i, n, t] /
-                                       n.conversion_factors[i][t])
-                                rhs = (m.flow[n, o, t] /
+                                lhs = (m.flow[i, n, t] *
                                        n.conversion_factors[o][t])
+                                rhs = (m.flow[n, o, t] *
+                                       n.conversion_factors[i][t])
                             except ValueError:
                                 raise ValueError(
                                     "Error in constraint creation",


### PR DESCRIPTION
Adapted constraint for comparison of input and output flows with
conversion factors to allow zero values.

By now, setting a conversion factor of "0" to a transformer leads to an zero-division-error due to following part in constraints (`oemof.solph.blocks.Transformer._create()._input_output_relation()`:
```
lhs = (m.flow[i, n, t] / n.conversion_factors[i][t])
rhs = (m.flow[n, o, t] / n.conversion_factors[o][t])
...
block.relation.add((n, i, o, t), (lhs == rhs))
```
I simply switched conversion factors and avoid the zero-division-error!
```
lhs = (m.flow[i, n, t] * n.conversion_factors[o][t])
rhs = (m.flow[n, o, t] * n.conversion_factors[i][t])
...
block.relation.add((n, i, o, t), (lhs == rhs))
```
Results stay the same, only lp-file tests are failing.
I wanted to discuss this before I adapt those tests.
Any drawbacks?

