### PR TITLE
Features/timedependent summed max

### DIFF
--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -36,6 +36,8 @@ class EnergySystem:
         Defaults to `[]` if not supplied.
     timeindex : pandas.datetimeindex
         Define the time range and increment for the energy system.
+    subperiods : dict (optional)
+        Dictionary with defined sub periods for the timeindex
     groupings : list
         The elements of this list are used to construct :class:`Groupings
         <oemof.core.energy_system.Grouping>` or they are used directly if they
@@ -121,6 +123,8 @@ class EnergySystem:
         self.results = kwargs.get('results')
 
         self.timeindex = kwargs.get('timeindex')
+
+        self.subperiods = kwargs.get('subperiods')
 
         self.temporal = kwargs.get('temporal')
 

--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -10,7 +10,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 from functools import partial
+import pandas as pd
 from pickle import UnpicklingError
+from itertools import chain
 import logging
 import os
 
@@ -124,7 +126,15 @@ class EnergySystem:
 
         self.timeindex = kwargs.get('timeindex')
 
-        self.subperiods = kwargs.get('subperiods')
+        self.subperiods = kwargs.get('subperiods', {0: self.timeindex})
+
+        check_subperiods_timeindex = pd.DatetimeIndex(
+            chain(*[i.values for i in self.subperiods.values()]),
+            tz=self.timeindex.tz, freq='H')
+
+        if not self.timeindex.equals(check_subperiods_timeindex):
+            raise ValueError(
+                "Timeindex and subperiods values do not match!")
 
         self.temporal = kwargs.get('temporal')
 

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -147,12 +147,14 @@ class Flow(SimpleBlock):
             """Rule definition for build action of max. sum flow constraint.
             """
             for inp, out in self.SUMMED_MAX_FLOWS:
-                lhs = sum(m.flow[inp, out, ts] * m.timeincrement[ts]
-                          for ts in m.TIMESTEPS)
-                rhs = (m.flows[inp, out].summed_max *
-                       m.flows[inp, out].nominal_value)
-                self.summed_max.add((inp, out), lhs <= rhs)
-        self.summed_max = Constraint(self.SUMMED_MAX_FLOWS, noruleinit=True)
+                for p in m.SUBPERIODS:
+                    lhs = sum(m.flow[inp, out, ts] * m.timeincrement[ts]
+                              for ts in m.SUBPERIODS[p])
+                    rhs = (m.flows[inp, out].summed_max[p] *
+                           m.flows[inp, out].nominal_value)
+                    self.summed_max.add((inp, out, p), lhs <= rhs)
+        self.summed_max = Constraint(
+            self.SUMMED_MAX_FLOWS, m.SUBPERIODS.keys(), noruleinit=True)
         self.summed_max_build = BuildAction(rule=_flow_summed_max_rule)
 
         def _flow_summed_min_rule(model):

--- a/oemof/solph/blocks.py
+++ b/oemof/solph/blocks.py
@@ -161,12 +161,14 @@ class Flow(SimpleBlock):
             """Rule definition for build action of min. sum flow constraint.
             """
             for inp, out in self.SUMMED_MIN_FLOWS:
-                lhs = sum(m.flow[inp, out, ts] * m.timeincrement[ts]
-                          for ts in m.TIMESTEPS)
-                rhs = (m.flows[inp, out].summed_min *
-                       m.flows[inp, out].nominal_value)
-                self.summed_min.add((inp, out), lhs >= rhs)
-        self.summed_min = Constraint(self.SUMMED_MIN_FLOWS, noruleinit=True)
+                for p in m.SUBPERIODS:
+                    lhs = sum(m.flow[inp, out, ts] * m.timeincrement[ts]
+                              for ts in m.TIMESTEPS)
+                    rhs = (m.flows[inp, out].summed_min[p] *
+                           m.flows[inp, out].nominal_value)
+                    self.summed_min.add((inp, out, p), lhs >= rhs)
+        self.summed_min = Constraint(
+            self.SUMMED_MIN_FLOWS, m.SUBPERIODS.keys(), noruleinit=True)
         self.summed_min_build = BuildAction(rule=_flow_summed_min_rule)
 
         def _positive_gradient_flow_rule(model):

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -270,6 +270,11 @@ class Model(BaseModel):
         self.TIMESTEPS = po.Set(initialize=range(len(self.es.timeindex)),
                                 ordered=True)
 
+        if self.es.subperiods is None:
+            self.SUBPERIODS = {0: self.TIMESTEPS}
+        else:
+            self.SUBPERIODS = self.es.subperiods
+
         # previous timesteps
         previous_timesteps = [x - 1 for x in self.TIMESTEPS]
         previous_timesteps[0] = self.TIMESTEPS.last()

--- a/oemof/solph/models.py
+++ b/oemof/solph/models.py
@@ -270,10 +270,18 @@ class Model(BaseModel):
         self.TIMESTEPS = po.Set(initialize=range(len(self.es.timeindex)),
                                 ordered=True)
 
+        # kind of hackish way to convert timeindex to ranges for SUBPERIODS
         if self.es.subperiods is None:
             self.SUBPERIODS = {0: self.TIMESTEPS}
         else:
-            self.SUBPERIODS = self.es.subperiods
+            self.SUBPERIODS = {}
+            for k, v in self.es.subperiods.items():
+                if k > 0:
+                    self.SUBPERIODS[k] = range(
+                        self.SUBPERIODS[k-1][-1]+1,
+                        self.SUBPERIODS[k-1][-1]+1 + len(v))
+                else:
+                    self.SUBPERIODS[k] = range(0, len(v))
 
         # previous timesteps
         previous_timesteps = [x - 1 for x in self.TIMESTEPS]

--- a/oemof/solph/network.py
+++ b/oemof/solph/network.py
@@ -146,7 +146,10 @@ class Flow(on.Edge):
 
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self,
+                 summed_max=None,
+                 summed_min=None,
+                 **kwargs):
         # TODO: Check if we can inherit from pyomo.core.base.var _VarData
         # then we need to create the var object with
         # pyomo.core.base.IndexedVarWithDomain before any Flow is created.
@@ -155,7 +158,7 @@ class Flow(on.Edge):
 
         super().__init__()
 
-        scalars = ['nominal_value', 'summed_max', 'summed_min',
+        scalars = ['nominal_value',
                    'investment', 'nonconvex', 'integer', 'fixed']
         sequences = ['actual_value', 'variable_costs', 'min', 'max']
         dictionaries = ['positive_gradient', 'negative_gradient']
@@ -177,6 +180,18 @@ class Flow(on.Edge):
             else:
                 setattr(self, attribute,
                         sequence(value) if attribute in sequences else value)
+        if summed_max is None:
+            self.summed_max = None
+        elif type(summed_max) is dict:
+            self.summed_max = summed_max
+        else:
+            self.summed_max = {0: summed_max}
+        if summed_min is None:
+            self.summed_min = None
+        elif type(summed_min) is dict:
+            self.summed_min = summed_min
+        else:
+            self.summed_min = {0: summed_min}
 
         # Checking for impossible attribute combinations
         if self.fixed and self.actual_value[0] is None:


### PR DESCRIPTION
(New PR, as deleting the 0.3 release branch closed #574.)

* Describe your pull request as transparent as possible
  * Allows to set max / min sums for the timehorizon for sub-periods of the timeindex 
  * oemof.energy_system, oemof.solph.models, oemof.solph.blocks
  * API sketch: 
```
es = EnergySystem 

es.subperiods = {0: [0, 1, ..., 23], 1: [24, 25, ... 47]} # values are sub-set of m.TIMESTEPS set in the model
...
Flow(..., summed_max={0: 2000, 1: 5000})

```

* Related issues?
#573 

* Other comments and questions
I am up to any changes, naming or whatever. I just added a very short sketch before doing too much. 

I think it would be great to keep the option to have `summed_max` as scalar also if not set differently
 
* [ ] For new features: Remember the documentation!
* [ ] Adapt tests 
* [ ] New tests? 
* [ ] Decide on naming for `subperiods`
* [ ] Decide on API 