### PR TITLE
Fix error message if object is a component not a Flow

### DIFF
--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -124,10 +124,16 @@ def results(om):
         try:
             df_dict[k].index = om.es.timeindex
         except ValueError as e:
-            msg = ("\nFlow: {0}-{1}. This could be caused by NaN-values in"
-                   " your input data.")
-            raise type(e)(str(e) + msg.format(k[0].label, k[1].label)
-                          ).with_traceback(sys.exc_info()[2])
+            msg = ("\n{2}: {0}-{1}. This could be caused by"
+                   " different dimensions or NaN-values in your input data.")
+            if k[1] is not None:
+                raise type(e)(str(e) + msg.format(k[0].label, k[1].label,
+                                                  'Flow')
+                              ).with_traceback(sys.exc_info()[2])
+            else:
+                raise type(e)(str(e) + msg.format(k[0].label, 'None',
+                                                  'Component')
+                              ).with_traceback(sys.exc_info()[2])
         try:
             condition = df_dict[k].isnull().any()
             scalars = df_dict[k].loc[:, condition].dropna().iloc[0]

--- a/oemof/outputlib/processing.py
+++ b/oemof/outputlib/processing.py
@@ -124,16 +124,10 @@ def results(om):
         try:
             df_dict[k].index = om.es.timeindex
         except ValueError as e:
-            msg = ("\n{2}: {0}-{1}. This could be caused by"
-                   " different dimensions or NaN-values in your input data.")
-            if k[1] is not None:
-                raise type(e)(str(e) + msg.format(k[0].label, k[1].label,
-                                                  'Flow')
-                              ).with_traceback(sys.exc_info()[2])
-            else:
-                raise type(e)(str(e) + msg.format(k[0].label, 'None',
-                                                  'Component')
-                              ).with_traceback(sys.exc_info()[2])
+            msg = ("\nFlow: {0}-{1}. This could be caused by NaN-values in"
+                   " your input data.")
+            raise type(e)(str(e) + msg.format(k[0].label, k[1].label)
+                          ).with_traceback(sys.exc_info()[2])
         try:
             condition = df_dict[k].isnull().any()
             scalars = df_dict[k].loc[:, condition].dropna().iloc[0]

--- a/oemof/solph/components.py
+++ b/oemof/solph/components.py
@@ -328,8 +328,17 @@ class GenericStorageBlock(SimpleBlock):
             """Rule definition for bounds of capacity variable of storage n
             in timestep t
             """
-            bounds = (n.nominal_storage_capacity * n.min_storage_level[t],
-                      n.nominal_storage_capacity * n.max_storage_level[t])
+            try:
+                bounds = (n.nominal_storage_capacity * n.min_storage_level[t],
+                          n.nominal_storage_capacity * n.max_storage_level[t])
+            except IndexError:
+                msg = (
+                    "Minimum/maximum storage level has a different length than"
+                    " the time steps. It is possible to define a list-like "
+                    "element or a scalar. A list-like element must have the "
+                    "same length as the number of time steps."
+                    "\nNumber of time steps: {0}.\nComponent: {1}")
+                raise ValueError(msg.format(len(m.TIMESTEPS), n.label))
             return bounds
         self.capacity = Var(self.STORAGES, m.TIMESTEPS,
                             bounds=_storage_capacity_bound_rule)


### PR DESCRIPTION
According to [this issue in the forum](https://forum.openmod-initiative.org/t/genericstorage-results-non-invest-error-label-bus-tuple-nonetype/1676) the solph error message fails if the object is a component. This is rare because the error message is raised if a sequence has a different size than the time index. For example storages do have time series.

* [ ] Add a test.
