### PR TITLE
Fix/remove entity class

### DIFF
--- a/oemof/energy_system.py
+++ b/oemof/energy_system.py
@@ -81,7 +81,6 @@ class EnergySystem:
     <oemof.core.network.Entity>` will always be grouped by their :attr:`uid
     <oemof.core.network.Entity.uid>`:
 
-    >>> from oemof.network import Entity
     >>> from oemof.network import Bus, Sink
     >>> es = EnergySystem()
     >>> bus = Bus(label='electricity')

--- a/oemof/network.py
+++ b/oemof/network.py
@@ -234,6 +234,8 @@ class Node:
         """
         return self._outputs
 
+# TODO: Adhere to PEP 0257 by listing the exported classes with a short
+#       summary.
 
 EdgeLabel = NT("EdgeLabel", ['input', 'output'])
 class Edge(Node):
@@ -346,77 +348,6 @@ class Source(Component):
 
 class Transformer(Component):
     pass
-
-
-# TODO: Adhere to PEP 0257 by listing the exported classes with a short
-#       summary.
-class Entity:
-    r"""
-    The most abstract type of vertex in an energy system graph. Since each
-    entity in an energy system has to be uniquely identifiable and
-    connected (either via input or via output) to at least one other
-    entity, these properties are collected here so that they are shared
-    with descendant classes.
-
-    Parameters
-    ----------
-    uid : string or tuple
-        Unique component identifier of the entity.
-    inputs : list
-        List of Entities acting as input to this Entity.
-    outputs : list
-        List of Entities acting as output from this Entity.
-    geo_data : shapely.geometry object
-        Geo-spatial data with informations for location/region-shape. The
-        geometry can be a polygon/multi-polygon for regions, a line fore
-        transport objects or a point for objects such as transformer sources.
-
-    Attributes
-    ----------
-    registry: :class:`EnergySystem <oemof.core.energy_system.EnergySystem>`
-        The central registry keeping track of all :class:`Node's <Node>`
-        created. If this is `None`, :class:`Node` instances are not
-        kept track of. Assign an :class:`EnergySystem
-        <oemof.core.energy_system.EnergySystem>` to this attribute to have it
-        become the a :class:`node <Node>` registry, i.e. all :class:`nodes
-        <Node>` created are added to its :attr:`nodes
-        <oemof.core.energy_system.EnergySystem.nodes>`
-        property on construction.
-    """
-    optimization_options = {}
-
-    registry = None
-
-    def __init__(self, **kwargs):
-        # TODO: @Günni:
-        # add default argument values to docstrings (if it's possible).
-        self.uid = kwargs["uid"]
-        self.inputs = kwargs.get("inputs", [])
-        self.outputs = kwargs.get("outputs", [])
-        for e_in in self.inputs:
-            if self not in e_in.outputs:
-                e_in.outputs.append(self)
-        for e_out in self.outputs:
-            if self not in e_out.inputs:
-                e_out.inputs.append(self)
-        self.geo_data = kwargs.get("geo_data", None)
-        self.regions = []
-        self.add_regions(kwargs.get('regions', []))
-        if __class__.registry is not None:
-            __class__.registry.add(self)
-
-        # TODO: @Gunni Yupp! Add docstring.
-    def add_regions(self, regions):
-        """Add regions to self.regions
-        """
-        self.regions.extend(regions)
-        for region in regions:
-            if self not in region.entities:
-                region.entities.append(self)
-
-    def __str__(self):
-        # TODO: @Günni: Unused privat method. No Docstring.
-        return "<{0} #{1}>".format(type(self).__name__, self.uid)
 
 
 @contextmanager

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -65,10 +65,10 @@ class TestsEnergySystem:
 
         ensys = es.EnergySystem(groupings=[by_uid])
 
-        ungrouped = [Entity(uid="Not in 'Group': {}".format(i))
-                     for i in range(10)]
-        grouped = [Entity(uid="In 'Group': {}".format(i))
-                   for i in range(10)]
+       # ungrouped = [Entity(uid="Not in 'Group': {}".format(i))
+       #              for i in range(10)]
+       # grouped = [Entity(uid="In 'Group': {}".format(i))
+       #            for i in range(10)]
         ok_(None not in ensys.groups)
         for g in ensys.groups.values():
             for e in ungrouped:

--- a/tests/basic_tests.py
+++ b/tests/basic_tests.py
@@ -18,7 +18,6 @@ from nose.tools import ok_, eq_
 import pandas as pd
 
 from oemof import energy_system as es
-from oemof.network import Entity
 from oemof.network import Bus, Transformer
 from oemof.network import Bus as NewBus, Node, temporarily_modifies_registry
 from oemof.groupings import Grouping, Nodes, Flows, FlowsWithNodes as FWNs
@@ -56,6 +55,7 @@ class TestsEnergySystem:
         self.es.nodes = empty
         ok_(self.es.entities is empty)
 
+
     def test_that_none_is_not_a_valid_group(self):
         def by_uid(n):
             if "Not in 'Group'" in n.uid:
@@ -77,6 +77,7 @@ class TestsEnergySystem:
             for e in grouped:
                 if isinstance(g, Iterable) and not isinstance(g, str):
                     ok_(e in g)
+
 
     @temporarily_modifies_registry
     def test_defining_multiple_groupings_with_one_function(self):


### PR DESCRIPTION
This pull request is meant to fix the issue #187 ("Entity class still exists") 

Basically I deleted the entity class from network.py and deleted some imports of the class. The comments in basic_tests.py are in order for the test to "run". As the class Entity doesn't exist anymore it cannot be used within the test. Most likely the test whole test is also obsolete? 

Also I'm pretty sure the docstring of the EnergySystem class is outdated, but I lack the understanding to fix the text. 

I would suggest you take it from here @gnn :) 