### PR TITLE
Disable GH PR and issue link checks outside of Travis

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,4 +47,11 @@ napoleon_use_ivar = True
 napoleon_use_rtype = False
 napoleon_use_param = False
 
-linkcheck_ignore = [r"https://requires.io/.*"]
+linkcheck_ignore = [r"https://requires.io/.*"] + (
+    [
+        r"https://github.com/oemof/oemof-solph/issues/*",
+        r"https://github.com/oemof/oemof-solph/pull/*",
+    ]
+    if not "TRAVIS" in os.environ
+    else []
+)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,6 +52,6 @@ linkcheck_ignore = [r"https://requires.io/.*"] + (
         r"https://github.com/oemof/oemof-solph/issues/*",
         r"https://github.com/oemof/oemof-solph/pull/*",
     ]
-    if not "TRAVIS" in os.environ
+    if "TRAVIS" not in os.environ
     else []
 )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ html_use_smartypants = True
 html_last_updated_fmt = '%b %d, %Y'
 html_split_index = False
 html_sidebars = {
-   '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
+    '**': ['searchbox.html', 'globaltoc.html', 'sourcelink.html'],
 }
 html_short_title = '%s-%s' % (project, version)
 


### PR DESCRIPTION
Our changelog contains so many links to GitHub issues and pull requests that checking them all locally causes GitHub do respond with a 429 error because of too many requests, but the requests from Travis seem to be whitelisted. So this PR is about finding a way to disable requests to the most frequented URLs when testing locally, but keeping everything switched on when building on Travis.