### PR TITLE
Fix/new pandas version changed indexing

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -242,10 +242,13 @@ class TestParameterResult:
         param_results = processing.parameter_as_dict(
             self.es, exclude_none=True)
         bel1 = views.node(param_results, 'b_el1')
-        eq_(bel1['scalars'][(('b_el1', 'storage'), 'variable_costs')], 3)
+        assert (
+            bel1['scalars'][[(('b_el1', 'storage'), 'variable_costs')]].values,
+            3
+        )
 
         bel1_m = views.node(param_results, 'b_el1', multiindex=True)
-        eq_(bel1_m['scalars'].loc[('b_el1', 'storage', 'variable_costs')], 3)
+        eq_(bel1_m['scalars'][('b_el1', 'storage', 'variable_costs')], 3)
 
     def test_multiindex_sequences(self):
         results = processing.results(self.om)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -243,8 +243,8 @@ class TestParameterResult:
             self.es, exclude_none=True)
         bel1 = views.node(param_results, 'b_el1')
         assert (
-            bel1['scalars'][[(('b_el1', 'storage'), 'variable_costs')]].values,
-            3
+            bel1['scalars'][[(('b_el1', 'storage'), 'variable_costs')]].values
+            == 3
         )
 
         bel1_m = views.node(param_results, 'b_el1', multiindex=True)

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -102,11 +102,11 @@ def test_connect_invest():
     my_results['line12'] = float(views.node(results, 'line12')['scalars'])
     my_results['line21'] = float(views.node(results, 'line21')['scalars'])
     stor_res = views.node(results, 'storage')['scalars']
-    my_results['storage_in'] = stor_res[
-        (('electricity1', 'storage'), 'invest')]
-    my_results['storage'] = stor_res[(('storage', 'None'), 'invest')]
-    my_results['storage_out'] = stor_res[
-        (('storage', 'electricity1'), 'invest')]
+    my_results['storage_in'] = stor_res[[
+        (('electricity1', 'storage'), 'invest')]]
+    my_results['storage'] = stor_res[[(('storage', 'None'), 'invest')]]
+    my_results['storage_out'] = stor_res[[
+        (('storage', 'electricity1'), 'invest')]]
 
     connect_invest_dict = {
         'line12': 814705,

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -138,8 +138,8 @@ def test_tuples_as_labels_example(filename="storage_investment.csv",
     my_results = electricity_bus['sequences'].sum(axis=0).to_dict()
     storage = es.groups['storage_electricity_battery']
     storage_node = views.node(results, storage)
-    my_results['max_load'] = storage_node['sequences'].max()[
-        ((storage, None), 'storage_content')]
+    my_results['max_load'] = storage_node['sequences'].max()[[
+        ((storage, None), 'storage_content')]]
     commodity_bus = views.node(results, 'bus_natural_gas_None')
 
     gas_usage = commodity_bus['sequences'][

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -118,12 +118,12 @@ def test_variable_chp(filename="variable_chp.csv", solver='cbc'):
 
     for key in variable_chp_dict_max.keys():
         logging.debug("Test the maximum value of {0}".format(key))
-        eq_(int(round(maxresults[key])),
+        eq_(int(round(maxresults[[key]])),
             int(round(variable_chp_dict_max[key])))
 
     for key in variable_chp_dict_sum.keys():
         logging.debug("Test the summed up value of {0}".format(key))
-        eq_(int(round(sumresults[key])),
+        eq_(int(round(sumresults[[key]])),
             int(round(variable_chp_dict_sum[key])))
 
     eq_(parameter[(energysystem.groups["('fixed_chp', 'gas')"], None)]


### PR DESCRIPTION
* Describe your pull request as transparent as possible
  * The new pandas version does not allow tuples as index but we use tuples as index

The following test method from `class TestParameterResult` (test_processing.py) fails but worked with old python versions.

```python
def test_parameter_with_node_view(self):
        param_results = processing.parameter_as_dict(
            self.es, exclude_none=True)
        bel1 = views.node(param_results, 'b_el1')
        assert (
            bel1['scalars'][(('b_el1', 'storage'), 'variable_costs')].values
            == 3
        )
  ```

The problem is that `bel1['scalars'].index[13]` returns:
(('b_el1', 'storage'), 'variable_costs')

But the following does not work anymore:
```python
key = bel1['scalars'].index[13]
bel1['scalars'][key]
```
The reason is that key is a tuple you have to use the following code:
```python
key = bel1['scalars'].index[13]
bel1['scalars'][[key]]
```

But this is not very intuitive.

In the test above you have to make the following changes:

```diff
- bel1['scalars'][(('b_el1', 'storage'), 'variable_costs')].values
+ bel1['scalars'][[(('b_el1', 'storage'), 'variable_costs')]].values 
```

I fixed the test but we should think about the concept or we should add that to the documentation.
