### PR TITLE
Reject 'variable_cost' on Flow objects

### DIFF
--- a/src/oemof/solph/network.py
+++ b/src/oemof/solph/network.py
@@ -169,6 +169,11 @@ class Flow(on.Edge):
                     'negative_gradient': {'ub': None, 'costs': 0}}
         keys = [k for k in kwargs if k != 'label']
 
+        if 'variable_cost' in keys:
+            raise AttributeError(
+                "There is no `variable_cost` attribute,"
+                " did you mean `variable_costs`?")
+
         if 'fixed_costs' in keys:
             raise AttributeError(
                 "The `fixed_costs` attribute has been removed"

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -20,6 +20,15 @@ from oemof.solph import NonConvex
 from oemof.solph import components
 from oemof.tools.debugging import SuspiciousUsageWarning
 
+# ********* Flow *********
+
+
+def test_flow_typo_variable_cost():
+    msg = r"did you mean `variable_costs`"
+    with pytest.raises(AttributeError, match=msg):
+        Flow(variable_cost=42)
+
+
 # ********* GenericStorage *********
 
 


### PR DESCRIPTION
It took me way too long to find this missing typo: 'variable_cost' when
'variable_costs' was meant.

This commit changes the error mode for this typo: Instead of silently
ignoring the costs, the user would now get a loud complaint about this
typo.

Signed-off-by: Uli Schlachter <psychon@znc.in>

-----

Feel free to take this PR as an issue instead and fix it in a different way if you prefer that.
Also, no idea if the unit test works. I was not able to get things to run (likely because I tried running oemof-solph dev against the latest release of oemof-network).

-----

* Describe your pull request as transparent as possible
  * What functionality does it implement?
    * Depending on how you count: This either does not implement any functionality, or this implements a quality-of-life improvement that avoids many wasted hours chasing a typo (after one finally notices that there is a problem at all)
  * Where is it located?
    * I'm sorry, but I do not understand the question.
  * How does the API look?
    * User makes a typo. User gets an exception saying so.
  ...

* Related issues?
  * None. Feel free to treat this as an issue instead.

* Share your knowledge: Insights/Remarks
  * I like strongly typed languages. Dynamic types feel like "please continue even if things go wrong".
  * More seriously: What are other similar typos? Should this be extended into a list of common papercuts that should be dealt with? Does it perhaps even make sense to complain if any attributes are specified which are not understood / which will be ignored? However, no idea how this would be implemented.

* Other comments and questions
  * None, thanks for asking.

* [] For new features: Remember the documentation!
  * Uhm... and don't forget the fifth of November...
