### PR TITLE
Fix import order

### DIFF
--- a/src/oemof/solph/components.py
+++ b/src/oemof/solph/components.py
@@ -19,6 +19,7 @@ SPDX-License-Identifier: MIT
 """
 
 import numpy as np
+from oemof.network import network
 from pyomo.core.base.block import SimpleBlock
 from pyomo.environ import Binary
 from pyomo.environ import BuildAction
@@ -28,7 +29,6 @@ from pyomo.environ import NonNegativeReals
 from pyomo.environ import Set
 from pyomo.environ import Var
 
-from oemof.network import network
 from oemof.solph import network as solph_network
 from oemof.solph.options import Investment
 from oemof.solph.plumbing import sequence as solph_sequence

--- a/src/oemof/solph/custom.py
+++ b/src/oemof/solph/custom.py
@@ -20,6 +20,7 @@ SPDX-License-Identifier: MIT
 
 import logging
 
+from oemof.network import network as on
 from pyomo.core.base.block import SimpleBlock
 from pyomo.environ import Binary
 from pyomo.environ import BuildAction
@@ -29,7 +30,6 @@ from pyomo.environ import NonNegativeReals
 from pyomo.environ import Set
 from pyomo.environ import Var
 
-from oemof.network import network as on
 from oemof.solph.network import Bus
 from oemof.solph.network import Flow
 from oemof.solph.network import Sink

--- a/src/oemof/solph/groupings.py
+++ b/src/oemof/solph/groupings.py
@@ -22,6 +22,7 @@ SPDX-License-Identifier: MIT
 """
 
 from oemof.network import groupings as groupings
+
 from oemof.solph import blocks
 
 

--- a/src/oemof/solph/network.py
+++ b/src/oemof/solph/network.py
@@ -21,9 +21,10 @@ from warnings import warn
 
 from oemof.network import energy_system as es
 from oemof.network import network as on
+from oemof.tools import debugging
+
 from oemof.solph import blocks
 from oemof.solph.plumbing import sequence
-from oemof.tools import debugging
 
 
 class EnergySystem(es.EnergySystem):

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -18,9 +18,10 @@ import sys
 from itertools import groupby
 
 import pandas as pd
-from pyomo.core.base.var import Var
 
 from oemof.network.network import Node
+from pyomo.core.base.var import Var
+
 from oemof.solph.helpers import flatten
 
 

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -18,7 +18,6 @@ import sys
 from itertools import groupby
 
 import pandas as pd
-
 from oemof.network.network import Node
 from pyomo.core.base.var import Var
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -17,9 +17,9 @@ from os import path as ospath
 import pandas as pd
 from nose.tools import assert_raises
 from nose.tools import eq_
+from oemof.network.network import Node
 
 from oemof import solph
-from oemof.network.network import Node
 
 logging.disable(logging.INFO)
 

--- a/tests/solph_tests.py
+++ b/tests/solph_tests.py
@@ -12,10 +12,10 @@ SPDX-License-Identifier: MIT
 import os
 
 from nose.tools import ok_
-
-from oemof import solph as solph
 from oemof.network.energy_system import EnergySystem as EnSys
 from oemof.network.network import Node
+
+from oemof import solph as solph
 from oemof.solph import Investment
 from oemof.solph.blocks import InvestmentFlow as InvFlow
 from oemof.solph.helpers import extend_basic_path

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -12,13 +12,13 @@ SPDX-License-Identifier: MIT
 import warnings
 
 import pytest
+from oemof.tools.debugging import SuspiciousUsageWarning
 
 from oemof.solph import Bus
 from oemof.solph import Flow
 from oemof.solph import Investment
 from oemof.solph import NonConvex
 from oemof.solph import components
-from oemof.tools.debugging import SuspiciousUsageWarning
 
 # ********* GenericStorage *********
 

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -15,8 +15,8 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-
 from oemof.network import network
+
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -18,9 +18,9 @@ import logging
 
 import pandas as pd
 from nose.tools import ok_
+from oemof.network.network import Node
 from pyomo import environ as po
 
-from oemof.network.network import Node
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -16,8 +16,8 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-
 from oemof.network.network import Node
+
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -16,9 +16,9 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
+from oemof.network.network import Node
 
 from oemof import solph as solph
-from oemof.network.network import Node
 from oemof.solph import processing
 from oemof.solph import views
 

--- a/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
+++ b/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
@@ -15,8 +15,9 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-
 from oemof.network.network import Node
+from oemof.tools import economics
+
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow
@@ -26,7 +27,6 @@ from oemof.solph import Sink
 from oemof.solph import Source
 from oemof.solph import processing
 from oemof.solph import views
-from oemof.tools import economics
 
 
 def test_dispatch_fix_example(solver='cbc', periods=10):

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
@@ -12,8 +12,8 @@ SPDX-License-Identifier: MIT
 """
 
 from nose.tools import eq_
-
 from oemof.network.network import Node
+
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
@@ -17,8 +17,9 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-
 from oemof.network.network import Node
+from oemof.tools import economics
+
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow
@@ -29,7 +30,6 @@ from oemof.solph import Source
 from oemof.solph import Transformer
 from oemof.solph import processing
 from oemof.solph import views
-from oemof.tools import economics
 
 
 def test_dispatch_example(solver='cbc', periods=24*5):

--- a/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
@@ -12,9 +12,9 @@ SPDX-License-Identifier: MIT
 import logging
 
 import pandas as pd
+from oemof.network.network import Node
 
 from oemof import solph
-from oemof.network.network import Node
 from oemof.solph import views
 
 

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -40,12 +40,12 @@ from unittest import skip
 
 import pandas as pd
 from nose.tools import eq_
+from oemof.network.network import Node
+from oemof.tools import economics
 
 from oemof import solph
-from oemof.network.network import Node
 from oemof.solph import processing
 from oemof.solph import views
-from oemof.tools import economics
 
 PP_GAS = None
 

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -40,9 +40,9 @@ from collections import namedtuple
 
 import pandas as pd
 from nose.tools import eq_
+from oemof.network.network import Node
 
 from oemof import solph as solph
-from oemof.network.network import Node
 from oemof.solph import processing
 from oemof.solph import views
 

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -17,9 +17,9 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
+from oemof.network.network import Node
 
 from oemof import solph
-from oemof.network.network import Node
 from oemof.solph import views
 
 

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -12,9 +12,9 @@ SPDX-License-Identifier: MIT
 import warnings
 
 import pytest
+from oemof.tools.debugging import SuspiciousUsageWarning
 
 from oemof import solph
-from oemof.tools.debugging import SuspiciousUsageWarning
 
 
 class TestTransformerClass:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -12,10 +12,10 @@ SPDX-License-Identifier: MIT
 import warnings
 
 import pytest
-
-from oemof import solph
 from oemof.network import network
 from oemof.tools.debugging import SuspiciousUsageWarning
+
+from oemof import solph
 
 
 @pytest.fixture()


### PR DESCRIPTION
As network/tools, etc. are now third party libraries, tox complains about the order of import. This PR fixes the import order.
