### PR TITLE
Replaced private class import with public one

### DIFF
--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -18,8 +18,8 @@ import sys
 from itertools import groupby
 
 import pandas as pd
-from pyomo.core.base.piecewise import IndexedPiecewise
 from oemof.network.network import Node
+from pyomo.core.base.piecewise import IndexedPiecewise
 from pyomo.core.base.var import Var
 
 from oemof.solph.helpers import flatten

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -82,8 +82,9 @@ def create_dataframe(om):
         bv.parent_component() for bv in om.component_data_objects(Var)]))
     var_dict = {}
     for bv in block_vars:
-        # Drop the auxiliary variables introduced by pyomo's PIecewise
-        if not isinstance(bv.parent_block().parent_component(), IndexedPiecewise):
+        # Drop the auxiliary variables introduced by pyomo's Piecewise
+        parent_component = bv.parent_block().parent_component()
+        if not isinstance(parent_component, IndexedPiecewise):
             for i in getattr(bv, '_index'):
                 key = (
                     str(bv).split('.')[0],

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -82,6 +82,7 @@ def create_dataframe(om):
         bv.parent_component() for bv in om.component_data_objects(Var)]))
     var_dict = {}
     for bv in block_vars:
+        # Drop the auxiliary variables introduced by pyomo's PIecewise
         if not isinstance(bv.parent_block(), _PiecewiseData):
             for i in getattr(bv, '_index'):
                 key = (

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -18,7 +18,7 @@ import sys
 from itertools import groupby
 
 import pandas as pd
-from pyomo.core.base.piecewise import _PiecewiseData
+from pyomo.core.base.piecewise import IndexedPiecewise
 from pyomo.core.base.var import Var
 
 from oemof.network.network import Node
@@ -83,7 +83,7 @@ def create_dataframe(om):
     var_dict = {}
     for bv in block_vars:
         # Drop the auxiliary variables introduced by pyomo's PIecewise
-        if not isinstance(bv.parent_block(), _PiecewiseData):
+        if not isinstance(bv.parent_block().parent_component(), IndexedPiecewise):
             for i in getattr(bv, '_index'):
                 key = (
                     str(bv).split('.')[0],

--- a/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
+++ b/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
@@ -12,8 +12,8 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import numpy as np
-import oemof.solph as solph
 import pandas as pd
+import oemof.solph as solph
 from oemof.solph import Bus
 from oemof.solph import EnergySystem
 from oemof.solph import Flow

--- a/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
+++ b/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
@@ -13,6 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import numpy as np
 import pandas as pd
+
 import oemof.solph as solph
 from oemof.solph import Bus
 from oemof.solph import EnergySystem


### PR DESCRIPTION
This addresses https://github.com/oemof/oemof-solph/pull/592#pullrequestreview-566257556

In processing.py, a private class had been imported from pyomo.core.base.piecewise. This is now replaced by an import of the public class IndexedPiecewise.
