### PR TITLE
A suggestion for incresing the users understanding of timeindex and timeincrement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 *.py[cod]
 __pycache__
 
@@ -69,3 +70,5 @@ docs/_build
 
 # Mypy Cache
 .mypy_cache/
+# vs code
+.vscode

--- a/src/oemof/solph/models.py
+++ b/src/oemof/solph/models.py
@@ -337,7 +337,8 @@ class Model(BaseModel):
 
     def __init__(self, energysystem, **kwargs):
         # the auto_construct shows underdefined behavior since the parent is
-        # not fully initialised => timeindex & timeincrement are not set properly
+        # not fully initialised => timeindex & timeincrement are not
+        # set properly
         # There fore this "hack"
         kwargs_ = kwargs.copy()
         kwargs_.update({"auto_construct": False})

--- a/src/oemof/solph/models.py
+++ b/src/oemof/solph/models.py
@@ -284,7 +284,14 @@ class Model(BaseModel):
     ]
 
     def __init__(self, energysystem, **kwargs):
-        super().__init__(energysystem, **kwargs)
+        # the auto_construct shows underdefined behavior since the parent is
+        # not fully initialised => timeindex & timeincrement are not set properly
+        # There fore this "hack"
+        kwargs_ = kwargs.copy()
+        kwargs_.update({"auto_construct": False})
+        super().__init__(energysystem, **kwargs_)
+        if kwargs.get("auto_construct", True):
+            self._construct()
 
     def _add_parent_block_sets(self):
         """ """
@@ -292,8 +299,9 @@ class Model(BaseModel):
         self.NODES = po.Set(initialize=[n for n in self.es.nodes])
 
         # pyomo set for timesteps of optimization problem
+        # Calculation is done on increments
         self.TIMESTEPS = po.Set(
-            initialize=range(len(self.es.timeindex)), ordered=True
+            initialize=range(len(self.timeincrement)), ordered=True
         )
 
         # previous timesteps

--- a/src/oemof/solph/models.py
+++ b/src/oemof/solph/models.py
@@ -63,6 +63,19 @@ class BaseModel(po.ConcreteModel):
     dual : ... or None
     rc : ... or None
 
+    Remark:
+    -------
+    The timeindex and timeincrement attribute have the following connection:
+    Timeindex at step i marks the **end** of timeincrement at step i. That
+    means all initial values are at timeindex[0]-timeincrement[0] and are not
+    part of the results table. Therefore all flow values at step i represent
+    the value between timeindex[i-1] and timeindex[i] or for the timerange
+    timeincrement[i].
+
+    The timeincrement and the timeindex have the same length due to this
+    interpretation.
+
+
     """
 
     CONSTRAINT_GROUPS = []
@@ -126,7 +139,6 @@ class BaseModel(po.ConcreteModel):
                 freq=kwargs.get("timeincrement_unit", "H"),
                 closed="right",
             )
-
 
         self.objective_weighting = kwargs.get(
             "objective_weighting", self.timeincrement

--- a/src/oemof/solph/models.py
+++ b/src/oemof/solph/models.py
@@ -50,6 +50,8 @@ class BaseModel(po.ConcreteModel):
     -----------
     timeincrement : sequence
         Time increments.
+    timeindex : pd.DatetimeIndex
+        The corresponding timeindex omitting the initial step.
     flows : dict
         Flows of the model.
     name : str
@@ -109,7 +111,7 @@ class BaseModel(po.ConcreteModel):
             self.timeindex = self.timeindex[1:]
         elif self.timeincrement is not None:
             # if both are given than the timeincrement is the leading parameter
-            t0 = pd.Timestamp("2020-01-01")
+            t0 = pd.Timestamp("2021-01-01")
             # from this follows the timeindex, now one has to assume again
             # TODO Maybe a timeincrement unit by kwargs and default
             if isinstance(self.timeincrement, int):
@@ -328,8 +330,6 @@ class Model(BaseModel):
         kwargs_ = kwargs.copy()
         kwargs_.update({"auto_construct": False})
         super().__init__(energysystem, **kwargs_)
-        print(self.timeincrement)
-        print(self.timeindex)
         if kwargs.get("auto_construct", True):
             self._construct()
 
@@ -340,7 +340,6 @@ class Model(BaseModel):
 
         # pyomo set for timesteps of optimization problem
         # Calculation is done on increments
-        print(len(self.timeincrement))
         self.TIMESTEPS = po.Set(
             initialize=range(len(self.timeincrement)), ordered=True
         )

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -139,7 +139,8 @@ def results(om):
         df_dict[k].set_index("timestep", inplace=True)
         df_dict[k] = df_dict[k].pivot(columns="variable_name", values="value")
         try:
-            df_dict[k].index = om.es.timeindex
+            # pick the timeindex according to the model
+            df_dict[k].index = om.timeindex
         except ValueError as e:
             msg = (
                 "\nFlow: {0}-{1}. This could be caused by NaN-values in"
@@ -166,7 +167,7 @@ def results(om):
         grouped = groupby(sorted(om.Bus.balance.iterkeys()), lambda p: p[0])
         for bus, timesteps in grouped:
             duals = [om.dual[om.Bus.balance[bus, t]] for _, t in timesteps]
-            df = pd.DataFrame({"duals": duals}, index=om.es.timeindex)
+            df = pd.DataFrame({"duals": duals}, index=om.timeindex)
             if (bus, None) not in result.keys():
                 result[(bus, None)] = {
                     "sequences": df,

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -32,7 +32,9 @@ class TestsConstraint:
             r"^objective.*(?=s\.t\.)", re.DOTALL | re.MULTILINE
         )
 
-        cls.date_time_index = pd.date_range("1/1/2012", periods=3, freq="H")
+        cls.date_time_index = pd.date_range(
+            "1/1/2012", periods=3 + 1, freq="H"
+        )
 
         cls.tmppath = solph.helpers.extend_basic_path("tmp")
         logging.info(cls.tmppath)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,9 +19,13 @@ from oemof.solph.helpers import calculate_timeincrement
 
 
 def test_timeincrement_with_valid_timeindex():
-    datetimeindex = pd.date_range("1/1/2012", periods=1, freq="H")
+    """Test if given a correct timeindex the calculation of the time
+    increments are correct
+    """
+    datetimeindex = pd.date_range("1/1/2012", periods=2, freq="H")
     es = solph.EnergySystem(timeindex=datetimeindex)
     m = solph.models.BaseModel(es)
+    assert len(m.timeincrement) == 1
     assert m.timeincrement[0] == 1
     assert es.timeindex.freq.nanos / 3.6e12 == 1
 
@@ -33,6 +37,7 @@ def test_timeincrement_with_non_valid_timeindex():
 
 
 def test_timeincrement_value():
+    """in this case a timeindex is ignored since a timeincrement is given"""
     es = solph.EnergySystem(timeindex=4)
     m = solph.models.BaseModel(es, timeincrement=3)
     assert m.timeincrement[0] == 3
@@ -42,6 +47,9 @@ def test_timeincrement_list():
     es = solph.EnergySystem(timeindex=4)
     m = solph.models.BaseModel(es, timeincrement=[0, 1, 2, 3])
     assert m.timeincrement[3] == 3
+    assert len(m.timeindex) == 4
+    assert m.timeindex[0] == pd.Timestamp("2020-01-01 01:00:00")
+    assert m.timeindex[-1] == pd.Timestamp("2020-01-01 04:00:00")
 
 
 def test_nonequ_timeincrement():

--- a/tests/test_outputlib/__init__.py
+++ b/tests/test_outputlib/__init__.py
@@ -122,7 +122,7 @@ heat_pump = Transformer(
     conversion_factors={bel: 1 / 3, b_heat_source: (cop - 1) / cop},
 )
 
-datetimeindex = pd.date_range("1/1/2012", periods=24, freq="H")
+datetimeindex = pd.date_range("1/1/2012", periods=25, freq="H")
 energysystem = EnergySystem(timeindex=datetimeindex)
 energysystem.add(
     bcoal,
@@ -145,11 +145,8 @@ energysystem.add(
     heat_source,
     heat_pump,
 )
-
 # ################################ optimization ###########################
-
 # create optimization model based on energy_system
 optimization_model = Model(energysystem=energysystem)
-
 # solve problem
 optimization_model.solve()

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -34,7 +34,7 @@ class TestParameterResult:
         cls.period = 24
         cls.es = EnergySystem(
             timeindex=pandas.date_range(
-                "2016-01-01", periods=cls.period, freq="H"
+                "2016-01-01", periods=cls.period+1, freq="H"
             )
         )
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -34,7 +34,7 @@ class TestParameterResult:
         cls.period = 24
         cls.es = EnergySystem(
             timeindex=pandas.date_range(
-                "2016-01-01", periods=cls.period+1, freq="H"
+                "2016-01-01", periods=(cls.period + 1), freq="H"
             )
         )
 

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -38,7 +38,7 @@ def test_gen_caes():
     periods = len(data) - 1
 
     # create an energy system
-    idx = pd.date_range("1/1/2017", periods=periods, freq="H")
+    idx = pd.date_range("1/1/2017", periods=periods+1, freq="H")
     es = EnergySystem(timeindex=idx)
     Node.registry = es
 

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -38,7 +38,7 @@ def test_gen_caes():
     periods = len(data) - 1
 
     # create an energy system
-    idx = pd.date_range("1/1/2017", periods=periods+1, freq="H")
+    idx = pd.date_range("1/1/2017", periods=(periods + 1), freq="H")
     es = EnergySystem(timeindex=idx)
     Node.registry = es
 

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -32,7 +32,7 @@ def test_gen_chp():
     periods = len(data) - 1
 
     # create an energy system
-    idx = pd.date_range("1/1/2017", periods=periods+1, freq="H")
+    idx = pd.date_range("1/1/2017", periods=(periods + 1), freq="H")
     es = solph.EnergySystem(timeindex=idx)
     Node.registry = es
 

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -32,7 +32,7 @@ def test_gen_chp():
     periods = len(data) - 1
 
     # create an energy system
-    idx = pd.date_range("1/1/2017", periods=periods, freq="H")
+    idx = pd.date_range("1/1/2017", periods=periods+1, freq="H")
     es = solph.EnergySystem(timeindex=idx)
     Node.registry = es
 

--- a/tests/test_scripts/test_solph/test_lopf/test_lopf.py
+++ b/tests/test_scripts/test_solph/test_lopf/test_lopf.py
@@ -32,7 +32,7 @@ def test_lopf(solver="cbc"):
     logging.info("Initialize the energy system")
 
     # create time index for 192 hours in May.
-    date_time_index = pd.date_range("5/5/2012", periods=1+1, freq="H")
+    date_time_index = pd.date_range("5/5/2012", periods=(1 + 1), freq="H")
     es = EnergySystem(timeindex=date_time_index)
 
     ##########################################################################

--- a/tests/test_scripts/test_solph/test_lopf/test_lopf.py
+++ b/tests/test_scripts/test_solph/test_lopf/test_lopf.py
@@ -32,7 +32,7 @@ def test_lopf(solver="cbc"):
     logging.info("Initialize the energy system")
 
     # create time index for 192 hours in May.
-    date_time_index = pd.date_range("5/5/2012", periods=1, freq="H")
+    date_time_index = pd.date_range("5/5/2012", periods=1+1, freq="H")
     es = EnergySystem(timeindex=date_time_index)
 
     ##########################################################################

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch.py
@@ -29,7 +29,7 @@ from oemof.solph import processing
 from oemof.solph import views
 
 
-def test_dispatch_example(solver="cbc", periods=24 * 5):
+def test_dispatch_example(solver="cbc", periods=(24 * 5)):
     """Create an energy system and optimize the dispatch at least costs."""
 
     filename = os.path.join(os.path.dirname(__file__), "input_data.csv")
@@ -125,7 +125,7 @@ def test_dispatch_example(solver="cbc", periods=24 * 5):
         conversion_factors={bel: 1 / 3, b_heat_source: (cop - 1) / cop},
     )
 
-    datetimeindex = pd.date_range("1/1/2012", periods=periods, freq="H")
+    datetimeindex = pd.date_range("1/1/2012", periods=periods + 1, freq="H")
     energysystem = EnergySystem(timeindex=datetimeindex)
     energysystem.add(
         bcoal,

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
@@ -143,7 +143,7 @@ def test_dispatch_example(solver="cbc", periods=24 * 5):
         conversion_factors={bel: 1 / 3, b_heat_source: (cop - 1) / cop},
     )
 
-    datetimeindex = pd.date_range("1/1/2012", periods=periods, freq="H")
+    datetimeindex = pd.date_range("1/1/2012", periods=periods + 1, freq="H")
     energysystem = EnergySystem(timeindex=datetimeindex)
     energysystem.add(
         bcoal,

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -65,7 +65,7 @@ def test_tuples_as_labels_example(
 ):
 
     logging.info("Initialize the energy system")
-    date_time_index = pd.date_range("1/1/2012", periods=40, freq="H")
+    date_time_index = pd.date_range("1/1/2012", periods=40 + 1, freq="H")
 
     energysystem = solph.EnergySystem(timeindex=date_time_index)
     Node.registry = energysystem

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -27,7 +27,7 @@ def test_variable_chp(filename="variable_chp.csv", solver="cbc"):
     logging.info("Initialize the energy system")
 
     # create time index for 192 hours in May.
-    date_time_index = pd.date_range("5/5/2012", periods=5, freq="H")
+    date_time_index = pd.date_range("5/5/2012", periods=5 + 1, freq="H")
     energysystem = solph.EnergySystem(timeindex=date_time_index)
     Node.registry = energysystem
 


### PR DESCRIPTION
Hello everybody,

I am coming back to issue #758. Looking at all tests and the general usage
of omoef-solph I think for a user it is the most convenient way to just
initialize the energy system with a timeindex.

But one has to be very clear about the definition of all linear equations and
their meaning. Looking at a storge, one realises that the solutions of the
(MI)LP problem rely internally on the soly timeincrement $\tau_{i}$ variable. Therefore
the results have the following interpretation:

All *flows* in the system represent the value **during** the timeincrement $\tau_{i}$,
while all *energy states* represent the value at the **end** of the
timeincrement $\tau_{i}$

In order to pin this behavior, following changes were implemented:

The `oemof.solph.models.BaseModel` now calculates the timeincrements from the
timeindex, if it is given by a user and no timeincrement is given. Then
the resulting timeindex attribute is truncated at the initial timeindex.

If a timeincrement is set, the timeindex argument is ignored and reset with a
timeindex inline with the timeindex.

This means when using it with an timeindex

```python
>>> import pandas as pd
>>> index = pd.date_range("1/1/2021",period = 8760, freq ="H")
```

not a lot would change. The result timeindex first item would be '2021-01-01 01:00:00'
and the last '2021-12-30 23:00:00'. If one wants to include the last hour of the
year one needs to set period to 8760+1.

Also the `auto_construct` argument, in `omoef.solph.models.Model` is now always
set to false when initializing the parent class. After finishing the initialization
of the parent class the _construct this called. This probably needs discussion, since I
was unsure about the internal mechanism of initialization. To me it seems, the construct
should reside only in `omoef.solph.models.Model`.

The pyomo construction now builds upon `oemof.solph.models.BaseModel.timeindex`
and `oemof.solph.models.BaseModel.timeincrement` and not `oemof.solph.models.BaseModel.es`.

Furthermore all tests with period were set to period+1.

This is a first suggestion on how to improve the interpretation of results, which
was a little fuzzy before, since providing a timeindex it resulted in a timeincrement of the
same length.
