### PR TITLE
Remove gradient costs due to bugs and implementation errors

### DIFF
--- a/src/oemof/solph/blocks/flow.py
+++ b/src/oemof/solph/blocks/flow.py
@@ -260,7 +260,6 @@ class Flow(SimpleBlock):
         m = self.parent_block()
 
         variable_costs = 0
-        gradient_costs = 0
 
         for i, o in m.FLOWS:
             if m.flows[i, o].variable_costs[0] is not None:

--- a/src/oemof/solph/blocks/flow.py
+++ b/src/oemof/solph/blocks/flow.py
@@ -215,8 +215,6 @@ class Flow(SimpleBlock):
                         self.positive_gradient_constr.add(
                             (inp, out, ts), lhs <= rhs
                         )
-                    else:
-                        pass  # return(Constraint.Skip)
 
         self.positive_gradient_constr = Constraint(
             self.POSITIVE_GRADIENT_FLOWS, m.TIMESTEPS, noruleinit=True
@@ -235,8 +233,6 @@ class Flow(SimpleBlock):
                         self.negative_gradient_constr.add(
                             (inp, out, ts), lhs <= rhs
                         )
-                    else:
-                        pass  # return(Constraint.Skip)
 
         self.negative_gradient_constr = Constraint(
             self.NEGATIVE_GRADIENT_FLOWS, m.TIMESTEPS, noruleinit=True

--- a/src/oemof/solph/blocks/flow.py
+++ b/src/oemof/solph/blocks/flow.py
@@ -271,18 +271,4 @@ class Flow(SimpleBlock):
                         * m.flows[i, o].variable_costs[t]
                     )
 
-            if m.flows[i, o].positive_gradient["ub"][0] is not None:
-                for t in m.TIMESTEPS:
-                    gradient_costs += (
-                        self.positive_gradient[i, o, t]
-                        * m.flows[i, o].positive_gradient["costs"]
-                    )
-
-            if m.flows[i, o].negative_gradient["ub"][0] is not None:
-                for t in m.TIMESTEPS:
-                    gradient_costs += (
-                        self.negative_gradient[i, o, t]
-                        * m.flows[i, o].negative_gradient["costs"]
-                    )
-
-        return variable_costs + gradient_costs
+        return variable_costs

--- a/src/oemof/solph/network/flow.py
+++ b/src/oemof/solph/network/flow.py
@@ -52,8 +52,7 @@ class Flow(on.Edge):
          * `'ub'`: numeric (iterable, scalar or None), the normed *upper
            bound* on the positive difference (`flow[t-1] < flow[t]`) of
            two consecutive flow values.
-         * `'costs``: numeric (scalar or None), the gradient cost per
-           unit.
+         * `'costs``: REMOVED!
 
     negative_gradient : :obj:`dict`, default: `{'ub': None, 'costs': 0}`
 
@@ -62,8 +61,7 @@ class Flow(on.Edge):
           * `'ub'`: numeric (iterable, scalar or None), the normed *upper
             bound* on the negative difference (`flow[t-1] > flow[t]`) of
             two consecutive flow values.
-          * `'costs``: numeric (scalar or None), the gradient cost per
-            unit.
+          * `'costs``: REMOVED!
 
     summed_max : numeric, :math:`f_{sum,max}`
         Specific maximum value summed over all timesteps. Will be multiplied
@@ -142,8 +140,8 @@ class Flow(on.Edge):
         dictionaries = ["positive_gradient", "negative_gradient"]
         defaults = {
             "variable_costs": 0,
-            "positive_gradient": {"ub": None, "costs": 0},
-            "negative_gradient": {"ub": None, "costs": 0},
+            "positive_gradient": {"ub": None},
+            "negative_gradient": {"ub": None},
         }
         keys = [k for k in kwargs if k != "label"]
 
@@ -184,13 +182,24 @@ class Flow(on.Edge):
         if kwargs.get("max") is None:
             defaults["max"] = 1
 
+        # Check gradient dictionaries for non-valid keys
+        for gradient_dict in ["negative_gradient", "positive_gradient"]:
+            if gradient_dict in kwargs:
+                if list(kwargs[gradient_dict].keys()) != list(
+                    defaults[gradient_dict].keys()
+                ):
+                    msg = (
+                        "Only the key 'ub' is allowed for the '{0}' attribute"
+                    )
+                    raise AttributeError(msg.format(gradient_dict))
+
         for attribute in set(scalars + sequences + dictionaries + keys):
             value = kwargs.get(attribute, defaults.get(attribute))
             if attribute in dictionaries:
                 setattr(
                     self,
                     attribute,
-                    {"ub": sequence(value["ub"]), "costs": value["costs"]},
+                    {"ub": sequence(value["ub"])},
                 )
 
             else:

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -846,8 +846,8 @@ class TestsConstraint:
                 bel: solph.Flow(
                     nominal_value=999,
                     variable_costs=23,
-                    positive_gradient={"ub": 0.03, "costs": 7},
-                    negative_gradient={"ub": 0.05, "costs": 8},
+                    positive_gradient={"ub": 0.03},
+                    negative_gradient={"ub": 0.05},
                 )
             },
         )
@@ -887,7 +887,7 @@ class TestsConstraint:
                 nonconvex=solph.NonConvex(
                     positive_gradient={"ub": 0.03, "costs": 7},
                 ),
-                positive_gradient={"ub": 0.03, "costs": 7},
+                positive_gradient={"ub": 0.03},
             )
 
     def test_nonconvex_negative_gradient_error(self):
@@ -903,7 +903,7 @@ class TestsConstraint:
                 nonconvex=solph.NonConvex(
                     negative_gradient={"ub": 0.03, "costs": 7},
                 ),
-                negative_gradient={"ub": 0.03, "costs": 7},
+                negative_gradient={"ub": 0.03},
             )
 
     def test_investment_limit(self):

--- a/tests/flow_tests.py
+++ b/tests/flow_tests.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -
+
+"""Testing the flows.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location oemof/tests/test_components.py
+
+SPDX-License-Identifier: MIT
+"""
+
+import warnings
+
+import pytest
+from oemof.tools.debugging import SuspiciousUsageWarning
+
+from oemof.solph import Flow
+
+
+def test_error_in_gradient_attribute():
+    msg = "Only the key 'ub' is allowed for the '{0}' attribute"
+    with pytest.raises(AttributeError, match=msg.format("negative_gradient")):
+        Flow(negative_gradient={"costs": 5})
+    with pytest.raises(AttributeError, match=msg.format("positive_gradient")):
+        Flow(positive_gradient={"something": 5})

--- a/tests/flow_tests.py
+++ b/tests/flow_tests.py
@@ -9,10 +9,7 @@ available from its original location oemof/tests/test_components.py
 SPDX-License-Identifier: MIT
 """
 
-import warnings
-
 import pytest
-from oemof.tools.debugging import SuspiciousUsageWarning
 
 from oemof.solph import Flow
 

--- a/tests/lp_files/source_with_gradient.lp
+++ b/tests/lp_files/source_with_gradient.lp
@@ -2,12 +2,6 @@
 
 min 
 objective:
-+8 Flow_negative_gradient(powerplant_electricityBus_0)
-+8 Flow_negative_gradient(powerplant_electricityBus_1)
-+8 Flow_negative_gradient(powerplant_electricityBus_2)
-+7 Flow_positive_gradient(powerplant_electricityBus_0)
-+7 Flow_positive_gradient(powerplant_electricityBus_1)
-+7 Flow_positive_gradient(powerplant_electricityBus_2)
 +23 flow(powerplant_electricityBus_0)
 +23 flow(powerplant_electricityBus_1)
 +23 flow(powerplant_electricityBus_2)
@@ -57,10 +51,8 @@ bounds
    0 <= flow(powerplant_electricityBus_0) <= 999
    0 <= flow(powerplant_electricityBus_1) <= 999
    0 <= flow(powerplant_electricityBus_2) <= 999
-    -inf <= Flow_positive_gradient(powerplant_electricityBus_0) <= 29.969999999999999
     -inf <= Flow_positive_gradient(powerplant_electricityBus_1) <= 29.969999999999999
     -inf <= Flow_positive_gradient(powerplant_electricityBus_2) <= 29.969999999999999
-    -inf <= Flow_negative_gradient(powerplant_electricityBus_0) <= 49.950000000000003
     -inf <= Flow_negative_gradient(powerplant_electricityBus_1) <= 49.950000000000003
     -inf <= Flow_negative_gradient(powerplant_electricityBus_2) <= 49.950000000000003
 end

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -99,8 +99,6 @@ class TestParameterResult:
                     "nominal_value": 1,
                     "max": 1,
                     "min": 0,
-                    "negative_gradient_costs": 0,
-                    "positive_gradient_costs": 0,
                     "variable_costs": 0,
                     "label": str(b_el2.outputs[demand].label),
                 }
@@ -128,9 +126,7 @@ class TestParameterResult:
             "max": 1,
             "min": 0,
             "negative_gradient_ub": None,
-            "negative_gradient_costs": 0,
             "positive_gradient_ub": None,
-            "positive_gradient_costs": 0,
             "variable_costs": 0,
             "flow": None,
             "values": None,


### PR DESCRIPTION
Adding gradient costs e.g. `negative_gradient={"costs": 12}` will make the optimisation problem infeasible. Fixing the bug wil not help, because the costs are implemented wrongly.

This PR will remove the gradient costs but we can open a new PR afterwards to reimplement them in a clean way.