### PR TITLE
Features/add user feedback for infeasible storage parameters

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -258,11 +258,11 @@ class GenericStorage(network.Node):
 
     def _check_infeasible_parameter_combinations(self):
         """Checks for infeasible parameter combinations and raises error"""
-        msg = ("initial_storage_level must be geater or equal to "
+        msg = ("initial_storage_level must be greater or equal to "
                "min_storage_level and smaller or equal to "
                "max_storage_level.")
-        if (self.initial_storage_level < self.min_storage_level
-                or self.initial_storage_level > self.max_storage_level):
+        if (self.initial_storage_level < self.min_storage_level[0]
+                or self.initial_storage_level > self.max_storage_level[0]):
             raise ValueError(msg)
 
     def constraint_group(self):

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -261,9 +261,10 @@ class GenericStorage(network.Node):
         msg = ("initial_storage_level must be greater or equal to "
                "min_storage_level and smaller or equal to "
                "max_storage_level.")
-        if (self.initial_storage_level < self.min_storage_level[0]
-                or self.initial_storage_level > self.max_storage_level[0]):
-            raise ValueError(msg)
+        if self.initial_storage_level is not None:
+            if (self.initial_storage_level < self.min_storage_level[0]
+                    or self.initial_storage_level > self.max_storage_level[0]):
+                raise ValueError(msg)
 
     def constraint_group(self):
         if self._invest_group is True:

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -166,6 +166,8 @@ class GenericStorage(network.Node):
 
         # Check number of flows.
         self._check_number_of_flows()
+        # Check for infeasible parameter combinations
+        self._check_infeasible_parameter_combinations()
 
         # Check attributes for the investment mode.
         if self._invest_group is True:
@@ -253,6 +255,15 @@ class GenericStorage(network.Node):
             raise AttributeError(msg.format("input", self.label))
         if len(self.outputs) > 1:
             raise AttributeError(msg.format("output", self.label))
+
+    def _check_infeasible_parameter_combinations(self):
+        """Checks for infeasible parameter combinations and raises error"""
+        msg = ("initial_storage_level must be geater or equal to "
+               "min_storage_level and smaller or equal to "
+               "max_storage_level.")
+        if (self.initial_storage_level < self.min_storage_level
+                or self.initial_storage_level > self.max_storage_level):
+            raise ValueError(msg)
 
     def constraint_group(self):
         if self._invest_group is True:

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -76,6 +76,27 @@ def test_generic_storage_3():
     )
 
 
+def test_generic_storage_4():
+    """Infeasible parameter combination for initial_storage_level"""
+    bel = Bus()
+    with pytest.raises(
+        ValueError,
+        match="initial_storage_level must be greater"
+    ):
+        components.GenericStorage(
+            label="storage4",
+            nominal_storage_capacity=10,
+            inputs={bel: Flow(variable_costs=10e10)},
+            outputs={bel: Flow(variable_costs=10e10)},
+            loss_rate=0.00,
+            initial_storage_level=0,
+            min_storage_level=0.1,
+            invest_relation_input_capacity=1 / 6,
+            invest_relation_output_capacity=1 / 6,
+            inflow_conversion_factor=1,
+            outflow_conversion_factor=0.8,
+        )
+
 def test_generic_storage_with_old_parameters():
     deprecated = {
         "nominal_capacity": 45,

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -97,6 +97,7 @@ def test_generic_storage_4():
             outflow_conversion_factor=0.8,
         )
 
+
 def test_generic_storage_with_old_parameters():
     deprecated = {
         "nominal_capacity": 45,


### PR DESCRIPTION
Raise a ValueError if `initial_storage_level` is either smaller than `min_storage_level` or greater than `max_storage_level`.

Relates to #784.