### PR TITLE
Featuers/add user feedback for infeasible parameter combinations

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -264,8 +264,10 @@ class GenericStorage(network.Node):
             "max_storage_level."
         )
         if self.initial_storage_level is not None:
-            if (self.initial_storage_level < self.min_storage_level[0]
-                    or self.initial_storage_level > self.max_storage_level[0]):
+            if (
+                self.initial_storage_level < self.min_storage_level[0]
+                or self.initial_storage_level > self.max_storage_level[0]
+            ):
                 raise ValueError(msg)
 
     def constraint_group(self):

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -258,9 +258,11 @@ class GenericStorage(network.Node):
 
     def _check_infeasible_parameter_combinations(self):
         """Checks for infeasible parameter combinations and raises error"""
-        msg = ("initial_storage_level must be greater or equal to "
-               "min_storage_level and smaller or equal to "
-               "max_storage_level.")
+        msg = (
+            "initial_storage_level must be greater or equal to "
+            "min_storage_level and smaller or equal to "
+            "max_storage_level."
+        )
         if self.initial_storage_level is not None:
             if (self.initial_storage_level < self.min_storage_level[0]
                     or self.initial_storage_level > self.max_storage_level[0]):

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -80,8 +80,7 @@ def test_generic_storage_4():
     """Infeasible parameter combination for initial_storage_level"""
     bel = Bus()
     with pytest.raises(
-        ValueError,
-        match="initial_storage_level must be greater"
+        ValueError, match="initial_storage_level must be greater"
     ):
         components.GenericStorage(
             label="storage4",


### PR DESCRIPTION
Raise a ValueError if `initial_storage_level` is either smaller than `min_storage_level` or greater than `max_storage_level`.

Relates to #784.