### PR TITLE
Features/raise error for summed min and max

### DIFF
--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -221,7 +221,7 @@ class Flow(on.Edge):
 
         if not self.investment:
             warn_msg = (
-                "If {} is set in a dispatch model, "
+                "If {} is set in a flow (except InvestmentFlow), "
                 "nominal_value must be set as well.\n"
                 "Otherwise, it won't have any effect."
             )

--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -225,14 +225,13 @@ class Flow(on.Edge):
                 "nominal_value must be set as well.\n"
                 "Otherwise, it won't have any effect."
             )
-            if self.summed_max is not None:
-                if self.nominal_value is None:
+            if self.nominal_value is None:
+                if self.summed_max is not None:
                     warn(
                         warn_msg.format("summed_max"),
                         debugging.SuspiciousUsageWarning,
                     )
-            if self.summed_min is not None:
-                if self.nominal_value is None:
+                if self.summed_min is not None:
                     warn(
                         warn_msg.format("summed_min"),
                         debugging.SuspiciousUsageWarning,

--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -221,20 +221,23 @@ class Flow(on.Edge):
             )
 
         if not self.investment:
-            assumption_msg = (
+            warn_msg = (
                 "If {} is set in a dispatch model, "
-                "nominal_value must be set as well."
+                "nominal_value must be set as well.\n"
+                "Otherwise, it won't have any effect."
             )
             if self.summed_max is not None:
-                assert (
-                    math.isfinite(self.nominal_value),
-                    assumption_msg.format("summed_max")
-                )
-            if self.summex_min is not None:
-                assert (
-                    math.isfinite(self.nominal_value),
-                    assumption_msg.format("summed_min")
-                )
+                if self.nominal_value is None:
+                    warn(
+                        warn_msg.format("summed_max"),
+                        debugging.SuspiciousUsageWarning,
+                    )
+            if self.summed_min is not None:
+                if self.nominal_value is None:
+                    warn(
+                        warn_msg.format("summed_min"),
+                        debugging.SuspiciousUsageWarning,
+                    )
 
         # Checking for impossible gradient combinations
         if self.nonconvex:

--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -14,7 +14,6 @@ SPDX-FileCopyrightText: jmloenneberga
 SPDX-License-Identifier: MIT
 
 """
-import math
 from warnings import warn
 
 from oemof.network import network as on

--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -14,6 +14,7 @@ SPDX-FileCopyrightText: jmloenneberga
 SPDX-License-Identifier: MIT
 
 """
+import math
 from warnings import warn
 
 from oemof.network import network as on
@@ -219,6 +220,10 @@ class Flow(on.Edge):
                 + "nonconvex flows!"
             )
 
+        infinite_error_msg = (
+            "{} must be a finite value. Passing an infinite "
+            "value is not allowed."
+        )
         if not self.investment:
             warn_msg = (
                 "If {} is set in a flow (except InvestmentFlow), "
@@ -236,6 +241,11 @@ class Flow(on.Edge):
                         warn_msg.format("summed_min"),
                         debugging.SuspiciousUsageWarning,
                     )
+            else:
+                assert math.isfinite(
+                    self.nominal_value
+                ), infinite_error_msg.format("nominal_value")
+        assert math.isfinite(self.max[0]), infinite_error_msg.format("max")
 
         # Checking for impossible gradient combinations
         if self.nonconvex:

--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -14,7 +14,7 @@ SPDX-FileCopyrightText: jmloenneberga
 SPDX-License-Identifier: MIT
 
 """
-
+import math
 from warnings import warn
 
 from oemof.network import network as on
@@ -219,6 +219,22 @@ class Flow(on.Edge):
                 "Investment flows cannot be combined with "
                 + "nonconvex flows!"
             )
+
+        if not self.investment:
+            assumption_msg = (
+                "If {} is set in a dispatch model, "
+                "nominal_value must be set as well."
+            )
+            if self.summed_max is not None:
+                assert (
+                    math.isfinite(self.nominal_value),
+                    assumption_msg.format("summed_max")
+                )
+            if self.summex_min is not None:
+                assert (
+                    math.isfinite(self.nominal_value),
+                    assumption_msg.format("summed_min")
+                )
 
         # Checking for impossible gradient combinations
         if self.nonconvex:

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -92,6 +92,15 @@ def test_flow_with_fix_and_min_max():
         solph.flows.Flow(fix=[1, 3], max=[0, 5], min=[4, 9])
 
 
+def test_infinite_values():
+    msg1 = "nominal_value must be a finite value"
+    msg2 = "max must be a finite value"
+    with pytest.raises(AssertionError, match=msg1):
+        solph.flows.Flow(nominal_value=float("+inf"))
+    with pytest.raises(AssertionError, match=msg2):
+        solph.flows.Flow(max=float("+inf"))
+
+
 def test_summed_min_and_summed_max():
     msg1 = "If summed_max is set in a flow "
     msg2 = "If summed_min is set in a flow "

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -92,6 +92,15 @@ def test_flow_with_fix_and_min_max():
         solph.flows.Flow(fix=[1, 3], max=[0, 5], min=[4, 9])
 
 
+def test_summed_min_and_summed_max():
+    msg1 = "If summed_max is set in a dispatch model,"
+    msg2 = "If summed_min is set in a dispatch model,"
+    with pytest.raises(AssertionError, match=msg1):
+        solph.flows.Flow(summed_max=0.3)
+    with pytest.raises(AssertionError, match=msg2):
+        solph.flows.Flow(summed_min=0.3)
+
+
 def test_min_max_values_for_bidirectional_flow():
     a = solph.flows.Flow(bidirectional=True)  # use default values
     b = solph.flows.Flow(bidirectional=True, min=-0.9, max=0.9)

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -93,8 +93,8 @@ def test_flow_with_fix_and_min_max():
 
 
 def test_summed_min_and_summed_max():
-    msg1 = "If summed_max is set in a dispatch model,"
-    msg2 = "If summed_min is set in a dispatch model,"
+    msg1 = "If summed_max is set in a flow "
+    msg2 = "If summed_min is set in a flow "
     with pytest.warns(SuspiciousUsageWarning, match=msg1):
         solph.flows.Flow(summed_max=0.3)
     with pytest.warns(SuspiciousUsageWarning, match=msg2):

--- a/tests/test_solph_network_classes.py
+++ b/tests/test_solph_network_classes.py
@@ -95,9 +95,9 @@ def test_flow_with_fix_and_min_max():
 def test_summed_min_and_summed_max():
     msg1 = "If summed_max is set in a dispatch model,"
     msg2 = "If summed_min is set in a dispatch model,"
-    with pytest.raises(AssertionError, match=msg1):
+    with pytest.warns(SuspiciousUsageWarning, match=msg1):
         solph.flows.Flow(summed_max=0.3)
-    with pytest.raises(AssertionError, match=msg2):
+    with pytest.warns(SuspiciousUsageWarning, match=msg2):
         solph.flows.Flow(summed_min=0.3)
 
 


### PR DESCRIPTION
Resolve #755 

If `summed_max` or `summed_min` is set nominal value must be not None.
