### PR TITLE
Add inicativity_costs to NonConvex

### DIFF
--- a/docs/whatsnew/v0-5-0.rst
+++ b/docs/whatsnew/v0-5-0.rst
@@ -15,6 +15,7 @@ API changes
 New features
 ############
 
+* Add `inactivity_costs` as an option for `NonConvexFlow`.
 
 Documentation
 #############

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -113,6 +113,8 @@ class NonConvex:
     activity_costs : numeric (iterable or scalar)
         Costs associated with the active operation of the flow, independently
         from the actual output.
+    inactivity_costs : numeric (iterable or scalar)
+        Costs associated with not operating the flow.
     minimum_uptime : numeric (1 or positive integer)
         Minimum time that a flow must be greater then its minimum flow after
         startup. Be aware that minimum up and downtimes can contradict each
@@ -161,7 +163,12 @@ class NonConvex:
             "maximum_startups",
             "maximum_shutdowns",
         ]
-        sequences = ["startup_costs", "shutdown_costs", "activity_costs"]
+        sequences = [
+            "startup_costs",
+            "shutdown_costs",
+            "activity_costs",
+            "inactivity_costs",
+        ]
         dictionaries = ["positive_gradient", "negative_gradient"]
         defaults = {
             "initial_status": 0,

--- a/src/oemof/solph/flows/_non_convex_flow.py
+++ b/src/oemof/solph/flows/_non_convex_flow.py
@@ -699,4 +699,9 @@ class NonConvexFlowBlock(SimpleBlock):
 
             self.gradient_costs = Expression(expr=gradient_costs)
 
-        return startup_costs + shutdown_costs + activity_costs + gradient_costs
+        return (
+            startup_costs
+            + shutdown_costs
+            + activity_costs
+            + inactivity_costs
+            + gradient_costs)

--- a/src/oemof/solph/flows/_non_convex_flow.py
+++ b/src/oemof/solph/flows/_non_convex_flow.py
@@ -106,7 +106,7 @@ class NonConvexFlow(Flow):
             startup_costs=startup_costs,
             shutdown_costs=shutdown_costs,
             activity_costs=activity_costs,
-            inactivity_costs=activity_costs,
+            inactivity_costs=inactivity_costs,
             minimum_uptime=minimum_uptime,
             minimum_downtime=minimum_downtime,
             maximum_startups=maximum_startups,

--- a/src/oemof/solph/flows/_non_convex_flow.py
+++ b/src/oemof/solph/flows/_non_convex_flow.py
@@ -704,4 +704,5 @@ class NonConvexFlowBlock(SimpleBlock):
             + shutdown_costs
             + activity_costs
             + inactivity_costs
-            + gradient_costs)
+            + gradient_costs
+        )

--- a/src/oemof/solph/flows/_non_convex_flow.py
+++ b/src/oemof/solph/flows/_non_convex_flow.py
@@ -87,6 +87,7 @@ class NonConvexFlow(Flow):
         startup_costs=None,
         shutdown_costs=None,
         activity_costs=None,
+        inactivity_costs=None,
         minimum_uptime=None,
         minimum_downtime=None,
         maximum_startups=None,
@@ -105,6 +106,7 @@ class NonConvexFlow(Flow):
             startup_costs=startup_costs,
             shutdown_costs=shutdown_costs,
             activity_costs=activity_costs,
+            inactivity_costs=activity_costs,
             minimum_uptime=minimum_uptime,
             minimum_downtime=minimum_downtime,
             maximum_startups=maximum_startups,
@@ -129,6 +131,9 @@ class NonConvexFlowBlock(SimpleBlock):
     ACTIVITYCOSTFLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
         `activity_costs` being not None.
+    INACTIVITYCOSTFLOWS
+        A subset of set NONCONVEX_FLOWS with the attribute
+        `inactivity_costs` being not None.
     STARTUPFLOWS
         A subset of set NONCONVEX_FLOWS with the attribute
         `maximum_startups` or `startup_costs`
@@ -291,6 +296,11 @@ class NonConvexFlowBlock(SimpleBlock):
             \sum_{i, o \in ACTIVITYCOSTFLOWS} \sum_t status(i, o, t) \
             \cdot activity\_costs(i, o)
 
+    If `nonconvex.inactivity_costs` is set by the user:
+        .. math::
+            \sum_{i, o \in INACTIVITYCOSTFLOWS} \sum_t (1 - status(i, o, t)) \
+            \cdot inactivity\_costs(i, o)
+
     If `nonconvex.positive_gradient["costs"]` is set by the user:
         .. math::
             \sum_{i, o \in POSITIVE_GRADIENT_FLOWS} \sum_t
@@ -377,6 +387,14 @@ class NonConvexFlowBlock(SimpleBlock):
                 (g[0], g[1])
                 for g in group
                 if g[2].nonconvex.activity_costs[0] is not None
+            ]
+        )
+
+        self.INACTIVITYCOSTFLOWS = Set(
+            initialize=[
+                (g[0], g[1])
+                for g in group
+                if g[2].nonconvex.inactivity_costs[0] is not None
             ]
         )
 
@@ -612,6 +630,7 @@ class NonConvexFlowBlock(SimpleBlock):
         startup_costs = 0
         shutdown_costs = 0
         activity_costs = 0
+        inactivity_costs = 0
         gradient_costs = 0
 
         if self.STARTUPFLOWS:
@@ -644,6 +663,17 @@ class NonConvexFlowBlock(SimpleBlock):
                     )
 
             self.activity_costs = Expression(expr=activity_costs)
+
+        if self.INACTIVITYCOSTFLOWS:
+            for i, o in self.INACTIVITYCOSTFLOWS:
+                if m.flows[i, o].nonconvex.inactivity_costs[0] is not None:
+                    inactivity_costs += sum(
+                        (1 - self.status[i, o, t])
+                        * m.flows[i, o].nonconvex.inactivity_costs[t]
+                        for t in m.TIMESTEPS
+                    )
+
+            self.inactivity_costs = Expression(expr=inactivity_costs)
 
         if self.POSITIVE_GRADIENT_FLOWS:
             for i, o in self.POSITIVE_GRADIENT_FLOWS:

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1009,7 +1009,7 @@ class TestsConstraint:
                     min=0.5,
                     max=1.0,
                     variable_costs=10,
-                    nonconvex=solph.NonConvex(activity_costs=2),
+                    activity_costs=2,
                 )
             },
         )
@@ -1021,12 +1021,12 @@ class TestsConstraint:
         solph.components.Source(
             label="cheap_plant_inactivity_costs",
             outputs={
-                bus_t: solph.flows.Flow(
+                bus_t: solph.flows.NonConvexFlow(
                     nominal_value=10,
                     min=0.5,
                     max=1.0,
                     variable_costs=10,
-                    nonconvex=solph.NonConvex(inactivity_costs=2),
+                    inactivity_costs=2,
                 )
             },
         )

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1004,7 +1004,7 @@ class TestsConstraint:
         solph.components.Source(
             label="cheap_plant_activity_costs",
             outputs={
-                bus_t: solph.flows.Flow(
+                bus_t: solph.flows.NonConvexFlow(
                     nominal_value=10,
                     min=0.5,
                     max=1.0,

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1015,6 +1015,23 @@ class TestsConstraint:
         )
         self.compare_lp_files("activity_costs.lp")
 
+    def test_inactivity_costs(self):
+        """Testing inactivity_costs attribute for nonconvex flows."""
+        bus_t = solph.buses.Bus(label="Bus_C")
+        solph.components.Source(
+            label="cheap_plant_inactivity_costs",
+            outputs={
+                bus_t: solph.flows.Flow(
+                    nominal_value=10,
+                    min=0.5,
+                    max=1.0,
+                    variable_costs=10,
+                    nonconvex=solph.NonConvex(inactivity_costs=2),
+                )
+            },
+        )
+        self.compare_lp_files("inactivity_costs.lp")
+
     def test_piecewise_linear_transformer_cc(self):
         """Testing PiecewiseLinearTransformer using CC formulation."""
         bgas = solph.buses.Bus(label="gasBus")

--- a/tests/lp_files/inactivity_costs.lp
+++ b/tests/lp_files/inactivity_costs.lp
@@ -1,0 +1,71 @@
+\* Source Pyomo model name=Model *\
+
+min
+objective:
+-2 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_0)
+-2 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_1)
+-2 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_2)
++10 flow(cheap_plant_inactivity_costs_Bus_C_0)
++10 flow(cheap_plant_inactivity_costs_Bus_C_1)
++10 flow(cheap_plant_inactivity_costs_Bus_C_2)
++6 ONE_VAR_CONSTANT
+
+s.t.
+
+c_e_BusBlock_balance(Bus_C_0)_:
++1 flow(cheap_plant_inactivity_costs_Bus_C_0)
+= 0
+
+c_e_BusBlock_balance(Bus_C_1)_:
++1 flow(cheap_plant_inactivity_costs_Bus_C_1)
+= 0
+
+c_e_BusBlock_balance(Bus_C_2)_:
++1 flow(cheap_plant_inactivity_costs_Bus_C_2)
+= 0
+
+c_u_NonConvexFlowBlock_min(cheap_plant_inactivity_costs_Bus_C_0)_:
++5 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_0)
+-1 flow(cheap_plant_inactivity_costs_Bus_C_0)
+<= 0
+
+c_u_NonConvexFlowBlock_min(cheap_plant_inactivity_costs_Bus_C_1)_:
++5 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_1)
+-1 flow(cheap_plant_inactivity_costs_Bus_C_1)
+<= 0
+
+c_u_NonConvexFlowBlock_min(cheap_plant_inactivity_costs_Bus_C_2)_:
++5 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_2)
+-1 flow(cheap_plant_inactivity_costs_Bus_C_2)
+<= 0
+
+c_u_NonConvexFlowBlock_max(cheap_plant_inactivity_costs_Bus_C_0)_:
+-10 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_0)
++1 flow(cheap_plant_inactivity_costs_Bus_C_0)
+<= 0
+
+c_u_NonConvexFlowBlock_max(cheap_plant_inactivity_costs_Bus_C_1)_:
+-10 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_1)
++1 flow(cheap_plant_inactivity_costs_Bus_C_1)
+<= 0
+
+c_u_NonConvexFlowBlock_max(cheap_plant_inactivity_costs_Bus_C_2)_:
+-10 NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_2)
++1 flow(cheap_plant_inactivity_costs_Bus_C_2)
+<= 0
+
+c_e_ONE_VAR_CONSTANT:
+ONE_VAR_CONSTANT = 1.0
+
+bounds
+   0 <= flow(cheap_plant_inactivity_costs_Bus_C_0) <= 10
+   0 <= flow(cheap_plant_inactivity_costs_Bus_C_1) <= 10
+   0 <= flow(cheap_plant_inactivity_costs_Bus_C_2) <= 10
+   0 <= NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_0) <= 1
+   0 <= NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_1) <= 1
+   0 <= NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_2) <= 1
+binary
+  NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_0)
+  NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_1)
+  NonConvexFlowBlock_status(cheap_plant_inactivity_costs_Bus_C_2)
+end


### PR DESCRIPTION
 The newly added `inactivity_costs` explicitly model potential costs of non-operation. This might be applicable if degradation is faster when not operating a device. Previously, this could only be expressed implicitly, by giving negative values for the complementary `acitivity_costs`.

PS: This feature was originally proposed at openmod to model [startup_costs dependent on time since last run](https://forum.openmod.org/t/startup-costs-dependent-on-time-since-last-run/2937). When the costs rise linearly, this directly translates to `inacitivity_costs`.