### PR TITLE
Fixed check for callables in processing.parameter_as_dict()

### DIFF
--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -267,9 +267,7 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
             "registry",
             "inputs",
             "outputs",
-            "register",
             "Label",
-            "from_object",
             "input",
             "output",
             "constraint_group",
@@ -277,7 +275,7 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
         attrs = [
             i
             for i in dir(com)
-            if not (callable(i) or i.startswith(exclusions))
+            if not (callable(getattr(com, i)) or i.startswith(exclusions))
         ]
 
         for a in attrs:


### PR DESCRIPTION
When processing results, function `processing.parameter_as_dict()` should return scalars and sequences of given ES. Within the function is a check for methods (aka a check for `callable()`) which shall not be included in parameter dict. Nevertheless, the check was implemented incorrect, resulting in methods to go into parameter dict. This PR fixes that.

Fixes #707 

Error was related to check outcome of `dir(component)` for callables. But as `dir()` returns list-of-str and str is not callable, methods weren't filtered out. 
