### PR TITLE
Add option `exclude_attrs` to processing.parameter_as_dict() 

### DIFF
--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -369,7 +369,8 @@ def __separate_attrs(
             if len(value) == 0 or value[0] is None:
                 del com["sequences"][ckey]
 
-    exclude_attrs = exclude_attrs or []
+    if exclude_attrs is None:
+        exclude_attrs = []
 
     # Check if system is es or om:
     if system.__class__.__name__ == "EnergySystem":
@@ -411,7 +412,8 @@ def parameter_as_dict(system, exclude_none=True, exclude_attrs=None):
     dict: Parameters for all nodes and flows
     """
 
-    exclude_attrs = exclude_attrs or []
+    if exclude_attrs is None:
+        exclude_attrs = []
 
     flow_data = __separate_attrs(
         system, exclude_attrs, get_flows=True, exclude_none=exclude_none

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -243,7 +243,7 @@ def meta_results(om, undefined=False):
 
 
 def __separate_attrs(
-    system, exclude_attrs=None, get_flows=False, exclude_none=True
+    system, exclude_attrs, get_flows=False, exclude_none=True
 ):
     """
     Create a dictionary with flow scalars and series.
@@ -256,7 +256,7 @@ def __separate_attrs(
     system:
         A solved oemof.solph.Model or oemof.solph.Energysystem
     exclude_attrs: List[str]
-        Optional list of additional attributes which shall be excluded from
+        List of additional attributes which shall be excluded from
         parameter dict
     get_flows: bool
         Whether to include flow values or not
@@ -368,9 +368,6 @@ def __separate_attrs(
         for ckey, value in list(com["sequences"].items()):
             if len(value) == 0 or value[0] is None:
                 del com["sequences"][ckey]
-
-    if exclude_attrs is None:
-        exclude_attrs = []
 
     # Check if system is es or om:
     if system.__class__.__name__ == "EnergySystem":

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -242,7 +242,9 @@ def meta_results(om, undefined=False):
     return meta_res
 
 
-def __separate_attrs(system, get_flows=False, exclude_none=True):
+def __separate_attrs(
+    system, exclude_attrs, get_flows=False, exclude_none=True
+):
     """
     Create a dictionary with flow scalars and series.
 
@@ -251,7 +253,15 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
     {(node1, node2): {'scalars': {'attr1': scalar, 'attr2': 'text'},
     'sequences': {'attr1': iterable, 'attr2': iterable}}}
 
-    om : A solved oemof.solph.Model.
+    system:
+        A solved oemof.solph.Model or oemof.solph.Energysystem
+    exclude_attrs: List[str]
+        Optional list of additional attributes which shall be excluded from
+        parameter dict
+    get_flows: bool
+        Whether to include flow values or not
+    exclude_none: bool
+        If set, scalars and sequences containing None values are excluded
 
     Returns
     -------
@@ -261,7 +271,7 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
     def detect_scalars_and_sequences(com):
         com_data = {"scalars": {}, "sequences": {}}
 
-        exclusions = (
+        default_exclusions = [
             "__",
             "_",
             "registry",
@@ -273,7 +283,9 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
             "input",
             "output",
             "constraint_group",
-        )
+        ]
+        # Must be tuple in order to work with `str.startswith()`:
+        exclusions = tuple(default_exclusions + exclude_attrs)
         attrs = [
             i
             for i in dir(com)
@@ -372,7 +384,7 @@ def __separate_attrs(system, get_flows=False, exclude_none=True):
     return data
 
 
-def parameter_as_dict(system, exclude_none=True):
+def parameter_as_dict(system, exclude_none=True, exclude_attrs=None):
     """
     Create a result dictionary containing node parameters.
 
@@ -388,14 +400,23 @@ def parameter_as_dict(system, exclude_none=True):
         A populated energy system.
     exclude_none: bool
         If True, all scalars and sequences containing None values are excluded
+    exclude_attrs: Optional[List[str]]
+        Optional list of additional attributes which shall be excluded from
+        parameter dict
 
     Returns
     -------
     dict: Parameters for all nodes and flows
     """
 
-    flow_data = __separate_attrs(system, True, exclude_none)
-    node_data = __separate_attrs(system, False, exclude_none)
+    exclude_attrs = exclude_attrs or []
+
+    flow_data = __separate_attrs(
+        system, exclude_attrs, get_flows=True, exclude_none=exclude_none
+    )
+    node_data = __separate_attrs(
+        system, exclude_attrs, get_flows=False, exclude_none=exclude_none
+    )
 
     flow_data.update(node_data)
     return flow_data

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -368,7 +368,7 @@ def __separate_attrs(
         for ckey, value in list(com["sequences"].items()):
             if len(value) == 0 or value[0] is None:
                 del com["sequences"][ckey]
-    
+
     exclude_attrs = exclude_attrs or []
 
     # Check if system is es or om:

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -243,7 +243,7 @@ def meta_results(om, undefined=False):
 
 
 def __separate_attrs(
-    system, exclude_attrs, get_flows=False, exclude_none=True
+    system, exclude_attrs=None, get_flows=False, exclude_none=True
 ):
     """
     Create a dictionary with flow scalars and series.
@@ -368,6 +368,8 @@ def __separate_attrs(
         for ckey, value in list(com["sequences"].items()):
             if len(value) == 0 or value[0] is None:
                 del com["sequences"][ckey]
+    
+    exclude_attrs = exclude_attrs or []
 
     # Check if system is es or om:
     if system.__class__.__name__ == "EnergySystem":

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -238,6 +238,21 @@ class TestParameterResult:
             param_results[(diesel, None)]["sequences"], pandas.DataFrame()
         )
 
+    def test_nodes_with_excluded_attrs(self):
+        diesel = self.es.groups["diesel"]
+        param_results = processing.parameter_as_dict(self.es, exclude_attrs=["conversion_factors"])
+        assert_series_equal(
+            param_results[(diesel, None)]["scalars"],
+            pandas.Series(
+                {
+                    "label": "diesel",
+                }
+            ),
+        )
+        assert_frame_equal(
+            param_results[(diesel, None)]["sequences"], pandas.DataFrame()
+        )
+
     def test_parameter_with_node_view(self):
         param_results = processing.parameter_as_dict(
             self.es, exclude_none=True

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -240,7 +240,9 @@ class TestParameterResult:
 
     def test_nodes_with_excluded_attrs(self):
         diesel = self.es.groups["diesel"]
-        param_results = processing.parameter_as_dict(self.es, exclude_attrs=["conversion_factors"])
+        param_results = processing.parameter_as_dict(
+            self.es, exclude_attrs=["conversion_factors"]
+        )
         assert_series_equal(
             param_results[(diesel, None)]["scalars"],
             pandas.Series(


### PR DESCRIPTION
This PR adds an option to exclude attributes from `processing.parameter_as_dict()` scan in.

Closes #824 

