### PR TITLE
Convert Link assertion into SuspiciousUsageWarning

### DIFF
--- a/src/oemof/solph/components/experimental/_link.py
+++ b/src/oemof/solph/components/experimental/_link.py
@@ -92,7 +92,11 @@ class Link(on.Transformer):
             + "disable the SuspiciousUsageWarning globally."
         )
 
-        if len(self.inputs) != 2 or len(self.outputs) != 2 or len(self.conversion_factors) != 2:
+        if (
+            len(self.inputs) != 2
+            or len(self.outputs) != 2
+            or len(self.conversion_factors) != 2
+        ):
             warn(msg, debugging.SuspiciousUsageWarning)
 
     def constraint_group(self):

--- a/src/oemof/solph/components/experimental/_link.py
+++ b/src/oemof/solph/components/experimental/_link.py
@@ -86,7 +86,8 @@ class Link(on.Transformer):
         msg = (
             "Component `Link` should have exactly "
             + "2 inputs, 2 outputs, and 2 "
-            + "conversion factors connecting these. "
+            + "conversion factors connecting these. You are initializing a `Link` "
+            + "without obeying this specification. "
             + "If this is intended and you know what you are doing you can "
             + "disable the SuspiciousUsageWarning globally."
         )

--- a/src/oemof/solph/components/experimental/_link.py
+++ b/src/oemof/solph/components/experimental/_link.py
@@ -86,8 +86,8 @@ class Link(on.Transformer):
         msg = (
             "Component `Link` should have exactly "
             + "2 inputs, 2 outputs, and 2 "
-            + "conversion factors connecting these. You are initializing a `Link` "
-            + "without obeying this specification. "
+            + "conversion factors connecting these. You are initializing "
+            + "a `Link`without obeying this specification. "
             + "If this is intended and you know what you are doing you can "
             + "disable the SuspiciousUsageWarning globally."
         )

--- a/src/oemof/solph/components/experimental/_link.py
+++ b/src/oemof/solph/components/experimental/_link.py
@@ -16,8 +16,10 @@ SPDX-FileCopyrightText: jnnr
 SPDX-License-Identifier: MIT
 
 """
+from warnings import warn
 
 from oemof.network import network as on
+from oemof.tools import debugging
 from pyomo.core import Binary
 from pyomo.core import Set
 from pyomo.core import Var
@@ -81,14 +83,16 @@ class Link(on.Transformer):
             for k, v in kwargs.get("conversion_factors", {}).items()
         }
 
-        wrong_args_message = (
-            "Component `Link` must have exactly"
-            + "2 inputs, 2 outputs, and 2"
-            + "conversion factors connecting these."
+        msg = (
+            "Component `Link` should have exactly "
+            + "2 inputs, 2 outputs, and 2 "
+            + "conversion factors connecting these. "
+            + "If this is intended and you know what you are doing you can "
+            + "disable the SuspiciousUsageWarning globally."
         )
-        assert len(self.inputs) == 2, wrong_args_message
-        assert len(self.outputs) == 2, wrong_args_message
-        assert len(self.conversion_factors) == 2, wrong_args_message
+
+        if len(self.inputs) != 2 or len(self.outputs) != 2 or len(self.conversion_factors) != 2:
+            warn(msg, debugging.SuspiciousUsageWarning)
 
     def constraint_group(self):
         return LinkBlock


### PR DESCRIPTION
The __init__ of the Link component asserts that 2 inputs, outputs and conversion factors are passed. However, some users might want to initialize without passing those, setting them later. This is what oemof.tabular tries to do - and fails. The PR aims to fix that by converting the assertion into a SuspiciousUsageWarning which can be silenced.

Related: https://github.com/oemof/oemof-tabular/pull/21#issuecomment-1058331661