### PR TITLE
Fix black test failing

### DIFF
--- a/src/oemof/solph/custom/sink_dsm.py
+++ b/src/oemof/solph/custom/sink_dsm.py
@@ -2128,13 +2128,10 @@ class SinkDSMDIWInvestmentBlock(SimpleBlock):
                             + self.dsm_do_shed[g, tt]
                         )
                         # max capacity at tt
-                        rhs = (
-                            max(
-                                g.capacity_up[tt] * g.flex_share_up,
-                                g.capacity_down[tt] * g.flex_share_down,
-                            )
-                            * (self.invest[g] + g.investment.existing)
-                        )
+                        rhs = max(
+                            g.capacity_up[tt] * g.flex_share_up,
+                            g.capacity_down[tt] * g.flex_share_down,
+                        ) * (self.invest[g] + g.investment.existing)
 
                         # add constraint
                         block.C2_constraint.add((g, tt), (lhs <= rhs))
@@ -2153,13 +2150,10 @@ class SinkDSMDIWInvestmentBlock(SimpleBlock):
                             + self.dsm_do_shed[g, tt]
                         )
                         # max capacity at tt
-                        rhs = (
-                            max(
-                                g.capacity_up[tt] * g.flex_share_up,
-                                g.capacity_down[tt] * g.flex_share_down,
-                            )
-                            * (self.invest[g] + g.investment.existing)
-                        )
+                        rhs = max(
+                            g.capacity_up[tt] * g.flex_share_up,
+                            g.capacity_down[tt] * g.flex_share_down,
+                        ) * (self.invest[g] + g.investment.existing)
 
                         # add constraint
                         block.C2_constraint.add((g, tt), (lhs <= rhs))
@@ -2178,13 +2172,10 @@ class SinkDSMDIWInvestmentBlock(SimpleBlock):
                             + self.dsm_do_shed[g, tt]
                         )
                         # max capacity at tt
-                        rhs = (
-                            max(
-                                g.capacity_up[tt] * g.flex_share_up,
-                                g.capacity_down[tt] * g.flex_share_down,
-                            )
-                            * (self.invest[g] + g.investment.existing)
-                        )
+                        rhs = max(
+                            g.capacity_up[tt] * g.flex_share_up,
+                            g.capacity_down[tt] * g.flex_share_down,
+                        ) * (self.invest[g] + g.investment.existing)
 
                         # add constraint
                         block.C2_constraint.add((g, tt), (lhs <= rhs))
@@ -4218,13 +4209,10 @@ class SinkDSMDLRInvestmentBlock(SinkDSMDLRBlock):
                         )
 
                         # maximum capacity eligibly for load shifting
-                        rhs = (
-                            max(
-                                g.capacity_down[t] * g.flex_share_down,
-                                g.capacity_up[t] * g.flex_share_up,
-                            )
-                            * (self.invest[g] + g.investment.existing)
-                        )
+                        rhs = max(
+                            g.capacity_down[t] * g.flex_share_down,
+                            g.capacity_up[t] * g.flex_share_up,
+                        ) * (self.invest[g] + g.investment.existing)
 
                         # add constraint
                         block.dr_logical_constraint.add((g, t), (lhs <= rhs))

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -977,7 +977,7 @@ class TestsConstraint:
             inputs={bgas: solph.Flow(nominal_value=100, variable_costs=1)},
             outputs={bel: solph.Flow()},
             in_breakpoints=[0, 25, 50, 75, 100],
-            conversion_function=lambda x: x ** 2,
+            conversion_function=lambda x: x**2,
             pw_repn="CC",
         )
         self.compare_lp_files("piecewise_linear_transformer_cc.lp")
@@ -991,7 +991,7 @@ class TestsConstraint:
             inputs={bgas: solph.Flow(nominal_value=100, variable_costs=1)},
             outputs={bel: solph.Flow()},
             in_breakpoints=[0, 25, 50, 75, 100],
-            conversion_function=lambda x: x ** 2,
+            conversion_function=lambda x: x**2,
             pw_repn="DCC",
         )
         self.compare_lp_files("piecewise_linear_transformer_dcc.lp")

--- a/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
+++ b/tests/test_scripts/test_solph/test_piecewiselineartransformer/test_piecewiselineartransformer.py
@@ -43,7 +43,7 @@ def test_pwltf():
 
     # Define conversion function and breakpoints
     def conv_func(x):
-        return 0.01 * x ** 2
+        return 0.01 * x**2
 
     in_breakpoints = np.arange(0, 110, 25)
     out_breakpoints = conv_func(in_breakpoints)


### PR DESCRIPTION
Black tests failed for new PRs due to already existing errors.
Simply run `black .` on top level.