### PR TITLE
Added option to (un-)limit directions in Link component

### DIFF
--- a/src/oemof/solph/custom/link.py
+++ b/src/oemof/solph/custom/link.py
@@ -38,6 +38,8 @@ class Link(on.Transformer):
         Keys are the connected tuples (input, output) bus objects.
         The dictionary values can either be a scalar or an iterable with length
         of time horizon for simulation.
+    limit_direction : boolean, default: True
+        Wether direction constraint should be set for Link component
 
     Note: This component is experimental. Use it with care.
 
@@ -79,6 +81,7 @@ class Link(on.Transformer):
             k: sequence(v)
             for k, v in kwargs.get("conversion_factors", {}).items()
         }
+        self.limit_direction = kwargs.get("limit_direction", True)
 
         wrong_args_message = (
             "Component `Link` must have exactly"
@@ -100,6 +103,7 @@ class LinkBlock(SimpleBlock):
     Note: This component is experimental. Use it with care.
 
     **The following constraints are created:**
+    (Equation 2&3 are only implemented, if `limit_direction` is enabled)
 
     .. _Link-equations:
 
@@ -147,11 +151,15 @@ class LinkBlock(SimpleBlock):
             }
 
         self.LINKS = Set(initialize=[g for g in group])
+
+        directed_conversions = {
+            n: n.conversion_factors for n in group if n.limit_direction
+        }
         self.LINK_1ST_INFLOWS = Set(
-            initialize=[(list(c)[0][0], n) for n, c in all_conversions.items()]
+            initialize=[(list(c)[0][0], n) for n, c in directed_conversions.items()]
         )
         self.LINK_2ND_INFLOWS = Set(
-            initialize=[(list(c)[1][0], n) for n, c in all_conversions.items()]
+            initialize=[(list(c)[1][0], n) for n, c in directed_conversions.items()]
         )
 
         #  0: Flows 1 connected; 1: Flows 2 connected

--- a/src/oemof/solph/custom/link.py
+++ b/src/oemof/solph/custom/link.py
@@ -156,10 +156,14 @@ class LinkBlock(SimpleBlock):
             n: n.conversion_factors for n in group if n.limit_direction
         }
         self.LINK_1ST_INFLOWS = Set(
-            initialize=[(list(c)[0][0], n) for n, c in directed_conversions.items()]
+            initialize=[
+                (list(c)[0][0], n) for n, c in directed_conversions.items()
+            ]
         )
         self.LINK_2ND_INFLOWS = Set(
-            initialize=[(list(c)[1][0], n) for n, c in directed_conversions.items()]
+            initialize=[
+                (list(c)[1][0], n) for n, c in directed_conversions.items()
+            ]
         )
 
         #  0: Flows 1 connected; 1: Flows 2 connected


### PR DESCRIPTION
Related issue: #837 

This PR adds an option `limit_direction` to Link component in order to suppress creation of flow constraints regarding link direction.
As option defaults to `True`, this should not effect current setup, but only enables other devs to disable mentioned feature. 
