### PR TITLE
Require oemof.network v0.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "pyomo >= 5.7.0, < 5.7.3",
         "networkx",
         "oemof.tools",
-        "oemof.network",
+        "oemof.network >= 0.4.0, < 0.5.0",
     ],
     extras_require={
         "dev": ["pytest", "sphinx", "sphinx_rtd_theme"],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -103,6 +103,9 @@ def test_optimal_solution():
 
 
 def test_infeasible_model():
+    # FutureWarning is i.e. emitted by network Entity registry
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+
     with pytest.raises(ValueError, match=""):
         with warnings.catch_warnings(record=True) as w:
             es = solph.EnergySystem(timeindex=[1])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -104,7 +104,7 @@ def test_optimal_solution():
 
 def test_infeasible_model():
     # FutureWarning is i.e. emitted by network Entity registry
-    warnings.simplefilter(action='ignore', category=FutureWarning)
+    warnings.simplefilter(action="ignore", category=FutureWarning)
 
     with pytest.raises(ValueError, match=""):
         with warnings.catch_warnings(record=True) as w:

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -23,6 +23,9 @@ def warning_fixture():
     """Explicitly activate the warnings."""
     warnings.filterwarnings("always", category=SuspiciousUsageWarning)
 
+    # FutureWarning is i.e. emitted by network Entity registry
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+
 
 def test_that_the_sink_warnings_actually_get_raised(warning_fixture):
     """Sink doesn't warn about potentially erroneous usage."""

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -24,7 +24,7 @@ def warning_fixture():
     warnings.filterwarnings("always", category=SuspiciousUsageWarning)
 
     # FutureWarning is i.e. emitted by network Entity registry
-    warnings.simplefilter(action='ignore', category=FutureWarning)
+    warnings.simplefilter(action="ignore", category=FutureWarning)
 
 
 def test_that_the_sink_warnings_actually_get_raised(warning_fixture):


### PR DESCRIPTION
Set stable release of oemof.network as requirement. As the stable release emits a FutureWarning when the deprecated Node/Entity.registry is used, the warning has to be silenced when testing for other warnings.

Note that out unit tests use the registry, but other software does probably not.