### PR TITLE
Update python versions for solph

### DIFF
--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v1

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,6 +4,7 @@ sphinx:
   configuration: docs/conf.py
 formats: all
 python:
+  version: "3.8"
   install:
     - requirements: docs/requirements.txt
     - method: pip

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Utilities",
     ],
@@ -74,7 +74,7 @@ setup(
     keywords=[
         # eg: 'keyword1', 'keyword2', 'keyword3',
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=[
         "blinker",
         "dill",

--- a/setup.py
+++ b/setup.py
@@ -82,10 +82,7 @@ setup(
         "pandas",
         "pyomo >= 6.0.0, < 7.0",
         "networkx",
-        (
-            "oemof.tools@https://github.com/oemof/oemof.tools/archive/feature/"
-            "set-minimal-lggin-level.zip"
-        ),
+        "oemof.tools >= 0.4.2",
         "oemof.network",
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -3,17 +3,17 @@ envlist =
     clean,
     check,
     docs,
-    py37,
     py38,
-    py39
+    py39,
+    py310,
     py3-nocov,
     report
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 basepython =
@@ -92,8 +92,8 @@ commands = coverage erase
 skip_install = true
 deps = coverage
 
-[testenv:py37]
-basepython = {env:TOXPYTHON:python3.7}
+[testenv:py310]
+basepython = {env:TOXPYTHON:python3.10}
 setenv =
     {[testenv]setenv}
 usedevelop = true


### PR DESCRIPTION
Add support for Python 3.10, remove support for Python 3.7

Even Debian stable is up to Python 3.7 and they are normally really slow :smile: 
