### PR TITLE
Revision/remove node registry

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -810,10 +810,10 @@ This small example of PV, grid and SinkDSM shows how to use the component
 
     # Create Energy System
     es = solph.EnergySystem(timeindex=datetimeindex)
-    Node.registry = es
 
     # Create bus representing electricity grid
     b_elec = solph.buses.Bus(label='Electricity bus')
+    es.add(b_elec)
 
     # Create a back supply
     grid = solph.components.Source(label='Grid',
@@ -822,6 +822,7 @@ This small example of PV, grid and SinkDSM shows how to use the component
                                 nominal_value=10000,
                                 variable_costs=50)}
                         )
+    es.add(grid)
 
     # PV supply from time series
     s_wind = solph.components.Source(label='wind',
@@ -830,6 +831,7 @@ This small example of PV, grid and SinkDSM shows how to use the component
                                   fix=data['pv'],
                                   nominal_value=3.5)}
                           )
+    es.add(s_wind)
 
     # Create DSM Sink
     demand_dsm = solph.custom.SinkDSM(label="DSM",
@@ -843,6 +845,7 @@ This small example of PV, grid and SinkDSM shows how to use the component
                                       max_capacity_down=1,
                                       approach="DIW",
                                       cost_dsm_down=5)
+    es.add(demand_dsm)
 
 Yielding the following results
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -15,10 +15,8 @@ from difflib import unified_diff
 from os import path as ospath
 
 import pandas as pd
-import pytest
 from nose.tools import assert_raises
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof import solph
 
@@ -1484,7 +1482,9 @@ class TestsConstraint:
         self.compare_lp_files("flow_invest_with_offset_no_minimum.lp")
 
     def test_nonequidistant_storage(self):
-        """Constraint test of an energy system with non-equidistant time index"""
+        """Constraint test of an energy system
+        with non-equidistant time index
+        """
         idxh = pd.date_range("1/1/2017", periods=3, freq="H")
         idx2h = pd.date_range("1/1/2017 03:00:00", periods=2, freq="2H")
         idx30m = pd.date_range("1/1/2017 07:00:00", periods=4, freq="30min")

--- a/tests/flow_tests.py
+++ b/tests/flow_tests.py
@@ -13,8 +13,8 @@ import warnings
 
 import pytest
 
-from oemof.solph.flows import Flow
 from oemof.solph import NonConvex
+from oemof.solph.flows import Flow
 
 
 def test_error_in_gradient_attribute():

--- a/tests/flow_tests.py
+++ b/tests/flow_tests.py
@@ -14,6 +14,7 @@ import warnings
 import pytest
 
 from oemof.solph.flows import Flow
+from oemof.solph import NonConvex
 
 
 def test_error_in_gradient_attribute():
@@ -44,3 +45,37 @@ def test_summed_min_future_warning():
 
 def test_source_with_full_load_time_max():
     Flow(nominal_value=1, full_load_time_max=2)
+
+
+def test_nonconvex_positive_gradient_error():
+    """Testing nonconvex positive gradient error."""
+    msg = (
+        "You specified a positive gradient in your nonconvex "
+        "option. This cannot be combined with a positive or a "
+        "negative gradient for a standard flow!"
+    )
+
+    with pytest.raises(ValueError, match=msg):
+        Flow(
+            nonconvex=NonConvex(
+                positive_gradient={"ub": 0.03},
+            ),
+            positive_gradient={"ub": 0.03},
+        )
+
+
+def test_non_convex_negative_gradient_error():
+    """Testing non-convex positive gradient error."""
+    msg = (
+        "You specified a negative gradient in your nonconvex "
+        "option. This cannot be combined with a positive or a "
+        "negative gradient for a standard flow!"
+    )
+
+    with pytest.raises(ValueError, match=msg):
+        Flow(
+            nonconvex=NonConvex(
+                negative_gradient={"ub": 0.03, "costs": 7},
+            ),
+            negative_gradient={"ub": 0.03},
+        )

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: MIT
 
 from nose.tools import ok_
 from oemof.network.energy_system import EnergySystem as EnSys
-from oemof.network.network import Node
 
 from oemof import solph as solph
 from oemof.solph import Investment

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -21,7 +21,6 @@ from oemof.solph.flows._investment_flow_block import InvestmentFlowBlock
 class TestsGrouping:
     def setup(self):
         self.es = EnSys(groupings=solph.GROUPINGS)
-        Node.registry = self.es
 
     def test_investment_flow_grouping(self):
         """Flows of investment sink should be grouped.
@@ -37,24 +36,31 @@ class TestsGrouping:
         """
 
         b = solph.buses.Bus(label="Bus")
+        self.es.add(b)
 
-        solph.components.Source(
-            label="Source",
-            outputs={
-                b: solph.flows.Flow(fix=[12, 16, 14], nominal_value=1000000)
-            },
+        self.es.add(
+            solph.components.Source(
+                label="Source",
+                outputs={
+                    b: solph.flows.Flow(
+                        fix=[12, 16, 14], nominal_value=1000000
+                    )
+                },
+            )
         )
 
-        solph.components.Sink(
-            label="Sink",
-            inputs={
-                b: solph.flows.Flow(
-                    full_load_time_max=2.3,
-                    variable_costs=25,
-                    max=0.8,
-                    investment=Investment(ep_costs=500, maximum=10e5),
-                )
-            },
+        self.es.add(
+            solph.components.Sink(
+                label="Sink",
+                inputs={
+                    b: solph.flows.Flow(
+                        full_load_time_max=2.3,
+                        variable_costs=25,
+                        max=0.8,
+                        investment=Investment(ep_costs=500, maximum=10e5),
+                    )
+                },
+            )
         )
 
         ok_(

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -15,7 +15,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network import network
 
 from oemof.solph import EnergySystem
 from oemof.solph import Investment

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -31,8 +31,7 @@ from oemof.solph.flows import Flow
 def test_connect_invest():
     date_time_index = pd.date_range("1/1/2012", periods=24 * 7, freq="H")
 
-    energysystem = EnergySystem(timeindex=date_time_index)
-    network.Node.registry = energysystem
+    es = EnergySystem(timeindex=date_time_index)
 
     # Read data file
     full_filename = os.path.join(
@@ -45,23 +44,30 @@ def test_connect_invest():
     # create electricity bus
     bel1 = Bus(label="electricity1")
     bel2 = Bus(label="electricity2")
+    es.add(bel1, bel2)
 
     # create excess component for the electricity bus to allow overproduction
-    components.Sink(label="excess_bel", inputs={bel2: Flow()})
-    components.Source(
-        label="shortage", outputs={bel2: Flow(variable_costs=50000)}
+    es.add(components.Sink(label="excess_bel", inputs={bel2: Flow()}))
+    es.add(
+        components.Source(
+            label="shortage", outputs={bel2: Flow(variable_costs=50000)}
+        )
     )
 
     # create fixed source object representing wind power plants
-    components.Source(
-        label="wind",
-        outputs={bel1: Flow(fix=data["wind"], nominal_value=1000000)},
+    es.add(
+        components.Source(
+            label="wind",
+            outputs={bel1: Flow(fix=data["wind"], nominal_value=1000000)},
+        )
     )
 
     # create simple sink object representing the electrical demand
-    components.Sink(
-        label="demand",
-        inputs={bel1: Flow(fix=data["demand_el"], nominal_value=1)},
+    es.add(
+        components.Sink(
+            label="demand",
+            inputs={bel1: Flow(fix=data["demand_el"], nominal_value=1)},
+        )
     )
 
     storage = components.GenericStorage(
@@ -76,20 +82,23 @@ def test_connect_invest():
         outflow_conversion_factor=0.8,
         investment=Investment(ep_costs=0.2),
     )
+    es.add(storage)
 
     line12 = components.Transformer(
         label="line12",
         inputs={bel1: Flow()},
         outputs={bel2: Flow(investment=Investment(ep_costs=20))},
     )
+    es.add(line12)
 
     line21 = components.Transformer(
         label="line21",
         inputs={bel2: Flow()},
         outputs={bel1: Flow(investment=Investment(ep_costs=20))},
     )
+    es.add(line21)
 
-    om = Model(energysystem)
+    om = Model(es)
 
     constraints.equate_variables(
         om,

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -18,7 +18,6 @@ import logging
 
 import pandas as pd
 from nose.tools import ok_
-from oemof.network.network import Node
 from pyomo import environ as po
 
 from oemof.solph import EnergySystem

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -34,15 +34,18 @@ def test_add_constraints_example(solver="cbc", nologg=False):
     # ##### creating an oemof solph optimization model, nothing special here ##
     # create an energy system object for the oemof solph nodes
     es = EnergySystem(timeindex=pd.date_range("1/1/2012", periods=4, freq="H"))
-    Node.registry = es
+
     # add some nodes
     boil = Bus(label="oil", balanced=False)
     blig = Bus(label="lignite", balanced=False)
     b_el = Bus(label="b_el")
+    es.add(boil, blig, b_el)
 
-    components.Sink(
-        label="Sink",
-        inputs={b_el: Flow(nominal_value=40, fix=[0.5, 0.4, 0.3, 1])},
+    es.add(
+        components.Sink(
+            label="Sink",
+            inputs={b_el: Flow(nominal_value=40, fix=[0.5, 0.4, 0.3, 1])},
+        )
     )
     pp_oil = components.Transformer(
         label="pp_oil",
@@ -50,11 +53,14 @@ def test_add_constraints_example(solver="cbc", nologg=False):
         outputs={b_el: Flow(nominal_value=50, variable_costs=25)},
         conversion_factors={b_el: 0.39},
     )
-    components.Transformer(
-        label="pp_lig",
-        inputs={blig: Flow()},
-        outputs={b_el: Flow(nominal_value=50, variable_costs=10)},
-        conversion_factors={b_el: 0.41},
+    es.add(pp_oil)
+    es.add(
+        components.Transformer(
+            label="pp_lig",
+            inputs={blig: Flow()},
+            outputs={b_el: Flow(nominal_value=50, variable_costs=10)},
+            conversion_factors={b_el: 0.41},
+        )
     )
 
     # create the model

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -16,7 +16,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof.solph import EnergySystem
 from oemof.solph import Model

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -40,24 +40,30 @@ def test_gen_caes():
     # create an energy system
     idx = pd.date_range("1/1/2017", periods=periods, freq="H")
     es = EnergySystem(timeindex=idx)
-    Node.registry = es
 
     # resources
     bgas = Bus(label="bgas")
+    es.add(bgas)
 
-    Source(label="rgas", outputs={bgas: Flow(variable_costs=20)})
+    es.add(Source(label="rgas", outputs={bgas: Flow(variable_costs=20)}))
 
     # power
     bel_source = Bus(label="bel_source")
-    Source(
-        label="source_el",
-        outputs={bel_source: Flow(variable_costs=data["price_el_source"])},
+    es.add(bel_source)
+    es.add(
+        Source(
+            label="source_el",
+            outputs={bel_source: Flow(variable_costs=data["price_el_source"])},
+        )
     )
 
     bel_sink = Bus(label="bel_sink")
-    Sink(
-        label="sink_el",
-        inputs={bel_sink: Flow(variable_costs=data["price_el_sink"])},
+    es.add(bel_sink)
+    es.add(
+        Sink(
+            label="sink_el",
+            inputs={bel_sink: Flow(variable_costs=data["price_el_sink"])},
+        )
     )
 
     # dictionary with parameters for a specific CAES plant
@@ -86,13 +92,15 @@ def test_gen_caes():
     }
 
     # generic compressed air energy storage (caes) plant
-    GenericCAES(
-        label="caes",
-        electrical_input={bel_source: Flow()},
-        fuel_input={bgas: Flow()},
-        electrical_output={bel_sink: Flow()},
-        params=concept,
-        fixed_costs=0,
+    es.add(
+        GenericCAES(
+            label="caes",
+            electrical_input={bel_source: Flow()},
+            fuel_input={bgas: Flow()},
+            electrical_output={bel_sink: Flow()},
+            params=concept,
+            fixed_costs=0,
+        )
     )
 
     # create an optimization problem and solve it

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -16,7 +16,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof import solph as solph
 from oemof.solph import processing

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -34,53 +34,70 @@ def test_gen_chp():
     # create an energy system
     idx = pd.date_range("1/1/2017", periods=periods, freq="H")
     es = solph.EnergySystem(timeindex=idx)
-    Node.registry = es
 
     # resources
     bgas = solph.buses.Bus(label="bgas")
+    es.add(bgas)
 
-    solph.components.Source(label="rgas", outputs={bgas: solph.flows.Flow()})
+    es.add(
+        solph.components.Source(
+            label="rgas", outputs={bgas: solph.flows.Flow()}
+        )
+    )
 
     # heat
     bth = solph.buses.Bus(label="bth")
+    es.add(bth)
 
-    solph.components.Source(
-        label="source_th", outputs={bth: solph.flows.Flow(variable_costs=1000)}
+    es.add(
+        solph.components.Source(
+            label="source_th",
+            outputs={bth: solph.flows.Flow(variable_costs=1000)},
+        )
     )
 
-    solph.components.Sink(
-        label="demand_th",
-        inputs={
-            bth: solph.flows.Flow(fix=data["demand_th"], nominal_value=200)
-        },
+    es.add(
+        solph.components.Sink(
+            label="demand_th",
+            inputs={
+                bth: solph.flows.Flow(fix=data["demand_th"], nominal_value=200)
+            },
+        )
     )
 
     # power
     bel = solph.buses.Bus(label="bel")
+    es.add(bel)
 
-    solph.components.Sink(
-        label="demand_el",
-        inputs={bel: solph.flows.Flow(variable_costs=data["price_el"])},
+    es.add(
+        solph.components.Sink(
+            label="demand_el",
+            inputs={bel: solph.flows.Flow(variable_costs=data["price_el"])},
+        )
     )
 
     # generic chp
     # (for back pressure characteristics Q_CW_min=0 and back_pressure=True)
-    solph.components.GenericCHP(
-        label="combined_cycle_extraction_turbine",
-        fuel_input={
-            bgas: solph.flows.Flow(H_L_FG_share_max=data["H_L_FG_share_max"])
-        },
-        electrical_output={
-            bel: solph.flows.Flow(
-                P_max_woDH=data["P_max_woDH"],
-                P_min_woDH=data["P_min_woDH"],
-                Eta_el_max_woDH=data["Eta_el_max_woDH"],
-                Eta_el_min_woDH=data["Eta_el_min_woDH"],
-            )
-        },
-        heat_output={bth: solph.flows.Flow(Q_CW_min=data["Q_CW_min"])},
-        Beta=data["Beta"],
-        back_pressure=False,
+    es.add(
+        solph.components.GenericCHP(
+            label="combined_cycle_extraction_turbine",
+            fuel_input={
+                bgas: solph.flows.Flow(
+                    H_L_FG_share_max=data["H_L_FG_share_max"]
+                )
+            },
+            electrical_output={
+                bel: solph.flows.Flow(
+                    P_max_woDH=data["P_max_woDH"],
+                    P_min_woDH=data["P_min_woDH"],
+                    Eta_el_max_woDH=data["Eta_el_max_woDH"],
+                    Eta_el_min_woDH=data["Eta_el_min_woDH"],
+                )
+            },
+            heat_output={bth: solph.flows.Flow(Q_CW_min=data["Q_CW_min"])},
+            Beta=data["Beta"],
+            back_pressure=False,
+        )
     )
 
     # create an optimization problem and solve it

--- a/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
+++ b/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-from oemof.network.network import Node
 from oemof.tools import economics
 
 from oemof.solph import EnergySystem

--- a/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
+++ b/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
@@ -31,7 +31,6 @@ from oemof.solph.flows import Flow
 
 def test_dispatch_fix_example(solver="cbc", periods=10):
     """Invest in a flow with a `fix` sequence containing values > 1."""
-    Node.registry = None
 
     filename = os.path.join(os.path.dirname(__file__), "input_data.csv")
     data = pd.read_csv(filename, sep=",")

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
@@ -29,8 +29,6 @@ def test_dispatch_one_time_step(solver="cbc"):
     """Create an energy system and optimize the dispatch at least costs."""
 
     # ######################### create energysystem components ################
-    Node.registry = None
-
     # resource buses
     bgas = Bus(label="gas", balanced=False)
 

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
@@ -12,7 +12,6 @@ SPDX-License-Identifier: MIT
 """
 
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof.solph import EnergySystem
 from oemof.solph import Model

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
@@ -29,8 +29,6 @@ def test_dispatch_one_time_step(solver="cbc"):
     """Create an energy system and optimize the dispatch at least costs."""
 
     # ######################### create energysystem components ################
-    Node.registry = None
-
     # resource buses
     bgas = Bus(label="gas", balanced=False)
 

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
@@ -12,7 +12,6 @@ SPDX-License-Identifier: MIT
 """
 
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof.solph import EnergySystem
 from oemof.solph import Model

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
@@ -17,7 +17,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 from oemof.tools import economics
 
 from oemof.solph import EnergySystem

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
@@ -34,7 +34,6 @@ from oemof.solph.flows import Flow
 
 def test_dispatch_example(solver="cbc", periods=24 * 5):
     """Create an energy system and optimize the dispatch at least costs."""
-    Node.registry = None
 
     filename = os.path.join(os.path.dirname(__file__), "input_data.csv")
     data = pd.read_csv(filename, sep=",")

--- a/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
@@ -12,7 +12,6 @@ SPDX-License-Identifier: MIT
 import logging
 
 import pandas as pd
-from oemof.network.network import Node
 
 from oemof import solph
 from oemof.solph import views

--- a/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_invest_storage_regression.py
@@ -27,52 +27,62 @@ def test_regression_investment_storage(solver="cbc"):
     date_time_index = pd.date_range("1/1/2012", periods=4, freq="H")
 
     energysystem = solph.EnergySystem(timeindex=date_time_index)
-    Node.registry = energysystem
 
     # Buses
     bgas = solph.buses.Bus(label=("natural", "gas"))
     bel = solph.buses.Bus(label="electricity")
+    energysystem.add(bgas, bel)
 
-    solph.components.Sink(
-        label="demand",
-        inputs={
-            bel: solph.flows.Flow(
-                fix=[209643, 207497, 200108, 191892], nominal_value=1
-            )
-        },
+    energysystem.add(
+        solph.components.Sink(
+            label="demand",
+            inputs={
+                bel: solph.flows.Flow(
+                    fix=[209643, 207497, 200108, 191892], nominal_value=1
+                )
+            },
+        )
     )
 
     # Sources
-    solph.components.Source(label="rgas", outputs={bgas: solph.flows.Flow()})
+    energysystem.add(
+        solph.components.Source(
+            label="rgas", outputs={bgas: solph.flows.Flow()}
+        )
+    )
 
     # Transformer
-    solph.components.Transformer(
-        label="pp_gas",
-        inputs={bgas: solph.flows.Flow()},
-        outputs={bel: solph.flows.Flow(nominal_value=300000)},
-        conversion_factors={bel: 0.58},
+    energysystem.add(
+        solph.components.Transformer(
+            label="pp_gas",
+            inputs={bgas: solph.flows.Flow()},
+            outputs={bel: solph.flows.Flow(nominal_value=300000)},
+            conversion_factors={bel: 0.58},
+        )
     )
 
     # Investment storage
-    solph.components.GenericStorage(
-        label="storage",
-        inputs={
-            bel: solph.flows.Flow(
-                investment=solph.Investment(existing=625046 / 6, maximum=0)
-            )
-        },
-        outputs={
-            bel: solph.flows.Flow(
-                investment=solph.Investment(existing=104174.33, maximum=1)
-            )
-        },
-        loss_rate=0.00,
-        initial_storage_level=0,
-        invest_relation_input_capacity=1 / 6,
-        invest_relation_output_capacity=1 / 6,
-        inflow_conversion_factor=1,
-        outflow_conversion_factor=0.8,
-        investment=solph.Investment(ep_costs=50, existing=625046),
+    energysystem.add(
+        solph.components.GenericStorage(
+            label="storage",
+            inputs={
+                bel: solph.flows.Flow(
+                    investment=solph.Investment(existing=625046 / 6, maximum=0)
+                )
+            },
+            outputs={
+                bel: solph.flows.Flow(
+                    investment=solph.Investment(existing=104174.33, maximum=1)
+                )
+            },
+            loss_rate=0.00,
+            initial_storage_level=0,
+            invest_relation_input_capacity=1 / 6,
+            invest_relation_output_capacity=1 / 6,
+            inflow_conversion_factor=1,
+            outflow_conversion_factor=0.8,
+            investment=solph.Investment(ep_costs=50, existing=625046),
+        )
     )
 
     # Solve model

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -39,7 +39,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 from oemof.tools import economics
 
 from oemof import solph

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -57,8 +57,7 @@ def test_optimise_storage_size(
     logging.info("Initialize the energy system")
     date_time_index = pd.date_range("1/1/2012", periods=400, freq="H")
 
-    energysystem = solph.EnergySystem(timeindex=date_time_index)
-    Node.registry = energysystem
+    es = solph.EnergySystem(timeindex=date_time_index)
 
     full_filename = os.path.join(os.path.dirname(__file__), filename)
     data = pd.read_csv(full_filename, sep=",")
@@ -66,35 +65,52 @@ def test_optimise_storage_size(
     # Buses
     bgas = solph.buses.Bus(label="natural_gas")
     bel = solph.buses.Bus(label="electricity")
+    es.add(bgas, bel)
 
     # Sinks
-    solph.components.Sink(label="excess_bel", inputs={bel: solph.flows.Flow()})
+    es.add(
+        solph.components.Sink(
+            label="excess_bel", inputs={bel: solph.flows.Flow()}
+        )
+    )
 
-    solph.components.Sink(
-        label="demand",
-        inputs={bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)},
+    es.add(
+        solph.components.Sink(
+            label="demand",
+            inputs={
+                bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)
+            },
+        )
     )
 
     # Sources
-    solph.components.Source(
-        label="rgas",
-        outputs={
-            bgas: solph.flows.Flow(
-                nominal_value=194397000 * 400 / 8760, full_load_time_max=1
-            )
-        },
+    es.add(
+        solph.components.Source(
+            label="rgas",
+            outputs={
+                bgas: solph.flows.Flow(
+                    nominal_value=194397000 * 400 / 8760, full_load_time_max=1
+                )
+            },
+        )
     )
 
-    solph.components.Source(
-        label="wind",
-        outputs={
-            bel: solph.flows.Flow(fix=data["wind"], nominal_value=1000000)
-        },
+    es.add(
+        solph.components.Source(
+            label="wind",
+            outputs={
+                bel: solph.flows.Flow(fix=data["wind"], nominal_value=1000000)
+            },
+        )
     )
 
-    solph.components.Source(
-        label="pv",
-        outputs={bel: solph.flows.Flow(fix=data["pv"], nominal_value=582000)},
+    es.add(
+        solph.components.Source(
+            label="pv",
+            outputs={
+                bel: solph.flows.Flow(fix=data["pv"], nominal_value=582000)
+            },
+        )
     )
 
     # Transformer
@@ -106,31 +122,34 @@ def test_optimise_storage_size(
         },
         conversion_factors={bel: 0.58},
     )
+    es.add(PP_GAS)
 
     # Investment storage
     epc = economics.annuity(capex=1000, n=20, wacc=0.05)
-    solph.components.GenericStorage(
-        label="storage",
-        inputs={bel: solph.flows.Flow(variable_costs=10e10)},
-        outputs={bel: solph.flows.Flow(variable_costs=10e10)},
-        loss_rate=0.00,
-        initial_storage_level=0,
-        invest_relation_input_capacity=1 / 6,
-        invest_relation_output_capacity=1 / 6,
-        inflow_conversion_factor=1,
-        outflow_conversion_factor=0.8,
-        investment=solph.Investment(ep_costs=epc, existing=6851),
+    es.add(
+        solph.components.GenericStorage(
+            label="storage",
+            inputs={bel: solph.flows.Flow(variable_costs=10e10)},
+            outputs={bel: solph.flows.Flow(variable_costs=10e10)},
+            loss_rate=0.00,
+            initial_storage_level=0,
+            invest_relation_input_capacity=1 / 6,
+            invest_relation_output_capacity=1 / 6,
+            inflow_conversion_factor=1,
+            outflow_conversion_factor=0.8,
+            investment=solph.Investment(ep_costs=epc, existing=6851),
+        )
     )
 
     # Solve model
-    om = solph.Model(energysystem)
+    om = solph.Model(es)
     om.receive_duals()
     om.solve(solver=solver)
-    energysystem.results["main"] = processing.results(om)
-    energysystem.results["meta"] = processing.meta_results(om)
+    es.results["main"] = processing.results(om)
+    es.results["meta"] = processing.meta_results(om)
 
     # Check dump and restore
-    energysystem.dump()
+    es.dump()
 
 
 def test_results_with_actual_dump():

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -40,7 +40,6 @@ from collections import namedtuple
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof import solph as solph
 from oemof.solph import processing

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -68,7 +68,6 @@ def test_tuples_as_labels_example(
     date_time_index = pd.date_range("1/1/2012", periods=40, freq="H")
 
     energysystem = solph.EnergySystem(timeindex=date_time_index)
-    Node.registry = energysystem
 
     full_filename = os.path.join(os.path.dirname(__file__), filename)
     data = pd.read_csv(full_filename, sep=",")
@@ -76,67 +75,84 @@ def test_tuples_as_labels_example(
     # Buses
     bgas = solph.buses.Bus(label=Label("bus", "natural_gas", None))
     bel = solph.buses.Bus(label=Label("bus", "electricity", ""))
+    energysystem.add(bgas, bel)
 
     # Sinks
-    solph.components.Sink(
-        label=Label("sink", "electricity", "excess"),
-        inputs={bel: solph.flows.Flow()},
+    energysystem.add(
+        solph.components.Sink(
+            label=Label("sink", "electricity", "excess"),
+            inputs={bel: solph.flows.Flow()},
+        )
     )
 
-    solph.components.Sink(
-        label=Label("sink", "electricity", "demand"),
-        inputs={bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)},
+    energysystem.add(
+        solph.components.Sink(
+            label=Label("sink", "electricity", "demand"),
+            inputs={
+                bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)
+            },
+        )
     )
 
     # Sources
-    solph.components.Source(
-        label=Label("source", "natural_gas", "commodity"),
-        outputs={
-            bgas: solph.flows.Flow(
-                nominal_value=194397000 * 400 / 8760, full_load_time_max=1
-            )
-        },
+    energysystem.add(
+        solph.components.Source(
+            label=Label("source", "natural_gas", "commodity"),
+            outputs={
+                bgas: solph.flows.Flow(
+                    nominal_value=194397000 * 400 / 8760, full_load_time_max=1
+                )
+            },
+        )
     )
 
-    solph.components.Source(
-        label=Label("renewable", "electricity", "wind"),
-        outputs={
-            bel: solph.flows.Flow(fix=data["wind"], nominal_value=1000000)
-        },
+    energysystem.add(
+        solph.components.Source(
+            label=Label("renewable", "electricity", "wind"),
+            outputs={
+                bel: solph.flows.Flow(fix=data["wind"], nominal_value=1000000)
+            },
+        )
     )
 
-    solph.components.Source(
-        label=Label("renewable", "electricity", "pv"),
-        outputs={
-            bel: solph.flows.Flow(
-                fix=data["pv"],
-                nominal_value=582000,
-            )
-        },
+    energysystem.add(
+        solph.components.Source(
+            label=Label("renewable", "electricity", "pv"),
+            outputs={
+                bel: solph.flows.Flow(
+                    fix=data["pv"],
+                    nominal_value=582000,
+                )
+            },
+        )
     )
 
     # Transformer
-    solph.components.Transformer(
-        label=Label("pp", "electricity", "natural_gas"),
-        inputs={bgas: solph.flows.Flow()},
-        outputs={
-            bel: solph.flows.Flow(nominal_value=10e10, variable_costs=50)
-        },
-        conversion_factors={bel: 0.58},
+    energysystem.add(
+        solph.components.Transformer(
+            label=Label("pp", "electricity", "natural_gas"),
+            inputs={bgas: solph.flows.Flow()},
+            outputs={
+                bel: solph.flows.Flow(nominal_value=10e10, variable_costs=50)
+            },
+            conversion_factors={bel: 0.58},
+        )
     )
 
     # Investment storage
-    solph.components.GenericStorage(
-        label=Label("storage", "electricity", "battery"),
-        nominal_storage_capacity=204685,
-        inputs={bel: solph.flows.Flow(variable_costs=10e10)},
-        outputs={bel: solph.flows.Flow(variable_costs=10e10)},
-        loss_rate=0.00,
-        initial_storage_level=0,
-        invest_relation_input_capacity=1 / 6,
-        invest_relation_output_capacity=1 / 6,
-        inflow_conversion_factor=1,
-        outflow_conversion_factor=0.8,
+    energysystem.add(
+        solph.components.GenericStorage(
+            label=Label("storage", "electricity", "battery"),
+            nominal_storage_capacity=204685,
+            inputs={bel: solph.flows.Flow(variable_costs=10e10)},
+            outputs={bel: solph.flows.Flow(variable_costs=10e10)},
+            loss_rate=0.00,
+            initial_storage_level=0,
+            invest_relation_input_capacity=1 / 6,
+            invest_relation_output_capacity=1 / 6,
+            inflow_conversion_factor=1,
+            outflow_conversion_factor=0.8,
+        )
     )
 
     # Solve model

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -17,7 +17,6 @@ import os
 
 import pandas as pd
 from nose.tools import eq_
-from oemof.network.network import Node
 
 from oemof import solph
 from oemof.solph import views

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -29,7 +29,6 @@ def test_variable_chp(filename="variable_chp.csv", solver="cbc"):
     # create time index for 192 hours in May.
     date_time_index = pd.date_range("5/5/2012", periods=5, freq="H")
     energysystem = solph.EnergySystem(timeindex=date_time_index)
-    Node.registry = energysystem
 
     # Read data file with heat and electrical demand (192 hours)
     full_filename = os.path.join(os.path.dirname(__file__), filename)
@@ -43,11 +42,14 @@ def test_variable_chp(filename="variable_chp.csv", solver="cbc"):
 
     # create natural gas bus
     bgas = solph.buses.Bus(label=("natural", "gas"))
+    energysystem.add(bgas)
 
     # create commodity object for gas resource
-    solph.components.Source(
-        label=("commodity", "gas"),
-        outputs={bgas: solph.flows.Flow(variable_costs=50)},
+    energysystem.add(
+        solph.components.Source(
+            label=("commodity", "gas"),
+            outputs={bgas: solph.flows.Flow(variable_costs=50)},
+        )
     )
 
     # create two electricity buses and two heat buses
@@ -55,62 +57,89 @@ def test_variable_chp(filename="variable_chp.csv", solver="cbc"):
     bel2 = solph.buses.Bus(label=("electricity", 2))
     bth = solph.buses.Bus(label=("heat", 1))
     bth2 = solph.buses.Bus(label=("heat", 2))
+    energysystem.add(bel, bel2, bth, bth2)
 
     # create excess components for the elec/heat bus to allow overproduction
-    solph.components.Sink(
-        label=("excess", "bth_2"), inputs={bth2: solph.flows.Flow()}
+    energysystem.add(
+        solph.components.Sink(
+            label=("excess", "bth_2"), inputs={bth2: solph.flows.Flow()}
+        )
     )
-    solph.components.Sink(
-        label=("excess", "bth_1"), inputs={bth: solph.flows.Flow()}
+    energysystem.add(
+        solph.components.Sink(
+            label=("excess", "bth_1"), inputs={bth: solph.flows.Flow()}
+        )
     )
-    solph.components.Sink(
-        label=("excess", "bel_2"), inputs={bel2: solph.flows.Flow()}
+    energysystem.add(
+        solph.components.Sink(
+            label=("excess", "bel_2"), inputs={bel2: solph.flows.Flow()}
+        )
     )
-    solph.components.Sink(
-        label=("excess", "bel_1"), inputs={bel: solph.flows.Flow()}
+    energysystem.add(
+        solph.components.Sink(
+            label=("excess", "bel_1"), inputs={bel: solph.flows.Flow()}
+        )
     )
 
     # create simple sink object for electrical demand for each electrical bus
-    solph.components.Sink(
-        label=("demand", "elec1"),
-        inputs={bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)},
+    energysystem.add(
+        solph.components.Sink(
+            label=("demand", "elec1"),
+            inputs={
+                bel: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)
+            },
+        )
     )
-    solph.components.Sink(
-        label=("demand", "elec2"),
-        inputs={
-            bel2: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)
-        },
+    energysystem.add(
+        solph.components.Sink(
+            label=("demand", "elec2"),
+            inputs={
+                bel2: solph.flows.Flow(fix=data["demand_el"], nominal_value=1)
+            },
+        )
     )
 
     # create simple sink object for heat demand for each thermal bus
-    solph.components.Sink(
-        label=("demand", "therm1"),
-        inputs={
-            bth: solph.flows.Flow(fix=data["demand_th"], nominal_value=741000)
-        },
+    energysystem.add(
+        solph.components.Sink(
+            label=("demand", "therm1"),
+            inputs={
+                bth: solph.flows.Flow(
+                    fix=data["demand_th"], nominal_value=741000
+                )
+            },
+        )
     )
-    solph.components.Sink(
-        label=("demand", "therm2"),
-        inputs={
-            bth2: solph.flows.Flow(fix=data["demand_th"], nominal_value=741000)
-        },
+    energysystem.add(
+        solph.components.Sink(
+            label=("demand", "therm2"),
+            inputs={
+                bth2: solph.flows.Flow(
+                    fix=data["demand_th"], nominal_value=741000
+                )
+            },
+        )
     )
 
     # create a fixed transformer to distribute to the heat_2 and elec_2 buses
-    solph.components.Transformer(
-        label=("fixed_chp", "gas"),
-        inputs={bgas: solph.flows.Flow(nominal_value=10e10)},
-        outputs={bel2: solph.flows.Flow(), bth2: solph.flows.Flow()},
-        conversion_factors={bel2: 0.3, bth2: 0.5},
+    energysystem.add(
+        solph.components.Transformer(
+            label=("fixed_chp", "gas"),
+            inputs={bgas: solph.flows.Flow(nominal_value=10e10)},
+            outputs={bel2: solph.flows.Flow(), bth2: solph.flows.Flow()},
+            conversion_factors={bel2: 0.3, bth2: 0.5},
+        )
     )
 
     # create a fixed transformer to distribute to the heat and elec buses
-    solph.components.ExtractionTurbineCHP(
-        label=("variable_chp", "gas"),
-        inputs={bgas: solph.flows.Flow(nominal_value=10e10)},
-        outputs={bel: solph.flows.Flow(), bth: solph.flows.Flow()},
-        conversion_factors={bel: 0.3, bth: 0.5},
-        conversion_factor_full_condensation={bel: 0.5},
+    energysystem.add(
+        solph.components.ExtractionTurbineCHP(
+            label=("variable_chp", "gas"),
+            inputs={bgas: solph.flows.Flow(nominal_value=10e10)},
+            outputs={bel: solph.flows.Flow(), bth: solph.flows.Flow()},
+            conversion_factors={bel: 0.3, bth: 0.5},
+            conversion_factor_full_condensation={bel: 0.5},
+        )
     )
 
     ##########################################################################


### PR DESCRIPTION
The feature to automatically add Nodes (strictly speaking Entities) of an oemof.network to an energy system is deprecated. Thus, it should not be used in the tests. This PR implements that.

PS: This PR is against feature/restructure_flow, as I branched from that branch. It would be cleaner to merge #856 first and merge this into dev afterwards.