### PR TITLE
Features/schedule profiles

### DIFF
--- a/examples/min_max_uptime_example/min_max_uptime_example.py
+++ b/examples/min_max_uptime_example/min_max_uptime_example.py
@@ -2,29 +2,39 @@
 """
 Example that shows how to use a combination of minimum and maximum uptime.
 
+The model consists of a volatile renewable energy source with
+a fixed profile (Source: 'renewable_energy'), a cyclic industrial process
+modelled as a Sink with a NonConvex flow with negative variable costs as
+revenues, and an excess for surplus of renewable energy.
+
+The cyclic industrial process has a fixed block profile and a certain time
+within each cycle is required. With the attributes `maximum_uptime`,
+`minimum_uptime` and `minimum_downtime`, and a given `nominal_value`
+combination with the `min` attribute it is possible to model
+this scheduling problem.
+
 SPDX-FileCopyrightText: Johannes Röder <johannes.roeder@uni-bremen.de>
 
 SPDX-License-Identifier: MIT
 """
-
 import os
+import logging
+
 import pandas as pd
 import matplotlib.pyplot as plt
 
-
 from oemof.solph import components
 from oemof.solph import Flow, Bus, EnergySystem, Model
-from oemof.solph._options import Investment, NonConvex
-
-import oemof.network
+from oemof.solph._options import NonConvex
 from oemof.solph import processing, views
 from oemof.solph import helpers
-import logging
 
-
-data_demand = [1, 2, 4, 5, 6, 4, 3, 2, 6, 7,
-               7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-               8, 8, 2, 1, 0, 5, 6]
+data_demand = [
+    1, 1, 2, 4, 5, 6, 4, 6, 2, 6, 7, 6,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    8, 8, 2, 1, 0, 5, 6, 7, 6, 7, 3,
+    3, 1, 1,
+]
 
 # select periods
 periods = len(data_demand)
@@ -32,37 +42,39 @@ periods = len(data_demand)
 # create an energy system
 idx = pd.date_range('1/1/2017', periods=periods, freq='H')
 es = EnergySystem(timeindex=idx)
-# oemof.network.Node.registry = es
 
-# bus_0 = solph.Bus(label='bus_0')
 bus_1 = Bus(label='bus')
 
 es.add(bus_1)
 
 es.add(components.Source(
-    label='NonConvexSource',
+    label='renewable_energy',
+    inputs={bus_1: Flow(
+        fix=data_demand,
+        nominal_value=1,
+    )}
+))
+
+es.add(components.Sink(
+    label='cyclic_process',
     outputs={bus_1: Flow(
-        variable_costs=10,
+        variable_costs=-10,
         nominal_value=4,
         min=1,
         nonconvex=NonConvex(
             minimum_downtime=2,
-            minimum_uptime=3,
-            maximum_uptime=3,
+            minimum_uptime=4,
+            maximum_uptime=4,
         ),
     )},
 ))
 
-es.add(components.Source(
-    label='Shortage_Source',
+es.add(components.Sink(
+    label='excess',
     outputs={bus_1: Flow(
-        variable_costs=1000,
+        variable_costs=0,
     )},
 ))
-
-es.add(components.Sink(label='demand', inputs={
-    bus_1: Flow(fix=data_demand,  nominal_value=1)}))
-
 
 # create an optimization problem and solve it
 om = Model(es)
@@ -77,11 +89,10 @@ om.write(filename, io_options={'symbolic_solver_labels': True})
 om.solve(solver='cbc', solve_kwargs={'tee': True})
 
 # create result object
-
-
 results = processing.results(om)
 
 bus1 = views.node(results, 'bus')["sequences"]
 bus1.plot(kind='line', drawstyle='steps-mid')
+plt.ylim(None, 10)
 plt.legend()
 plt.show()

--- a/examples/min_max_uptime_example/min_max_uptime_example.py
+++ b/examples/min_max_uptime_example/min_max_uptime_example.py
@@ -29,7 +29,7 @@ from oemof.solph._options import NonConvex
 from oemof.solph import processing, views
 from oemof.solph import helpers
 
-data_demand = [
+renewable_timeseries = [
     1, 1, 2, 4, 5, 6, 4, 6, 2, 6, 7, 6,
     7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
     8, 8, 2, 1, 0, 5, 6, 7, 6, 7, 3,
@@ -37,10 +37,10 @@ data_demand = [
 ]
 
 # select periods
-periods = len(data_demand)
+periods = len(renewable_timeseries)
 
 # create an energy system
-idx = pd.date_range('1/1/2017', periods=periods, freq='H')
+idx = pd.date_range('1/1/2022', periods=periods, freq='H')
 es = EnergySystem(timeindex=idx)
 
 bus_1 = Bus(label='bus')
@@ -50,7 +50,7 @@ es.add(bus_1)
 es.add(components.Source(
     label='renewable_energy',
     inputs={bus_1: Flow(
-        fix=data_demand,
+        fix=renewable_timeseries,
         nominal_value=1,
     )}
 ))

--- a/examples/min_max_uptime_example/min_max_uptime_example.py
+++ b/examples/min_max_uptime_example/min_max_uptime_example.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""
+Example that shows how to use a combination of minimum and maximum uptime.
+
+SPDX-FileCopyrightText: Johannes Röder <johannes.roeder@uni-bremen.de>
+
+SPDX-License-Identifier: MIT
+"""
+
+import os
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+from oemof.solph import components
+from oemof.solph import Flow, Bus, EnergySystem, Model
+from oemof.solph._options import Investment, NonConvex
+
+import oemof.network
+from oemof.solph import processing, views
+from oemof.solph import helpers
+import logging
+
+
+data_demand = [1, 2, 4, 5, 6, 4, 3, 2, 6, 7,
+               7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+               8, 8, 2, 1, 0, 5, 6]
+
+# select periods
+periods = len(data_demand)
+
+# create an energy system
+idx = pd.date_range('1/1/2017', periods=periods, freq='H')
+es = EnergySystem(timeindex=idx)
+# oemof.network.Node.registry = es
+
+# bus_0 = solph.Bus(label='bus_0')
+bus_1 = Bus(label='bus')
+
+es.add(bus_1)
+
+es.add(components.Source(
+    label='NonConvexSource',
+    outputs={bus_1: Flow(
+        variable_costs=10,
+        nominal_value=4,
+        min=1,
+        nonconvex=NonConvex(
+            minimum_downtime=2,
+            minimum_uptime=3,
+            maximum_uptime=3,
+        ),
+    )},
+))
+
+es.add(components.Source(
+    label='Shortage_Source',
+    outputs={bus_1: Flow(
+        variable_costs=1000,
+    )},
+))
+
+es.add(components.Sink(label='demand', inputs={
+    bus_1: Flow(fix=data_demand,  nominal_value=1)}))
+
+
+# create an optimization problem and solve it
+om = Model(es)
+
+# export lp file
+filename = os.path.join(
+    helpers.extend_basic_path('lp_files'), 'NonconvexDSM.lp')
+logging.info('Store lp-file in {0}.'.format(filename))
+om.write(filename, io_options={'symbolic_solver_labels': True})
+
+# solve model
+om.solve(solver='cbc', solve_kwargs={'tee': True})
+
+# create result object
+
+
+results = processing.results(om)
+
+bus1 = views.node(results, 'bus')["sequences"]
+bus1.plot(kind='line', drawstyle='steps-mid')
+plt.legend()
+plt.show()

--- a/examples/schedule_profiles_example/schedule_profiles_example.py
+++ b/examples/schedule_profiles_example/schedule_profiles_example.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Example that shows how to use a combination of minimum and maximum uptime.
+
+The model consists of a volatile renewable energy source with
+a fixed profile (Source: 'renewable_energy'), a cyclic industrial process
+modelled as a Sink with a NonConvex flow with negative variable costs as
+revenues, and an excess for surplus of renewable energy.
+
+The cyclic industrial process has a fixed block profile and a certain time
+within each cycle is required. With the attributes `maximum_uptime`,
+`minimum_uptime` and `minimum_downtime`, and a given `nominal_value`
+combination with the `min` attribute it is possible to model
+this scheduling problem.
+
+SPDX-FileCopyrightText: Johannes Röder <johannes.roeder@uni-bremen.de>
+
+SPDX-License-Identifier: MIT
+"""
+import os
+import logging
+
+import pandas as pd
+import matplotlib.pyplot as plt
+
+from oemof.solph import components
+from oemof.solph import Flow, Bus, EnergySystem, Model
+from oemof.solph._options import NonConvex
+from oemof.solph import processing, views
+from oemof.solph import helpers
+
+renewable_timeseries = [
+    1, 1, 2, 4, 5, 6, 4, 6, 2, 6, 7, 6,
+    7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+    8, 8, 2, 1, 0, 5, 6, 7, 6, 7, 3,
+    3, 1, 1,
+]
+
+# select periods
+periods = len(renewable_timeseries)
+
+# create an energy system
+idx = pd.date_range('1/1/2022', periods=periods, freq='H')
+es = EnergySystem(timeindex=idx)
+
+bus_1 = Bus(label='bus')
+
+es.add(bus_1)
+
+es.add(components.Source(
+    label='renewable_energy',
+    outputs={bus_1: Flow(
+        fix=renewable_timeseries,
+        nominal_value=1,
+    )}
+))
+
+es.add(components.Sink(
+    label='cyclic_process',
+    inputs={bus_1: Flow(
+        variable_costs=-5565,
+        nominal_value=10,
+        min=0,
+        nonconvex=NonConvex(
+            minimum_downtime=3,
+            minimum_uptime=4,
+            maximum_uptime=4,
+            profile=[2, 3, 4, 5],
+            startup_costs=10,
+            # shutdown_costs=2,
+        ),
+    )},
+))
+
+es.add(components.Sink(
+    label='excess',
+    inputs={bus_1: Flow(
+        variable_costs=0,
+    )},
+))
+
+# create an optimization problem and solve it
+om = Model(es)
+
+# export lp file
+filename = os.path.join(
+    helpers.extend_basic_path('lp_files'), 'Schedule_profile.lp')
+logging.info('Store lp-file in {0}.'.format(filename))
+om.write(filename, io_options={'symbolic_solver_labels': True})
+
+# solve model
+om.solve(solver='gurobi', solve_kwargs={'tee': True})
+
+# create result object
+results = processing.results(om)
+
+bus1 = views.node(results, 'bus')["sequences"]
+bus1.plot(kind='line', drawstyle='steps-mid')
+plt.ylim(None, 10)
+plt.legend()
+plt.show()
+
+

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -158,6 +158,7 @@ class NonConvex:
     def __init__(self, **kwargs):
         scalars = [
             "minimum_uptime",
+            "maximum_uptime",
             "minimum_downtime",
             "initial_status",
             "maximum_startups",
@@ -206,6 +207,8 @@ class NonConvex:
             max_up_down = self.minimum_uptime
         elif self.minimum_uptime is None and self.minimum_downtime is not None:
             max_up_down = self.minimum_downtime
+        elif self.maximum_uptime is not None:
+            max_up_down = self.maximum_uptime
         else:
             max_up_down = max(self.minimum_uptime, self.minimum_downtime)
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -169,6 +169,7 @@ class NonConvex:
             "shutdown_costs",
             "activity_costs",
             "inactivity_costs",
+            "profile",
         ]
         dictionaries = ["positive_gradient", "negative_gradient"]
         defaults = {


### PR DESCRIPTION
* Describe your pull request as transparent as possible
  * What functionality does it implement?
    * Scheduling of fixed load profiles, e.g. you have an industrial process with a fixed load profile, and you are wondering how to schedule this process in time.
  * Where is it located?
    * NonConvex option and NonConvex Flow Block
  * How does the API look?
  
  ```
  nonconvex=NonConvex(
            minimum_downtime=3,
            minimum_uptime=4,
            maximum_uptime=4,
            profile=[2, 3, 4, 5],
            startup_costs=10,
            # shutdown_costs=2,
        ),
  ```

* Related issues?
  * #859

* Share your knowledge: Insights/Remarks

  * This is a first draft, it is still under development
  * It makes use of the binary start-up variable, so at the moment, `startup_costs` must not be none. Roughly, the binary startup variable is multiplied with the fixed profile for each timestep.
  * At the moment, the profile must not begin or end with values of zero. This needs to be considered via a minimum_downtime.
  * Furthermore, the first process cannot start before the lenght of the profile (The starting phase is not implemented or the constraint need to be reformulated to make this possible)

* Other comments and questions

  * I am wondering if anybody did something before or is interesting is such a feature and could support development, e.g. also by testing and using this feature.
