### PR TITLE
Remove pytest travis fold

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,6 @@ passenv =
 deps =
     pytest
     nose
-    pytest-travis-fold
 commands =
     {posargs:pytest -vv --ignore=src}
 


### PR DESCRIPTION
Testing via `tox -e "py39"` did not work due to an error with pytest_travis_fold.

This PR removes the dependency, as we do not use travis anymore.
