### PR TITLE
Make kwargs explicit in storage

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -132,10 +132,9 @@ class GenericStorage(network.Node):
 
     def __init__(
         self,
-        label,
-        inputs,
-        outputs,
-        *,
+        label=None,
+        inputs=None,
+        outputs=None,
         nominal_storage_capacity=None,
         initial_storage_level=None,
         investment=None,
@@ -151,7 +150,11 @@ class GenericStorage(network.Node):
         inflow_conversion_factor=1,
         outflow_conversion_factor=1
     ):
-        super().__init__(label, inputs, outputs)
+        if inputs is None:
+            inputs = {}
+        if outputs is None:
+            outputs = {}
+        super().__init__(label=label, inputs=inputs, outputs=outputs)
         self.nominal_storage_capacity = nominal_storage_capacity
         self.initial_storage_level = initial_storage_level
         self.balanced = balanced

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -135,13 +135,13 @@ class GenericStorage(network.Node):
         label,
         inputs,
         outputs,
+        *,
         nominal_storage_capacity,
         initial_storage_level,
         investment,
         invest_relation_input_output,
         invest_relation_input_capacity,
         invest_relation_output_capacity,
-        *args,
         max_storage_level=1,
         balanced=True,
         loss_rate=0,
@@ -150,9 +150,8 @@ class GenericStorage(network.Node):
         fixed_losses_absolute=0,
         inflow_conversion_factor=1,
         outflow_conversion_factor=1,
-        **kwargs
     ):
-        super().__init__(*args, **kwargs)
+        super().__init__(label, inputs, outputs)
         self.nominal_storage_capacity = nominal_storage_capacity
         self.initial_storage_level = initial_storage_level
         self.balanced = balanced
@@ -180,33 +179,6 @@ class GenericStorage(network.Node):
         if self._invest_group is True:
             self._check_invest_attributes()
 
-        # Check for old parameter names. This is a temporary fix and should
-        # be removed once a general solution is found.
-        # TODO: https://github.com/oemof/oemof-solph/issues/560
-        renamed_parameters = [
-            ("nominal_capacity", "nominal_storage_capacity"),
-            ("initial_capacity", "initial_storage_level"),
-            ("capacity_loss", "loss_rate"),
-            ("capacity_min", "min_storage_level"),
-            ("capacity_max", "max_storage_level"),
-        ]
-        messages = [
-            "`{0}` to `{1}`".format(old_name, new_name)
-            for old_name, new_name in renamed_parameters
-            if old_name in kwargs
-        ]
-        if messages:
-            message = (
-                "The following attributes have been renamed from v0.2 to v0.3:"
-                "\n\n  {}\n\n"
-                "You are using the old names as parameters, thus setting "
-                "deprecated\n"
-                "attributes, which is not what you might have intended.\n"
-                "Use the new names, or, if you know what you're doing, set "
-                "these\n"
-                "attributes explicitly after construction instead."
-            )
-            raise AttributeError(message.format("\n  ".join(messages)))
 
     def _set_flows(self):
         for flow in self.inputs.values():

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -136,20 +136,20 @@ class GenericStorage(network.Node):
         inputs,
         outputs,
         *,
-        nominal_storage_capacity,
-        initial_storage_level,
-        investment,
-        invest_relation_input_output,
-        invest_relation_input_capacity,
-        invest_relation_output_capacity,
+        nominal_storage_capacity=None,
+        initial_storage_level=None,
+        investment=None,
+        invest_relation_input_output=None,
+        invest_relation_input_capacity=None,
+        invest_relation_output_capacity=None,
+        min_storage_level=0,
         max_storage_level=1,
         balanced=True,
         loss_rate=0,
         fixed_losses_relative=0,
-        min_storage_level=0,
         fixed_losses_absolute=0,
         inflow_conversion_factor=1,
-        outflow_conversion_factor=1,
+        outflow_conversion_factor=1
     ):
         super().__init__(label, inputs, outputs)
         self.nominal_storage_capacity = nominal_storage_capacity

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -179,7 +179,6 @@ class GenericStorage(network.Node):
         if self._invest_group is True:
             self._check_invest_attributes()
 
-
     def _set_flows(self):
         for flow in self.inputs.values():
             if (

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -131,37 +131,39 @@ class GenericStorage(network.Node):
     """  # noqa: E501
 
     def __init__(
-        self, *args, max_storage_level=1, min_storage_level=0, **kwargs
+        self,
+        nominal_storage_capacity,
+        initial_storage_level,
+        investment,
+        invest_relation_input_output,
+        invest_relation_input_capacity,
+        invest_relation_output_capacity,
+        *args,
+        max_storage_level=1,
+        balanced=True,
+        loss_rate=0,
+        fixed_losses_relative=0,
+        min_storage_level=0,
+        fixed_losses_absolute=0,
+        inflow_conversion_factor=1,
+        outflow_conversion_factor=1,
+        **kwargs
     ):
         super().__init__(*args, **kwargs)
-        self.nominal_storage_capacity = kwargs.get("nominal_storage_capacity")
-        self.initial_storage_level = kwargs.get("initial_storage_level")
-        self.balanced = kwargs.get("balanced", True)
-        self.loss_rate = solph_sequence(kwargs.get("loss_rate", 0))
-        self.fixed_losses_relative = solph_sequence(
-            kwargs.get("fixed_losses_relative", 0)
-        )
-        self.fixed_losses_absolute = solph_sequence(
-            kwargs.get("fixed_losses_absolute", 0)
-        )
-        self.inflow_conversion_factor = solph_sequence(
-            kwargs.get("inflow_conversion_factor", 1)
-        )
-        self.outflow_conversion_factor = solph_sequence(
-            kwargs.get("outflow_conversion_factor", 1)
-        )
+        self.nominal_storage_capacity = nominal_storage_capacity
+        self.initial_storage_level = initial_storage_level
+        self.balanced = balanced
+        self.loss_rate = solph_sequence(loss_rate)
+        self.fixed_losses_relative = solph_sequence(fixed_losses_relative)
+        self.fixed_losses_absolute = solph_sequence(fixed_losses_absolute)
+        self.inflow_conversion_factor = solph_sequence(inflow_conversion_factor)
+        self.outflow_conversion_factor = solph_sequence(outflow_conversion_factor)
         self.max_storage_level = solph_sequence(max_storage_level)
         self.min_storage_level = solph_sequence(min_storage_level)
-        self.investment = kwargs.get("investment")
-        self.invest_relation_input_output = kwargs.get(
-            "invest_relation_input_output"
-        )
-        self.invest_relation_input_capacity = kwargs.get(
-            "invest_relation_input_capacity"
-        )
-        self.invest_relation_output_capacity = kwargs.get(
-            "invest_relation_output_capacity"
-        )
+        self.investment = investment
+        self.invest_relation_input_output = invest_relation_input_output
+        self.invest_relation_input_capacity = invest_relation_input_capacity
+        self.invest_relation_output_capacity = invest_relation_output_capacity
         self._invest_group = isinstance(self.investment, Investment)
 
         # Check number of flows.

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -156,8 +156,10 @@ class GenericStorage(network.Node):
         self.loss_rate = solph_sequence(loss_rate)
         self.fixed_losses_relative = solph_sequence(fixed_losses_relative)
         self.fixed_losses_absolute = solph_sequence(fixed_losses_absolute)
-        self.inflow_conversion_factor = solph_sequence(inflow_conversion_factor)
-        self.outflow_conversion_factor = solph_sequence(outflow_conversion_factor)
+        self.inflow_conversion_factor = solph_sequence(
+            inflow_conversion_factor)
+        self.outflow_conversion_factor = solph_sequence(
+            outflow_conversion_factor)
         self.max_storage_level = solph_sequence(max_storage_level)
         self.min_storage_level = solph_sequence(min_storage_level)
         self.investment = investment

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -132,6 +132,9 @@ class GenericStorage(network.Node):
 
     def __init__(
         self,
+        label,
+        inputs,
+        outputs,
         nominal_storage_capacity,
         initial_storage_level,
         investment,


### PR DESCRIPTION
Make keyword arguments explicit in generic storage component.

Error message for kwargs not removed.
