### PR TITLE
Remove sphinx.ext.imgmath

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ extensions = [
     "sphinx.ext.ifconfig",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "sphinx.ext.imgmath",
     "sphinx.ext.viewcode",
 ]
 source_suffix = ".rst"


### PR DESCRIPTION
Resolve #879

This renders equations as Math instead of images. You can also right-click on equations and extract their contents and switch for lightmode/darkmode (if somthing like this would be implemented in the future) also works with that.

Example:

![grafik](https://user-images.githubusercontent.com/20252362/201020702-a1dabaa2-e918-4aca-b05b-fac46dbe54dd.png)
