### PR TITLE
make kwargs explicit for component Transformer

### DIFF
--- a/src/oemof/solph/_helpers.py
+++ b/src/oemof/solph/_helpers.py
@@ -29,3 +29,14 @@ def check_node_object_for_missing_attribute(obj, attribute):
             msg.format(attribute, obj.label, type(obj)),
             debugging.SuspiciousUsageWarning,
         )
+
+def warn_if_missing_attribute(obj, attribute):
+    msg = (
+        "Attribute <{0}> is missing in Node <{1}> of {2}.\n"
+        "If this is intended and you know what you are doing you can"
+        "disable the SuspiciousUsageWarning globally."
+    )
+    warn(
+        msg.format(attribute, obj.label, type(obj)),
+        debugging.SuspiciousUsageWarning,
+    )

--- a/src/oemof/solph/_helpers.py
+++ b/src/oemof/solph/_helpers.py
@@ -30,6 +30,7 @@ def check_node_object_for_missing_attribute(obj, attribute):
             debugging.SuspiciousUsageWarning,
         )
 
+
 def warn_if_missing_attribute(obj, attribute):
     msg = (
         "Attribute <{0}> is missing in Node <{1}> of {2}.\n"

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -77,16 +77,24 @@ class Transformer(on.Transformer):
      * :py:class:`~oemof.solph.components._transformer.TransformerBlock`
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, label=None, inputs=None, outputs=None, conversion_factors=None,
+                 *args, **kwargs):
+        if inputs is None:
+            inputs={}
+        if outputs is None:
+            outputs={}
+        super().__init__(label=label, inputs=inputs, outputs=outputs, *args, **kwargs)
 
 
         check_node_object_for_missing_attribute(self, "inputs")
         check_node_object_for_missing_attribute(self, "outputs")
 
+        if conversion_factors is None:
+            conversion_factors={}
+
         self.conversion_factors = {
             k: sequence(v)
-            for k, v in kwargs.get("conversion_factors", {}).items()
+            for k, v in conversion_factors.items()
         }
 
         missing_conversion_factor_keys = (

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -29,16 +29,15 @@ from oemof.solph._plumbing import sequence
 
 class Transformer(on.Transformer):
     """A linear converter object with n inputs and n outputs.
-<<<<<<< HEAD
 
-    Expects specified inputs and outputs as dicts with respective flows.
-    If no inputs or outputs are specified,  
+    Expects inputs and outputs as dicts with respective flows.
 
-=======
-    
->>>>>>> 1c27995cbbced2b825a4c7702326067b7e60f06b
     Parameters
     ----------
+    inputs : dict
+        Dictionary with inflows. Keys must be starting node(s) of inflow(s).
+    outputs : dict
+        Dictionary with outflows. Keys must be ending node(s) of outflow(s).
     conversion_factors : dict
         Dictionary containing conversion factors for conversion of each flow.
         Keys are the connected bus objects.

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -30,6 +30,9 @@ from oemof.solph._plumbing import sequence
 class Transformer(on.Transformer):
     """A linear converter object with n inputs and n outputs.
 
+    Expects specified inputs and outputs as dicts with respective flows.
+    If no inputs or outputs are specified,  
+
     Parameters
     ----------
     conversion_factors : dict

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -83,20 +83,20 @@ class Transformer(on.Transformer):
      * :py:class:`~oemof.solph.components._transformer.TransformerBlock`
     """
 
-    def __init__(self, label=None, inputs=None, outputs=None, conversion_factors=None):
+    def __init__(self, label=None, inputs=None, outputs=None,
+                 conversion_factors=None):
 
         if inputs is None:
-            inputs={}
+            inputs = {}
         if outputs is None:
-            outputs={}
+            outputs = {}
         super().__init__(label=label, inputs=inputs, outputs=outputs)
-
 
         check_node_object_for_missing_attribute(self, "inputs")
         check_node_object_for_missing_attribute(self, "outputs")
 
         if conversion_factors is None:
-            conversion_factors={}
+            conversion_factors = {}
 
         self.conversion_factors = {
             k: sequence(v)

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -80,6 +80,7 @@ class Transformer(on.Transformer):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+
         check_node_object_for_missing_attribute(self, "inputs")
         check_node_object_for_missing_attribute(self, "outputs")
 

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -23,7 +23,10 @@ from pyomo.core import BuildAction
 from pyomo.core import Constraint
 from pyomo.core.base.block import ScalarBlock
 
-from oemof.solph._helpers import check_node_object_for_missing_attribute
+from oemof.solph._helpers import (
+    check_node_object_for_missing_attribute,
+    warn_if_missing_attribute,
+)
 from oemof.solph._plumbing import sequence
 
 
@@ -94,22 +97,26 @@ class Transformer(on.Transformer):
         conversion_factors=None,
         options=None,
     ):
+        self.label = label
         if inputs is None:
+            warn_if_missing_attribute(self, "inputs")  # label ???
             inputs = {}
         if outputs is None:
+            warn_if_missing_attribute(self, "outputs")  # label ???
             outputs = {}
-        super().__init__(label=label, inputs=inputs, outputs=outputs,
-                         options=options)
 
-        check_node_object_for_missing_attribute(self, "inputs")
-        check_node_object_for_missing_attribute(self, "outputs")
+        super().__init__(
+            label=label, inputs=inputs, outputs=outputs, options=options
+        )
+
+        # check_node_object_for_missing_attribute(self, "inputs")
+        # check_node_object_for_missing_attribute(self, "outputs")
 
         if conversion_factors is None:
             conversion_factors = {}
 
         self.conversion_factors = {
-            k: sequence(v)
-            for k, v in conversion_factors.items()
+            k: sequence(v) for k, v in conversion_factors.items()
         }
 
         missing_conversion_factor_keys = (

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -83,13 +83,13 @@ class Transformer(on.Transformer):
      * :py:class:`~oemof.solph.components._transformer.TransformerBlock`
     """
 
-    def __init__(self, label=None,inputs=None, outputs=None, conversion_factors=None):
-                 #*args):#, **kwargs):
+    def __init__(self, label=None, inputs=None, outputs=None, conversion_factors=None):
+
         if inputs is None:
             inputs={}
         if outputs is None:
             outputs={}
-        super().__init__(label=label, inputs=inputs, outputs=outputs)#, *args, **kwargs)
+        super().__init__(label=label, inputs=inputs, outputs=outputs)
 
 
         check_node_object_for_missing_attribute(self, "inputs")

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -84,13 +84,14 @@ class Transformer(on.Transformer):
     """
 
     def __init__(self, label=None, inputs=None, outputs=None,
-                 conversion_factors=None):
+                 conversion_factors=None, options=None):
 
         if inputs is None:
             inputs = {}
         if outputs is None:
             outputs = {}
-        super().__init__(label=label, inputs=inputs, outputs=outputs)
+        super().__init__(label=label, inputs=inputs, outputs=outputs,
+                         options=options)
 
         check_node_object_for_missing_attribute(self, "inputs")
         check_node_object_for_missing_attribute(self, "outputs")

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -43,6 +43,9 @@ class Transformer(on.Transformer):
         Keys are the connected bus objects.
         The dictionary values can either be a scalar or an iterable with length
         of time horizon for simulation.
+    options : dict
+        Dictionary with additional parameters for usage in additional
+        constraints.
 
     Examples
     --------
@@ -83,9 +86,14 @@ class Transformer(on.Transformer):
      * :py:class:`~oemof.solph.components._transformer.TransformerBlock`
     """
 
-    def __init__(self, label=None, inputs=None, outputs=None,
-                 conversion_factors=None, options=None):
-
+    def __init__(
+        self,
+        label=None,
+        inputs=None,
+        outputs=None,
+        conversion_factors=None,
+        options=None,
+    ):
         if inputs is None:
             inputs = {}
         if outputs is None:

--- a/src/oemof/solph/components/_transformer.py
+++ b/src/oemof/solph/components/_transformer.py
@@ -80,13 +80,13 @@ class Transformer(on.Transformer):
      * :py:class:`~oemof.solph.components._transformer.TransformerBlock`
     """
 
-    def __init__(self, label=None, inputs=None, outputs=None, conversion_factors=None,
-                 *args, **kwargs):
+    def __init__(self, label=None,inputs=None, outputs=None, conversion_factors=None):
+                 #*args):#, **kwargs):
         if inputs is None:
             inputs={}
         if outputs is None:
             outputs={}
-        super().__init__(label=label, inputs=inputs, outputs=outputs, *args, **kwargs)
+        super().__init__(label=label, inputs=inputs, outputs=outputs)#, *args, **kwargs)
 
 
         check_node_object_for_missing_attribute(self, "inputs")


### PR DESCRIPTION
remove kwargs from network transformer class to avoid misspelled kwargs
