### PR TITLE
Add missing .py dependency

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,7 @@ setenv =
 passenv =
     *
 deps =
+    py
     pytest
     nose
 commands =


### PR DESCRIPTION
It was not that complicated... Solution found at https://github.com/kevlened/pytest-parallel/issues/118