### PR TITLE
Allow SinkDSM's delay_time to be an iterable for approach 'DSM'

### DIFF
--- a/src/oemof/solph/components/experimental/_sink_dsm.py
+++ b/src/oemof/solph/components/experimental/_sink_dsm.py
@@ -118,14 +118,15 @@ class SinkDSM(Sink):
         None.
         It's the interval in which between :math:`DSM_{t}^{up}` and
         :math:`DSM_{t}^{down}` have to be compensated.
-    delay_time: int
+    delay_time: int or iterable
         Only used when :attr:`~approach` is set to 'DIW' or 'DLR'. Otherwise,
-        can be None.
+        can be None. Iterable only allowed in case approach 'DLR' is used.
         Length of symmetrical time windows around :math:`t` in which
         :math:`DSM_{t}^{up}` and :math:`DSM_{t,tt}^{down}` have to be
         compensated.
-        Note: For approach 'DLR', an iterable is constructed in order
-        to model flexible delay times
+        Note: For approach 'DLR', if an integer is passed,
+        an iterable is constructed in order to model flexible delay times.
+        In case an iterable is passed, this will be used directly.
     shift_time: int
         Only used when :attr:`~approach` is set to 'DLR'.
         Duration of a single upwards or downwards shift (half a shifting cycle
@@ -262,9 +263,18 @@ class SinkDSM(Sink):
         self.approach = approach
         self.shift_interval = shift_interval
         if not approach == "DLR":
+            if approach == "DIW":
+                if not isinstance(delay_time, int):
+                    raise ValueError(
+                        "If approach 'DIW' is used, "
+                        "delay time has to be of type int."
+                    )
             self.delay_time = delay_time
         else:
-            self.delay_time = [el for el in range(1, delay_time + 1)]
+            if isinstance(delay_time, int):
+                self.delay_time = [el for el in range(1, delay_time + 1)]
+            else:
+                self.delay_time = delay_time
         self.shift_time = shift_time
         self.shed_time = shed_time
         self.max_capacity_down = max_capacity_down

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1500,6 +1500,28 @@ class TestsConstraint:
         )
         self.compare_lp_files("dsm_module_oemof_invest.lp")
 
+    def test_dsm_module_DLR_delay_time(self):
+        """Constraint test of SinkDSM with approach=DLR;
+        testing for passing an iterable for delay_time"""
+
+        b_elec = solph.buses.Bus(label="bus_elec")
+        solph.components.experimental.SinkDSM(
+            label="demand_dsm",
+            inputs={b_elec: solph.flows.Flow()},
+            demand=[1] * 3,
+            capacity_up=[0.5] * 3,
+            capacity_down=[0.5] * 3,
+            approach="DLR",
+            max_demand=1,
+            max_capacity_up=1,
+            max_capacity_down=1,
+            delay_time=[1, 3],
+            shift_time=1,
+            cost_dsm_down_shift=2,
+            shed_eligibility=False,
+        )
+        self.compare_lp_files("dsm_module_DLR_delay_time.lp")
+
     def test_invest_non_convex_flow(self):
         """Invest into a non-convex Flow"""
         b1 = solph.buses.Bus(label="b1")

--- a/tests/lp_files/dsm_module_DLR_delay_time.lp
+++ b/tests/lp_files/dsm_module_DLR_delay_time.lp
@@ -1,0 +1,356 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0)
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0)
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1)
++2 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
++2 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
+
+s.t.
+
+c_e_BusBlock_balance(bus_elec_0_0)_:
++1 flow(bus_elec_demand_dsm_0_0)
+= 0
+
+c_e_BusBlock_balance(bus_elec_0_1)_:
++1 flow(bus_elec_demand_dsm_0_1)
+= 0
+
+c_e_BusBlock_balance(bus_elec_0_2)_:
++1 flow(bus_elec_demand_dsm_0_2)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_1_0)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_1_1)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_1_2)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_3_0)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_3_1)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRBlock_shift_shed_vars(demand_dsm_3_2)_:
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRBlock_input_output_relation(demand_dsm_0_0)_:
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_0)
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_0)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_0)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_0)
++1 flow(bus_elec_demand_dsm_0_0)
+= 1
+
+c_e_SinkDSMDLRBlock_input_output_relation(demand_dsm_0_1)_:
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_1)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_1)
++1 flow(bus_elec_demand_dsm_0_1)
+= 1
+
+c_e_SinkDSMDLRBlock_input_output_relation(demand_dsm_0_2)_:
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_2)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_2)
++1 flow(bus_elec_demand_dsm_0_2)
+= 1
+
+c_e_SinkDSMDLRBlock_capacity_balance_red(demand_dsm_1_0)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_red(demand_dsm_1_1)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_red(demand_dsm_1_2)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_red(demand_dsm_3_0)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_0)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_inc(demand_dsm_1_0)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_inc(demand_dsm_1_1)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_inc(demand_dsm_1_2)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_1)
+= 0
+
+c_e_SinkDSMDLRBlock_capacity_balance_inc(demand_dsm_3_0)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_red(demand_dsm_1_2)_:
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_red(demand_dsm_3_0)_:
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_red(demand_dsm_3_1)_:
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_red(demand_dsm_3_2)_:
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_inc(demand_dsm_1_2)_:
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_2)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_inc(demand_dsm_3_0)_:
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_0)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_inc(demand_dsm_3_1)_:
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_1)
+= 0
+
+c_e_SinkDSMDLRBlock_no_comp_inc(demand_dsm_3_2)_:
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_2)
+= 0
+
+c_u_SinkDSMDLRBlock_availability_red(demand_dsm_0)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_availability_red(demand_dsm_1)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_availability_red(demand_dsm_2)_:
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_availability_inc(demand_dsm_0)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_0)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_0)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_availability_inc(demand_dsm_1)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_1)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_availability_inc(demand_dsm_2)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_2)
+<= 0.5
+
+c_e_SinkDSMDLRBlock_dr_storage_red(demand_dsm_0)_:
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_0)
+-1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
+-1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
+= 0
+
+c_e_SinkDSMDLRBlock_dr_storage_red(demand_dsm_1)_:
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_0)
+-1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
+= 0
+
+c_e_SinkDSMDLRBlock_dr_storage_red(demand_dsm_2)_:
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_1)
+-1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
+= 0
+
+c_e_SinkDSMDLRBlock_dr_storage_inc(demand_dsm_0)_:
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_0)
+-1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRBlock_dr_storage_inc(demand_dsm_1)_:
+-1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
+-1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_0)
+-1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRBlock_dr_storage_inc(demand_dsm_2)_:
+-1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
+-1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_1)
+-1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_2)
+= 0
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_red(demand_dsm_0)_:
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_0)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_red(demand_dsm_1)_:
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_1)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_red(demand_dsm_2)_:
++1 SinkDSMDLRBlock_dsm_do_level(demand_dsm_2)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_inc(demand_dsm_0)_:
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_0)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_inc(demand_dsm_1)_:
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_1)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_storage_limit_inc(demand_dsm_2)_:
++1 SinkDSMDLRBlock_dsm_up_level(demand_dsm_2)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_logical_constraint(demand_dsm_0)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_0)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_0)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_0)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_logical_constraint(demand_dsm_1)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_1)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_1)
+<= 0.5
+
+c_u_SinkDSMDLRBlock_dr_logical_constraint(demand_dsm_2)_:
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2)
++1 SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_2)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRBlock_dsm_up(demand_dsm_3_2)
+<= 0.5
+
+c_e_ONE_VAR_CONSTANT: 
+ONE_VAR_CONSTANT = 1.0
+
+bounds
+   0 <= flow(bus_elec_demand_dsm_0_0) <= +inf
+   0 <= flow(bus_elec_demand_dsm_0_1) <= +inf
+   0 <= flow(bus_elec_demand_dsm_0_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shift(demand_dsm_3_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shed(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shed(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_shed(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_3_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_3_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up(demand_dsm_3_2) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_0) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_1) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_do(demand_dsm_3_2) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_0) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_1) <= +inf
+   0 <= SinkDSMDLRBlock_balance_dsm_up(demand_dsm_3_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_level(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_level(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_do_level(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up_level(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up_level(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRBlock_dsm_up_level(demand_dsm_2) <= +inf
+end


### PR DESCRIPTION
This enables to directly pass an iterable (usually) a list to the `delay_time` attribute of the experimental `SinkDSM`.
Instead of passing an integer, this allows to exclude some delay times which might be desired in order to limit model complexity which grows with longer delay times, see #903. 

Closes #903
