### PR TITLE
Revision/remove nose

### DIFF
--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -121,7 +121,7 @@ class TestsConstraint:
                 expected = normalize_to_positive_results(expected)
                 generated = normalize_to_positive_results(generated)
 
-                assert generated  == expected, (
+                assert generated == expected, (
                     "Failed matching expected with generated lp file:\n"
                     + "\n".join(
                         unified_diff(

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -34,7 +34,7 @@ class TestsConstraint:
         cls.tmppath = solph.helpers.extend_basic_path("tmp")
         logging.info(cls.tmppath)
 
-    def setup(self):
+    def setup_method(self):
         self.energysystem = solph.EnergySystem(
             groupings=solph.GROUPINGS, timeindex=self.date_time_index
         )

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -16,8 +16,6 @@ from os import path as ospath
 
 import pandas as pd
 import pytest
-from nose.tools import assert_raises
-from nose.tools import eq_
 
 from oemof import solph
 
@@ -123,9 +121,7 @@ class TestsConstraint:
                 expected = normalize_to_positive_results(expected)
                 generated = normalize_to_positive_results(generated)
 
-                eq_(
-                    generated,
-                    expected,
+                assert generated  == expected, (
                     "Failed matching expected with generated lp file:\n"
                     + "\n".join(
                         unified_diff(
@@ -879,8 +875,7 @@ class TestsConstraint:
 
     def test_flow_without_emission_for_emission_constraint(self):
         """ """
-
-        def define_emission_limit():
+        with pytest.raises(AttributeError):
             bel = solph.buses.Bus(label="electricityBus")
             source1 = solph.components.Source(
                 label="source1",
@@ -898,8 +893,6 @@ class TestsConstraint:
             self.energysystem.add(bel, source1, source2)
             om = self.get_om()
             solph.constraints.emission_limit(om, om.flows, limit=777)
-
-        assert_raises(AttributeError, define_emission_limit)
 
     def test_flow_without_emission_for_emission_constraint_no_error(self):
         """ """

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -61,9 +61,7 @@ class TestsGrouping:
             )
         )
 
-        assert (
-            self.es.groups.get(InvestmentFlowBlock),
-            (
-                "Expected InvestmentFlow group to be nonempty.\n" + "Got: {}"
-            ).format(self.es.groups.get(InvestmentFlowBlock)),
+        assert self.es.groups.get(InvestmentFlowBlock), (
+            "Expected InvestmentFlow group to be nonempty.\n"
+            + "Got: {}".format(self.es.groups.get(InvestmentFlowBlock))
         )

--- a/tests/test_grouping.py
+++ b/tests/test_grouping.py
@@ -9,7 +9,6 @@ available from its original location oemof/tests/solph_tests.py
 SPDX-License-Identifier: MIT
 """
 
-from nose.tools import ok_
 from oemof.network.energy_system import EnergySystem as EnSys
 
 from oemof import solph as solph
@@ -18,7 +17,7 @@ from oemof.solph.flows._investment_flow_block import InvestmentFlowBlock
 
 
 class TestsGrouping:
-    def setup(self):
+    def setup_method(self):
         self.es = EnSys(groupings=solph.GROUPINGS)
 
     def test_investment_flow_grouping(self):
@@ -62,7 +61,7 @@ class TestsGrouping:
             )
         )
 
-        ok_(
+        assert (
             self.es.groups.get(InvestmentFlowBlock),
             (
                 "Expected InvestmentFlow group to be nonempty.\n" + "Got: {}"

--- a/tests/test_outputlib/test_views.py
+++ b/tests/test_outputlib/test_views.py
@@ -1,5 +1,4 @@
-from nose.tools import eq_
-from nose.tools import raises
+import pytest
 
 from oemof.solph import processing
 from oemof.solph import views
@@ -9,17 +8,17 @@ from . import optimization_model
 
 
 class TestFilterView:
-    def setup(self):
+    def setup_method(self):
         self.results = processing.results(optimization_model)
         self.param_results = processing.parameter_as_dict(optimization_model)
 
     def test_filter_all_(self):
         nodes = views.filter_nodes(self.results)
-        eq_(len(nodes), 19)
+        assert len(nodes) == 19
 
     def test_filter_all_without_busses(self):
         nodes = views.filter_nodes(self.results, exclude_busses=True)
-        eq_(len(nodes), 19 - 7)
+        assert len(nodes) == 19 - 7
 
     def test_filter_only_sources(self):
         nodes = views.filter_nodes(
@@ -27,7 +26,7 @@ class TestFilterView:
             option=views.NodeOption.HasOnlyOutputs,
             exclude_busses=True,
         )
-        eq_(len(nodes), 3)
+        assert len(nodes) == 3
 
     def test_filter_only_sinks(self):
         nodes = views.filter_nodes(
@@ -35,7 +34,7 @@ class TestFilterView:
             option=views.NodeOption.HasOnlyInputs,
             exclude_busses=True,
         )
-        eq_(len(nodes), 3)
+        assert len(nodes) == 3
 
     def test_filter_no_sources(self):
         nodes = views.filter_nodes(
@@ -43,26 +42,26 @@ class TestFilterView:
             option=views.NodeOption.HasInputs,
             exclude_busses=True,
         )
-        eq_(len(nodes), 9)
+        assert len(nodes) == 9
 
     def test_filter_has_outputs(self):
         nodes = views.filter_nodes(self.results, option="has_outputs")
-        eq_(len(nodes), 16)
+        assert len(nodes) == 16
 
-    @raises(ValueError)
     def test_filter_has_something(self):
-        views.filter_nodes(self.results, option="has_something")
+        with pytest.raises(ValueError):
+            views.filter_nodes(self.results, option="has_something")
 
     def test_get_node_by_name(self):
         node = views.get_node_by_name(self.results, "heat_pump")
-        eq_(energysystem.groups["heat_pump"], node)
+        assert energysystem.groups["heat_pump"] == node
 
     def test_get_multiple_nodes_by_name(self):
         node1, node2 = views.get_node_by_name(self.results, "b_el", "pp_oil")
-        eq_(energysystem.groups["b_el"], node1)
-        eq_(energysystem.groups["pp_oil"], node2)
+        assert energysystem.groups["b_el"] == node1
+        assert energysystem.groups["pp_oil"] == node2
 
     def test_get_node_by_name_with_wrong_attribute(self):
         node1, node2 = views.get_node_by_name(self.results, "b_el", "wrong")
-        eq_(energysystem.groups["b_el"], node1)
-        eq_(None, node2)
+        assert energysystem.groups["b_el"] == node1
+        assert node2 is None

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
 """
 
 import pandas
-from nose.tools import assert_raises
+import pytest
 from nose.tools import eq_
 from pandas.testing import assert_frame_equal
 from pandas.testing import assert_series_equal
@@ -276,7 +276,7 @@ class TestParameterResult:
         trsf = self.es.groups["diesel"]
         bus = self.es.groups["b_el1"]
         self.mod.flow[trsf, bus, 5] = float("nan")
-        with assert_raises(ValueError):
+        with pytest.raises(ValueError):
             processing.results(self.mod)
 
     def test_duals(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -12,7 +12,6 @@ SPDX-License-Identifier: MIT
 import pandas
 from nose.tools import assert_raises
 from nose.tools import eq_
-from nose.tools import ok_
 from pandas.testing import assert_frame_equal
 from pandas.testing import assert_series_equal
 
@@ -332,21 +331,21 @@ class TestParameterResult:
     def test_output_by_type_view_empty(self):
         results = processing.results(self.om)
         view = views.node_output_by_type(results, node_type=Flow)
-        ok_(view is None)
+        assert view is None
 
     def test_input_by_type_view_empty(self):
         results = processing.results(self.om)
         view = views.node_input_by_type(results, node_type=Flow)
-        ok_(view is None)
+        assert view is None
 
     def test_net_storage_flow_empty(self):
         results = processing.results(self.om)
         view = views.net_storage_flow(results, node_type=Sink)
-        ok_(view is None)
+        assert view is None
         view2 = views.net_storage_flow(results, node_type=Flow)
-        ok_(view2 is None)
+        assert view2 is None
 
     def test_node_weight_by_type_empty(self):
         results = processing.results(self.om)
         view = views.node_weight_by_type(results, node_type=Flow)
-        ok_(view is None)
+        assert view is None

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: MIT
 
 import pandas
 import pytest
-from nose.tools import eq_
 from pandas.testing import assert_frame_equal
 from pandas.testing import assert_series_equal
 
@@ -265,12 +264,14 @@ class TestParameterResult:
         )
 
         bel1_m = views.node(param_results, "b_el1", multiindex=True)
-        eq_(bel1_m["scalars"][("b_el1", "storage", "variable_costs")], 3)
+        assert bel1_m["scalars"][("b_el1", "storage", "variable_costs")] == 3
 
     def test_multiindex_sequences(self):
         results = processing.results(self.om)
         bel1 = views.node(results, "b_el1", multiindex=True)
-        eq_(int(bel1["sequences"][("diesel", "b_el1", "flow")].sum()), 2875)
+        assert (
+            int(bel1["sequences"][("diesel", "b_el1", "flow")].sum()) == 2875
+        )
 
     def test_error_from_nan_values(self):
         trsf = self.es.groups["diesel"]
@@ -282,14 +283,14 @@ class TestParameterResult:
     def test_duals(self):
         results = processing.results(self.om)
         bel = views.node(results, "b_el1", multiindex=True)
-        eq_(int(bel["sequences"]["b_el1", "None", "duals"].sum()), 48)
+        assert int(bel["sequences"]["b_el1", "None", "duals"].sum()) == 48
 
     def test_node_weight_by_type(self):
         results = processing.results(self.om)
         storage_content = views.node_weight_by_type(
             results, node_type=GenericStorage
         )
-        eq_(round(float(storage_content.sum()), 6), 1437.500003)
+        assert round(float(storage_content.sum()), 6) == 1437.500003
 
     def test_output_by_type_view(self):
         results = processing.results(self.om)
@@ -299,15 +300,14 @@ class TestParameterResult:
         compare = views.node(results, "diesel", multiindex=True)["sequences"][
             ("diesel", "b_el1", "flow")
         ]
-        eq_(int(transformer_output.sum()), int(compare.sum()))
+        assert int(transformer_output.sum()) == int(compare.sum())
 
     def test_input_by_type_view(self):
         results = processing.results(self.om)
         sink_input = views.node_input_by_type(results, node_type=Sink)
         compare = views.node(results, "demand_el", multiindex=True)
-        eq_(
-            int(sink_input.sum()),
-            int(compare["sequences"][("b_el2", "demand_el", "flow")].sum()),
+        assert int(sink_input.sum()) == int(
+            compare["sequences"][("b_el2", "demand_el", "flow")].sum()
         )
 
     def test_net_storage_flow(self):

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -14,7 +14,6 @@ import logging
 import os
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof.solph import EnergySystem
 from oemof.solph import Investment
@@ -139,4 +138,6 @@ def test_connect_invest():
     }
 
     for key in connect_invest_dict.keys():
-        eq_(int(round(my_results[key])), int(round(connect_invest_dict[key])))
+        assert int(round(my_results[key])) == int(
+            round(connect_invest_dict[key])
+        )

--- a/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
+++ b/tests/test_scripts/test_solph/test_flexible_modelling/test_add_constraints.py
@@ -17,7 +17,6 @@ SPDX-License-Identifier: MIT
 import logging
 
 import pandas as pd
-from nose.tools import ok_
 from pyomo import environ as po
 
 from oemof.solph import EnergySystem
@@ -126,5 +125,5 @@ def test_add_constraints_example(solver="cbc", nologg=False):
 
     # solve and write results to dictionary
     # you may print the model with om.pprint()
-    ok_(om.solve(solver=solver))
+    assert om.solve(solver=solver)
     logging.info("Successfully finished.")

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof.solph import EnergySystem
 from oemof.solph import Model
@@ -141,4 +140,4 @@ def test_gen_caes():
     }
 
     for key in test_dict.keys():
-        eq_(int(round(data[key])), int(round(test_dict[key])))
+        assert int(round(data[key])) == int(round(test_dict[key]))

--- a/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
+++ b/tests/test_scripts/test_solph/test_generic_chp/test_generic_chp.py
@@ -15,7 +15,6 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof import solph as solph
 from oemof.solph import processing
@@ -125,4 +124,4 @@ def test_gen_chp():
     }
 
     for key in test_dict.keys():
-        eq_(int(round(data[key])), int(round(test_dict[key])))
+        assert int(round(data[key])) == int(round(test_dict[key]))

--- a/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
+++ b/tests/test_scripts/test_solph/test_invest_fix_flow/test_simple_invest_fixed.py
@@ -92,13 +92,3 @@ def test_dispatch_fix_example(solver="cbc", periods=10):
     comp_results["pv_capacity"] = results[(pv, bel)]["scalars"].invest
 
     assert comp_results[(("pv", "b_el"), "flow")] > 0
-
-    # test_results = {
-    #     (('pv', 'b_el'), 'flow'): 2150.5,
-    #     (('b_el', 'demand_elec'), 'flow'): 436.05,
-    #     (('b_el', 'excess_el'), 'flow'): 1714.45,
-    #     'pv_capacity': 467.5,
-    # }
-
-    # for key in test_results.keys():
-    #     eq_(int(round(comp_results[key])), int(round(test_results[key])))

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch.py
@@ -16,7 +16,6 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof.solph import EnergySystem
 from oemof.solph import Model
@@ -191,4 +190,4 @@ def test_dispatch_example(solver="cbc", periods=24 * 5):
     }
 
     for key in test_results.keys():
-        eq_(int(round(results[key])), int(round(test_results[key])))
+        assert int(round(results[key])) == int(round(test_results[key]))

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one.py
@@ -11,8 +11,6 @@ oemof/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
 SPDX-License-Identifier: MIT
 """
 
-from nose.tools import eq_
-
 from oemof.solph import EnergySystem
 from oemof.solph import Model
 from oemof.solph import processing
@@ -118,4 +116,4 @@ def test_dispatch_one_time_step(solver="cbc"):
     }
 
     for key in test_results.keys():
-        eq_(int(round(results[key])), int(round(test_results[key])))
+        assert int(round(results[key])) == int(round(test_results[key]))

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_dispatch_one_explicit_timemode.py
@@ -11,8 +11,6 @@ oemof/tests/test_scripts/test_solph/test_simple_dispatch/test_simple_dispatch.py
 SPDX-License-Identifier: MIT
 """
 
-from nose.tools import eq_
-
 from oemof.solph import EnergySystem
 from oemof.solph import Model
 from oemof.solph import processing
@@ -118,4 +116,4 @@ def test_dispatch_one_time_step(solver="cbc"):
     }
 
     for key in test_results.keys():
-        eq_(int(round(results[key])), int(round(test_results[key])))
+        assert int(round(results[key])) == int(round(test_results[key]))

--- a/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
+++ b/tests/test_scripts/test_solph/test_simple_model/test_simple_invest.py
@@ -16,7 +16,6 @@ SPDX-License-Identifier: MIT
 import os
 
 import pandas as pd
-from nose.tools import eq_
 from oemof.tools import economics
 
 from oemof.solph import EnergySystem
@@ -209,4 +208,4 @@ def test_dispatch_example(solver="cbc", periods=24 * 5):
     }
 
     for key in test_results.keys():
-        eq_(int(round(comp_results[key])), int(round(test_results[key])))
+        assert int(round(comp_results[key])) == int(round(test_results[key]))

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_investment.py
@@ -38,7 +38,6 @@ import logging
 import os
 
 import pandas as pd
-from nose.tools import eq_
 from oemof.tools import economics
 
 from oemof import solph
@@ -212,4 +211,4 @@ def test_solph_transformer_attributes_before_dump_and_after_restore():
     )
 
     # Compare attributes before dump and after restore
-    eq_(trsf_attr_before_dump, trsf_attr_after_restore)
+    assert trsf_attr_before_dump == trsf_attr_after_restore

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -39,7 +39,6 @@ import os
 from collections import namedtuple
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof import solph as solph
 from oemof.solph import processing
@@ -55,8 +54,8 @@ class Label(namedtuple("solph_label", ["tag1", "tag2", "tag3"])):
 
 def test_label():
     my_label = Label("arg", 5, None)
-    eq_(str(my_label), "arg_5_None")
-    eq_(repr(my_label), "Label(tag1='arg', tag2=5, tag3=None)")
+    assert str(my_label) == "arg_5_None"
+    assert repr(my_label) == "Label(tag1='arg', tag2=5, tag3=None)"
 
 
 def test_tuples_as_labels_example(
@@ -203,21 +202,21 @@ def test_tuples_as_labels_example(
     }
 
     for key in stor_invest_dict.keys():
-        eq_(int(round(my_results[key])), int(round(stor_invest_dict[key])))
+        assert int(round(my_results[key])) == int(round(stor_invest_dict[key]))
 
     # Solver results
-    eq_(str(meta["solver"]["Termination condition"]), "optimal")
-    eq_(meta["solver"]["Error rc"], 0)
-    eq_(str(meta["solver"]["Status"]), "ok")
+    assert str(meta["solver"]["Termination condition"]) == "optimal"
+    assert meta["solver"]["Error rc"] == 0
+    assert str(meta["solver"]["Status"]) == "ok"
 
     # Problem results
-    eq_(int(meta["problem"]["Lower bound"]), 37819254)
-    eq_(int(meta["problem"]["Upper bound"]), 37819254)
-    eq_(meta["problem"]["Number of variables"], 281)
-    eq_(meta["problem"]["Number of constraints"], 163)
-    eq_(meta["problem"]["Number of nonzeros"], 116)
-    eq_(meta["problem"]["Number of objectives"], 1)
-    eq_(str(meta["problem"]["Sense"]), "minimize")
+    assert int(meta["problem"]["Lower bound"]) == 37819254
+    assert int(meta["problem"]["Upper bound"]) == 37819254
+    assert meta["problem"]["Number of variables"] == 281
+    assert meta["problem"]["Number of constraints"] == 163
+    assert meta["problem"]["Number of nonzeros"] == 116
+    assert meta["problem"]["Number of objectives"] == 1
+    assert str(meta["problem"]["Sense"]) == "minimize"
 
     # Objective function
-    eq_(round(meta["objective"]), 37819254)
+    assert round(meta["objective"]) == 37819254

--- a/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
+++ b/tests/test_scripts/test_solph/test_variable_chp/test_variable_chp.py
@@ -16,7 +16,6 @@ import logging
 import os
 
 import pandas as pd
-from nose.tools import eq_
 
 from oemof import solph
 from oemof.solph import views
@@ -173,30 +172,28 @@ def test_variable_chp(filename="variable_chp.csv", solver="cbc"):
 
     for key in variable_chp_dict_max.keys():
         logging.debug("Test the maximum value of {0}".format(key))
-        eq_(
-            int(round(maxresults[[key]])),
-            int(round(variable_chp_dict_max[key])),
+        assert int(round(maxresults[[key]])) == int(
+            round(variable_chp_dict_max[key])
         )
 
     for key in variable_chp_dict_sum.keys():
         logging.debug("Test the summed up value of {0}".format(key))
-        eq_(
-            int(round(sumresults[[key]])),
-            int(round(variable_chp_dict_sum[key])),
+        assert int(round(sumresults[[key]])) == int(
+            round(variable_chp_dict_sum[key])
         )
 
-    eq_(
+    assert (
         parameter[(energysystem.groups["('fixed_chp', 'gas')"], None)][
             "scalars"
-        ]["label"],
-        "('fixed_chp', 'gas')",
+        ]["label"]
+        == "('fixed_chp', 'gas')"
     )
-    eq_(
+    assert (
         parameter[(energysystem.groups["('fixed_chp', 'gas')"], None)][
             "scalars"
-        ]["conversion_factors_('electricity', 2)"],
-        0.3,
+        ]["conversion_factors_('electricity', 2)"]
+        == 0.3
     )
 
     # objective function
-    eq_(round(solph.processing.meta_results(om)["objective"]), 326661590)
+    assert round(solph.processing.meta_results(om)["objective"]) == 326661590

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,6 @@ passenv =
     *
 deps =
     pytest
-    nose
 commands =
     {posargs:pytest -vv --ignore=src}
 


### PR DESCRIPTION
Support for tests written for nose is deprecated in pytest[1]. Thus, we should go fully pytest and remove the legacy nose stuff. In particular, many features of nose just "save a few characters", i.e by typing `eq_(a, b)` instead of `assert a == b`. 


1: https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose