### PR TITLE
Let GenericStorage inherit from network.Component

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -32,7 +32,7 @@ from oemof.solph._options import Investment
 from oemof.solph._plumbing import sequence as solph_sequence
 
 
-class GenericStorage(network.Node):
+class GenericStorage(network.Component):
     r"""
     Component `GenericStorage` to model with basic characteristics of storages.
 


### PR DESCRIPTION
GenericStorage is a component. Its definition resides in the module components. However, it inherits directly from Node.

This PR fixes that by letting GenericStorage inherit from network.Component.

I checked: All other components do inherit in some way from Component.