### PR TITLE
Add storage_level_constraint

### DIFF
--- a/docs/reference/oemof.solph.constraints.rst
+++ b/docs/reference/oemof.solph.constraints.rst
@@ -2,6 +2,6 @@ oemof.solph.constraints
 -----------------------
 
 .. automodule:: oemof.solph.constraints
-    :members: equate_variables, equate_flows, limit_active_flow_count, limit_active_flow_count_by_keyword, emission_limit, generic_integral_limit, additional_investment_flow_limit, investment_limit, shared_limit
+    :members: equate_variables, equate_flows, limit_active_flow_count, limit_active_flow_count_by_keyword, emission_limit, generic_integral_limit, additional_investment_flow_limit, investment_limit, shared_limit, storage_level_constraint
     :undoc-members:
     :show-inheritance:

--- a/docs/whatsnew/v0-5-1.rst
+++ b/docs/whatsnew/v0-5-1.rst
@@ -25,6 +25,7 @@ New features
       `old_end` holding model-endogenously installed capacity to be decommissioned after its lifetime.
     * Include discounting and calculating annuities in the objective function terms. Introduce attribute `discount_rate`
       of :class:`oemof.solph.models.Model` and `interest_rate` for individual investment objects (options.Investment).
+* Add `storage_level_constraint` that allows to set flows from/to storage (in)active based on storage content.
 
 Documentation
 #############
@@ -52,4 +53,5 @@ Contributors
 
 * Johannes Kochems
 * Tobi Rohrer
+* Patrik Schönfeldt
 

--- a/examples/storage_level_constraint/storage_level_constraint.py
+++ b/examples/storage_level_constraint/storage_level_constraint.py
@@ -83,10 +83,11 @@ plt.step(df.index, df["out1"], where="post", label="outflow (> 1/2)")
 plt.grid()
 plt.legend()
 plt.ylabel("Flow Power (arb. units)")
+plt.ylim(0, 0.5)
 
 plt.twinx()
 
-plt.plot(df.index, df["storage_content"], "r-", label="storage content")
+plt.plot(df.index, df["storage_content"], "k--", label="storage content")
 plt.ylim(0, 3)
 plt.legend(loc="center right")
 plt.ylabel("Stored Energy (arb. units)")

--- a/examples/storage_level_constraint/storage_level_constraint.py
+++ b/examples/storage_level_constraint/storage_level_constraint.py
@@ -1,0 +1,94 @@
+import pandas as pd
+from oemof.solph import Bus, EnergySystem, Flow, Model
+from oemof.solph.components import GenericStorage, Source, Sink
+from oemof.solph.processing import results
+
+import matplotlib.pyplot as plt
+
+from oemof.solph.constraints import storage_level_constraint
+
+
+es = EnergySystem(
+    timeindex=pd.date_range("2022-01-01", freq="1H", periods=24),
+    infer_last_interval=True,
+)
+
+multiplexer = Bus(
+    label="multiplexer",
+)
+
+storage = GenericStorage(
+    label="storage",
+    nominal_storage_capacity=3,
+    initial_storage_level=1,
+    balanced=True,
+    loss_rate=0.05,
+    inputs={multiplexer: Flow()},
+    outputs={multiplexer: Flow()},
+)
+
+es.add(multiplexer, storage)
+
+in_0 = Source(
+    label="in_0",
+    outputs={multiplexer: Flow(nominal_value=0.5, variable_costs=0.15)},
+)
+es.add(in_0)
+
+in_1 = Source(label="in_1", outputs={multiplexer: Flow(nominal_value=0.1)})
+es.add(in_1)
+
+out_0 = Sink(
+    label="out_0",
+    inputs={multiplexer: Flow(nominal_value=0.25, variable_costs=-0.1)},
+)
+es.add(out_0)
+
+out_1 = Sink(
+    label="out_1",
+    inputs={multiplexer: Flow(nominal_value=0.15, variable_costs=-0.1)},
+)
+es.add(out_1)
+
+
+model = Model(es)
+
+storage_level_constraint(
+    model=model,
+    name="multiplexer",
+    storage_component=storage,
+    multiplexer_bus=multiplexer,
+    input_levels={in_1: 1 / 3},  # in_0 is always active
+    output_levels={out_0: 1 / 6, out_1: 1 / 2},
+)
+model.solve()
+
+my_results = results(model)
+
+df = pd.DataFrame(my_results[(storage, None)]["sequences"])
+df["in1_status"] = my_results[(in_1, None)]["sequences"]
+df["out1_status"] = my_results[(out_1, None)]["sequences"]
+df["out0_status"] = my_results[(out_0, None)]["sequences"]
+
+df["in1"] = my_results[(in_1, multiplexer)]["sequences"]
+df["in0"] = my_results[(in_0, multiplexer)]["sequences"]
+df["out0"] = my_results[(multiplexer, out_0)]["sequences"]
+df["out1"] = my_results[(multiplexer, out_1)]["sequences"]
+
+plt.step(df.index, df["in0"], where="post", label="inflow (<= 1)")
+plt.step(df.index, df["in1"], where="post", label="inflow (< 1/3)")
+plt.step(df.index, df["out0"], where="post", label="outflow (> 1/6)")
+plt.step(df.index, df["out1"], where="post", label="outflow (> 1/2)")
+
+plt.grid()
+plt.legend()
+
+plt.twinx()
+
+plt.plot(df.index, df["storage_content"], "r-", label="storage content")
+plt.ylim(0, 3)
+plt.legend(loc="center right")
+
+print(df)
+
+plt.show()

--- a/examples/storage_level_constraint/storage_level_constraint.py
+++ b/examples/storage_level_constraint/storage_level_constraint.py
@@ -82,12 +82,14 @@ plt.step(df.index, df["out1"], where="post", label="outflow (> 1/2)")
 
 plt.grid()
 plt.legend()
+plt.ylabel("Flow Power (arb. units)")
 
 plt.twinx()
 
 plt.plot(df.index, df["storage_content"], "r-", label="storage content")
 plt.ylim(0, 3)
 plt.legend(loc="center right")
+plt.ylabel("Stored Energy (arb. units)")
 
 print(df)
 

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -178,7 +178,7 @@ class EnergySystem(es.EnergySystem):
         -------
         periods_years: dict
             the simulation year of the start of each a period,
-            relative to the start of the optimization rund and starting with 0
+            relative to the start of the optimization run and starting with 0
         """
         periods_years = [0]
         if self.periods is not None:

--- a/src/oemof/solph/constraints/__init__.py
+++ b/src/oemof/solph/constraints/__init__.py
@@ -16,6 +16,7 @@ from .investment_limit import additional_investment_flow_limit
 from .investment_limit import investment_limit
 from .investment_limit import investment_limit_per_period
 from .shared_limit import shared_limit
+from .storage_level import storage_level_constraint
 
 __all__ = [
     "equate_flows",
@@ -31,4 +32,5 @@ __all__ = [
     "investment_limit",
     "investment_limit_per_period",
     "shared_limit",
+    "storage_level_constraint",
 ]

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -15,8 +15,8 @@ def storage_level_constraint(
     name,
     storage_component,
     multiplexer_bus,
-    input_levels=None,
-    output_levels=None,
+    input_levels,
+    output_levels,
 ):
     r"""
     Add constraints to implement storage content based access.
@@ -44,10 +44,6 @@ def storage_level_constraint(
 
     Verbose description can be found in https://arxiv.org/abs/2211.14080
     """
-    if input_levels is None:
-        input_levels = {}
-    if output_levels is None:
-        output_levels = {}
 
     def _outputs():
         OUTPUTS = po.Set(initialize=output_levels.keys())

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -124,17 +124,17 @@ def storage_level_constraint(
                 \hat{y}_n \ge (E(t) - E_n) / E_{max}
             """
             for t in m.TIMESTEPS:
-                for o in input_levels:
+                for i in input_levels:
                     getattr(m, constraint_name).add(
-                        (o, t),
+                        (i, t),
                         (
                             m.GenericStorageBlock.storage_content[
                                 storage_component, t
                             ]
                             / storage_component.nominal_storage_capacity
-                            - input_levels[o]
+                            - input_levels[i]
                         )
-                        <= inactive_input[o, t],
+                        <= inactive_input[i, t],
                     )
 
         setattr(

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -1,0 +1,181 @@
+"""A constraint to allow flows from to a storage based on the storage level.
+
+SPDX-FileCopyrightText: Patrik Schönfeldt
+SPDX-FileCopyrightText: Johannes Kochems
+SPDX-FileCopyrightText: Deutsches Zentrum für Luft- und Raumfahrt (DLR)
+
+SPDX-License-Identifier: MIT
+"""
+
+from pyomo import environ as po
+
+
+def storage_level_constraint(
+    model,
+    name,
+    storage_component,
+    multiplexer_bus,
+    input_levels=None,
+    output_levels=None,
+):
+    r"""
+    Add constraints to implement storage content based access.
+
+    As a GenericStorage just allows exactly one input and one output,
+    an additional bus, the multiplexer_bus, is used for the connections.
+    Note that all Flow objects connected to the multiplexer_bus have to have
+    a nominal_value.
+
+    Parameters
+    ----------
+    model : oemof.solph.Model
+        Model to which the constraint is added.
+    name : string
+        Name of the multiplexer.
+    storage_component : oemof.solph.components.GenericStorage
+        Storage component whose content should mandate
+        the possible inputs and outputs.
+    multiplexer_bus : oemof.solph.Bus
+        Bus which connects the input and output levels to the storage.
+    input_levels : dictionary with oemof.solph.Bus as keys and float as values
+        Dictionary of buses which act as inputs and corresponding levels
+    output_levels : dictionary with oemof.solph.Bus as keys and float as values
+        Dictionary of buses which act as outputs and corresponding level
+
+    Verbose description can be found in https://arxiv.org/abs/2211.14080
+    """
+    if input_levels is None:
+        input_levels = {}
+    if output_levels is None:
+        output_levels = {}
+
+    def _outputs():
+        OUTPUTS = po.Set(initialize=output_levels.keys())
+        setattr(model, f"{name}_OUTPUTS", OUTPUTS)
+
+        active_output = po.Var(
+            OUTPUTS, model.TIMESTEPS, domain=po.Binary, bounds=(0, 1)
+        )
+        setattr(model, f"{name}_active_output", active_output)
+
+        constraint_name = f"{name}_output_active_constraint"
+
+        def _output_active_rule(m):
+            r"""
+            .. math::
+                y_n \le E(t) / E_n
+            """
+            for t in m.TIMESTEPS:
+                for o in output_levels:
+                    getattr(m, constraint_name).add(
+                        (o, t),
+                        m.GenericStorageBlock.storage_content[
+                            storage_component, t + 1
+                        ]
+                        / storage_component.nominal_storage_capacity
+                        >= active_output[o, t] * output_levels[o],
+                    )
+
+        setattr(
+            model,
+            constraint_name,
+            po.Constraint(
+                OUTPUTS,
+                model.TIMESTEPS,
+                noruleinit=True,
+            ),
+        )
+        setattr(
+            model,
+            constraint_name + "build",
+            po.BuildAction(rule=_output_active_rule),
+        )
+
+        # Define constraints on the output flows
+        def _constraint_output_rule(m, o, p, t):
+            return (
+                m.flow[multiplexer_bus, o, p, t]
+                / m.flows[multiplexer_bus, o].nominal_value
+                <= active_output[o, t]
+            )
+
+        setattr(
+            model,
+            f"{name}_output_constraint",
+            po.Constraint(
+                OUTPUTS,
+                model.PERIODS,
+                model.TIMESTEPS,
+                rule=_constraint_output_rule,
+            ),
+        )
+
+    _outputs()
+
+    def _inputs():
+        INPUTS = po.Set(initialize=input_levels.keys())
+        setattr(model, f"{name}_INPUTS", INPUTS)
+
+        inactive_input = po.Var(
+            INPUTS, model.TIMESTEPS, domain=po.Binary, bounds=(0, 1)
+        )
+        setattr(model, f"{name}_active_input", inactive_input)
+
+        constraint_name = f"{name}_input_active_constraint"
+
+        def _input_active_rule(m):
+            r"""
+            .. math::
+                \hat{y}_n \ge (E(t) - E_n) - E_{max}
+            """
+            for t in m.TIMESTEPS:
+                for o in input_levels:
+                    getattr(m, constraint_name).add(
+                        (o, t),
+                        (
+                            m.GenericStorageBlock.storage_content[
+                                storage_component, t
+                            ]
+                            - input_levels[o]
+                        )
+                        / storage_component.nominal_storage_capacity
+                        <= inactive_input[o, t],
+                    )
+
+        setattr(
+            model,
+            constraint_name,
+            po.Constraint(
+                INPUTS,
+                model.TIMESTEPS,
+                noruleinit=True,
+            ),
+        )
+        setattr(
+            model,
+            constraint_name + "build",
+            po.BuildAction(rule=_input_active_rule),
+        )
+
+        # Define constraints on the input flows
+        def _constraint_input_rule(m, i, p, t):
+            return (
+                m.flow[i, multiplexer_bus, p, t]
+                / m.flows[i, multiplexer_bus].nominal_value
+                <= 1 - inactive_input[i, t]
+            )
+
+        setattr(
+            model,
+            f"{name}_input_constraint",
+            po.Constraint(
+                INPUTS,
+                model.PERIODS,
+                model.TIMESTEPS,
+                rule=_constraint_input_rule,
+            ),
+        )
+
+    _inputs()
+
+    return

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -100,8 +100,7 @@ def storage_level_constraint(
             f"{name}_output_constraint",
             po.Constraint(
                 OUTPUTS,
-                model.PERIODS,
-                model.TIMESTEPS,
+                model.TIMEINDEX,
                 rule=_constraint_output_rule,
             ),
         )
@@ -166,8 +165,7 @@ def storage_level_constraint(
             f"{name}_input_constraint",
             po.Constraint(
                 INPUTS,
-                model.PERIODS,
-                model.TIMESTEPS,
+                model.TIMEINDEX,
                 rule=_constraint_input_rule,
             ),
         )

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -171,5 +171,3 @@ def storage_level_constraint(
         )
 
     _inputs()
-
-    return

--- a/src/oemof/solph/constraints/storage_level.py
+++ b/src/oemof/solph/constraints/storage_level.py
@@ -121,7 +121,7 @@ def storage_level_constraint(
         def _input_active_rule(m):
             r"""
             .. math::
-                \hat{y}_n \ge (E(t) - E_n) - E_{max}
+                \hat{y}_n \ge (E(t) - E_n) / E_{max}
             """
             for t in m.TIMESTEPS:
                 for o in input_levels:
@@ -131,9 +131,9 @@ def storage_level_constraint(
                             m.GenericStorageBlock.storage_content[
                                 storage_component, t
                             ]
+                            / storage_component.nominal_storage_capacity
                             - input_levels[o]
                         )
-                        / storage_component.nominal_storage_capacity
                         <= inactive_input[o, t],
                     )
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1910,7 +1910,7 @@ class TestsConstraint:
         om = solph.Model(es)
         self.compare_lp_files("nonequidistant_timeindex.lp", my_om=om)
 
-    def test_nonequidistant_storage(self):
+    def test_storage_level_constraint(self):
         """Constraint test of an energy system
         with storage_level_constraint
         """

--- a/tests/lp_files/storage_level_constraint.lp
+++ b/tests/lp_files/storage_level_constraint.lp
@@ -1,0 +1,139 @@
+\* Source Pyomo model name=Model *\
+
+min
+objective:
++0.25 flow(in_0_multiplexer_0_0)
++0.25 flow(in_0_multiplexer_0_1)
+-0.125 flow(multiplexer_out_0_0_0)
+-0.125 flow(multiplexer_out_0_0_1)
+-0.125 flow(multiplexer_out_1_0_0)
+-0.125 flow(multiplexer_out_1_0_1)
+
+s.t.
+
+c_u_multiplexer_output_active_constraint(out_0_0)_:
+-0.25 GenericStorageBlock_storage_content(storage_1)
++0.125 multiplexer_active_output(out_0_0)
+<= 0
+
+c_u_multiplexer_output_active_constraint(out_0_1)_:
+-0.25 GenericStorageBlock_storage_content(storage_2)
++0.125 multiplexer_active_output(out_0_1)
+<= 0
+
+c_u_multiplexer_output_active_constraint(out_1_0)_:
+-0.25 GenericStorageBlock_storage_content(storage_1)
++0.5 multiplexer_active_output(out_1_0)
+<= 0
+
+c_u_multiplexer_output_active_constraint(out_1_1)_:
+-0.25 GenericStorageBlock_storage_content(storage_2)
++0.5 multiplexer_active_output(out_1_1)
+<= 0
+
+c_u_multiplexer_output_constraint(out_0_0_0)_:
++4 flow(multiplexer_out_0_0_0)
+-1 multiplexer_active_output(out_0_0)
+<= 0
+
+c_u_multiplexer_output_constraint(out_0_0_1)_:
++4 flow(multiplexer_out_0_0_1)
+-1 multiplexer_active_output(out_0_1)
+<= 0
+
+c_u_multiplexer_output_constraint(out_1_0_0)_:
++8 flow(multiplexer_out_1_0_0)
+-1 multiplexer_active_output(out_1_0)
+<= 0
+
+c_u_multiplexer_output_constraint(out_1_0_1)_:
++8 flow(multiplexer_out_1_0_1)
+-1 multiplexer_active_output(out_1_1)
+<= 0
+
+c_u_multiplexer_input_active_constraint(in_1_0)_:
+-1 multiplexer_active_input(in_1_0)
+<= -0.9375
+
+c_u_multiplexer_input_active_constraint(in_1_1)_:
++0.25 GenericStorageBlock_storage_content(storage_1)
+-1 multiplexer_active_input(in_1_1)
+<= 0.0625
+
+c_u_multiplexer_input_constraint(in_1_0_0)_:
++8 flow(in_1_multiplexer_0_0)
++1 multiplexer_active_input(in_1_0)
+<= 1
+
+c_u_multiplexer_input_constraint(in_1_0_1)_:
++8 flow(in_1_multiplexer_0_1)
++1 multiplexer_active_input(in_1_1)
+<= 1
+
+c_e_BusBlock_balance(multiplexer_0_0)_:
++1 flow(in_0_multiplexer_0_0)
++1 flow(in_1_multiplexer_0_0)
+-1 flow(multiplexer_out_0_0_0)
+-1 flow(multiplexer_out_1_0_0)
+-1 flow(multiplexer_storage_0_0)
++1 flow(storage_multiplexer_0_0)
+= 0
+
+c_e_BusBlock_balance(multiplexer_0_1)_:
++1 flow(in_0_multiplexer_0_1)
++1 flow(in_1_multiplexer_0_1)
+-1 flow(multiplexer_out_0_0_1)
+-1 flow(multiplexer_out_1_0_1)
+-1 flow(multiplexer_storage_0_1)
++1 flow(storage_multiplexer_0_1)
+= 0
+
+c_e_GenericStorageBlock_balance(storage_0_0)_:
++1 GenericStorageBlock_storage_content(storage_1)
+-1 flow(multiplexer_storage_0_0)
++1 flow(storage_multiplexer_0_0)
+= 3
+
+c_e_GenericStorageBlock_balance(storage_0_1)_:
+-0.75 GenericStorageBlock_storage_content(storage_1)
++1 GenericStorageBlock_storage_content(storage_2)
+-1 flow(multiplexer_storage_0_1)
++1 flow(storage_multiplexer_0_1)
+= 0
+
+c_e_GenericStorageBlock_balanced_cstr(storage)_:
++1 GenericStorageBlock_storage_content(storage_2)
+= 4
+
+c_e_ONE_VAR_CONSTANT:
+ONE_VAR_CONSTANT = 1.0
+
+bounds
+   0 <= flow(in_0_multiplexer_0_0) <= 0.5
+   0 <= flow(in_0_multiplexer_0_1) <= 0.5
+   0 <= flow(in_1_multiplexer_0_0) <= 0.125
+   0 <= flow(in_1_multiplexer_0_1) <= 0.125
+   0 <= flow(multiplexer_out_0_0_0) <= 0.25
+   0 <= flow(multiplexer_out_0_0_1) <= 0.25
+   0 <= flow(multiplexer_out_1_0_0) <= 0.125
+   0 <= flow(multiplexer_out_1_0_1) <= 0.125
+   0 <= flow(multiplexer_storage_0_0) <= +inf
+   0 <= flow(multiplexer_storage_0_1) <= +inf
+   0 <= flow(storage_multiplexer_0_0) <= +inf
+   0 <= flow(storage_multiplexer_0_1) <= +inf
+   0 <= multiplexer_active_output(out_0_0) <= 1
+   0 <= multiplexer_active_output(out_0_1) <= 1
+   0 <= multiplexer_active_output(out_1_0) <= 1
+   0 <= multiplexer_active_output(out_1_1) <= 1
+   0 <= multiplexer_active_input(in_1_0) <= 1
+   0 <= multiplexer_active_input(in_1_1) <= 1
+   0 <= GenericStorageBlock_storage_content(storage_1) <= 4
+   0 <= GenericStorageBlock_storage_content(storage_2) <= 4
+binary
+  multiplexer_active_output(out_0_0)
+  multiplexer_active_output(out_0_1)
+  multiplexer_active_output(out_1_0)
+  multiplexer_active_output(out_1_1)
+  multiplexer_active_input(in_1_0)
+  multiplexer_active_input(in_1_1)
+end

--- a/tests/lp_files/storage_level_constraint.lp
+++ b/tests/lp_files/storage_level_constraint.lp
@@ -53,12 +53,12 @@ c_u_multiplexer_output_constraint(out_1_0_1)_:
 
 c_u_multiplexer_input_active_constraint(in_1_0)_:
 -1 multiplexer_active_input(in_1_0)
-<= -0.9375
+<= -0.75
 
 c_u_multiplexer_input_active_constraint(in_1_1)_:
 +0.25 GenericStorageBlock_storage_content(storage_1)
 -1 multiplexer_active_input(in_1_1)
-<= 0.0625
+<= 0.25
 
 c_u_multiplexer_input_constraint(in_1_0_0)_:
 +8 flow(in_1_multiplexer_0_0)


### PR DESCRIPTION
- [X] constraint that allows to (in) activate flows from/to a storage based on storage level
- [X] Example
- [X] Documentation (basic)
- [x] Tests

**From the example**

```Python
storage_level_constraint(
    model=model,
    name="multiplexer",
    storage_component=storage,
    multiplexer_bus=multiplexer,
    input_levels={in_1: 1 / 3},  # in_0 is always active
    output_levels={out_0: 1 / 6, out_1: 1 / 2},
)
```

There are two inflows (one always active, one active if storage level < 1/3) and two outflows (one active if storage level > 1/6 the second if storage level > 1/2). There is revenue for the outputs, the constraint inflow is free, the unconstraint one costs more than the revenue.

![grafik](https://github.com/oemof/oemof-solph/assets/4871848/ff33fca5-3363-47f9-b5f0-ea7356640d3a)

As the storage has losses, the outflows are used to empty it as fast as possible. It is held above the limit for the free inflow so that it can be used to recharge in the end. As the free inflow is constraint, the costly has to kick in in the end to fully recharge the storage.