### PR TITLE
Fix SinkDSM load shedding limit

### DIFF
--- a/src/oemof/solph/components/experimental/_sink_dsm.py
+++ b/src/oemof/solph/components/experimental/_sink_dsm.py
@@ -4859,7 +4859,11 @@ class SinkDSMDLRInvestmentBlock(ScalarBlock):
                 for p in m.PERIODS:
                     if g.shed_eligibility:
                         # sum of all load reductions
-                        lhs = sum(self.dsm_do_shed[g, t] for t in m.TIMESTEPS)
+                        lhs = sum(
+                            self.dsm_do_shed[g, t]
+                            for pp, t in m.TIMEINDEX
+                            if pp == p
+                        )
 
                         # year limit
                         rhs = (

--- a/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
+++ b/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
@@ -623,7 +623,6 @@ c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_2_5)_:
 c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_0)_:
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
-
 -50 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
 <= 0
 

--- a/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
+++ b/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
@@ -623,28 +623,16 @@ c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_2_5)_:
 c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_0)_:
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
 -50 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
 <= 0
 
 c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_1)_:
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
 -50 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
 <= 0
 
 c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_2)_:
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
-+1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
 +1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
 -50 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)


### PR DESCRIPTION
This PR fixes one constraint formulation in the `SinkDSMDLRInvestmentBlock`. I was meaning to impose a periodical limit on shedding, but forgot to adjust it, resulting in an overall limit that did not make any sense. Now it is fixed.

Please review, @p-snft and if okay, feel free to merge back.