### PR TITLE
Fix Python versions in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -94,9 +94,9 @@ skip = migrations
 #  - can use as many you want
 
 python_versions =
-    py36
-    py37
     py38
+    py39
+    py310
 
 dependencies =
 #    1.4: Django==1.4.16 !python_versions[py3*]


### PR DESCRIPTION
setup.cfg named outdated versions of Python. This PR fixes that so that it is aligned with setup.py.