### PR TITLE
Set arguments defaults in link

### DIFF
--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -80,10 +80,10 @@ class Link(on.Transformer):
 
     def __init__(
         self,
-        label,
-        inputs,
-        outputs,
-        conversion_factors,
+        label=None,
+        inputs=None,
+        outputs=None,
+        conversion_factors=None,
     ):
         if inputs is None:
             warn_if_missing_attribute(self, "inputs")

--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -25,6 +25,7 @@ from pyomo.core.base.block import ScalarBlock
 from pyomo.environ import BuildAction
 from pyomo.environ import Constraint
 
+from oemof.solph._helpers import warn_if_missing_attribute
 from oemof.solph._plumbing import sequence
 
 

--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -85,10 +85,13 @@ class Link(on.Transformer):
         conversion_factors,
     ):
         if inputs is None:
+            warn_if_missing_attribute(self, "inputs")
             inputs = {}
         if outputs is None:
+            warn_if_missing_attribute(self, "outputs")
             outputs = {}
         if conversion_factors is None:
+            warn_if_missing_attribute(self, "conversion_factors")
             conversion_factors = {}
         super().__init__(
             label=label,

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -171,11 +171,11 @@ def test_link_to_warn_about_not_matching_number_of_flows(warning_fixture):
     with warnings.catch_warnings(record=True) as w:
         solph.components.Link(
             label="empty_link",
-            inputs=None,
-            outputs=None,
-            conversion_factors=None,
         )
-        assert len(w) == 1
+        assert len(w) == 4
+        # Check  number of raised warnings:
+        # 1. empty inputs, 2. empty outputs 3. empty conversion_factors
+        # 4. unmatched number of flows
         # Check warning for unmatched number of flows
         assert msg in str(w[-1].message)
 


### PR DESCRIPTION
close #949

Due to the process of building oemof.tabular.facades, it's necessary that the Link component uses its default values during its instantiation, as no values are passed. These default values are updated afterward.

Therefore, I will add None as default values for the explicit arguments and add a warning for this case.
