### PR TITLE
Use solph instead of oemof in the documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,10 +115,10 @@ Read our `contribution <https://oemof.readthedocs.io/en/latest/contributing.html
 
 Contribution is already possible on a low level by simply fixing typos in
 oemof's documentation or rephrasing sections which are unclear.
-If you want to support us that way please fork the oemof repository to your own
+If you want to support us that way please fork the oemof-solph repository to your own
 github account and make changes as described in the `github guidelines <https://docs.github.com/en/get-started/quickstart/hello-world>`_
 
-If you have questions regarding the use of oemof you can visit the forum at `openmod-initiative.org <https://forum.openmod-initiative.org/tags/c/qa/oemof>`_ and open a new thread if your questions hasn't been already answered.
+If you have questions regarding the use of oemof including oemof-solph you can visit the forum at `openmod-initiative.org <https://forum.openmod-initiative.org/tags/c/qa/oemof>`_ and open a new thread if your questions hasn't been already answered.
 
 Keep in touch! - You can become a watcher at our `github site <https://github.com/oemof/oemof>`_,
 but this will bring you quite a few mails and might be more interesting for developers.
@@ -135,7 +135,7 @@ The `oemof.solph documentation <https://oemof-solph.readthedocs.io/>`_ is powere
 Installation
 ============
 
-If you have a working Python3 environment, use pypi to install the latest oemof version. Python >= 3.6 is recommended. Lower versions may work but are not tested.
+If you have a working Python3 environment, use pypi to install the latest oemof-solph version. Python >= 3.6 is recommended. Lower versions may work but are not tested.
 
 
 ::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 =================================
-Welcome to oemof's documentation!
+Welcome to oemof-solph's documentation!
 =================================
 
 .. toctree::

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -156,7 +156,7 @@ For all parameters see the API documentation of the :py:class:`~oemof.solph.flow
 
     solph.flows.Flow()
 
-Oemof has different types of *flows* but you should be aware that you cannot connect every *flow* type with every *component*.
+oemof-solph has different types of *flows* but you should be aware that you cannot connect every *flow* type with every *component*.
 
 .. note:: See the :py:class:`~oemof.solph.flows._flow.Flow` class for all parameters and the mathematical background.
 
@@ -1004,7 +1004,7 @@ Using the multi-period (investment) mode (experimental)
 Sometimes you might be interested in how energy systems could evolve in the longer-term, e.g. until 2045 or 2050 to meet some
 carbon neutrality and climate protection or RES and energy efficiency targets.
 
-While in principle, you could try to model this in oemof using the standard investment mode described above (see :ref:`investment_mode_label`),
+While in principle, you could try to model this in oemof-solph using the standard investment mode described above (see :ref:`investment_mode_label`),
 you would make the implicit assumption that your entire system is built at the start of your optimization and doesn't change over time.
 To address this shortcoming, the multi-period (investment) feature has been introduced. Be aware that it is still experimental.
 So feel free to report any bugs or unexpected behaviour if you come across them.


### PR DESCRIPTION
# Description

The aim of this PR is to consistently refer to `solph` instead of `oemof` in the documentation. I seem to remember from the 2022.11 meeting, that `oemof` should no longer be used synonymously with `solph`. However, in the documentation sometimes `oemof` is used while actually referring just to the `solph` package. A prominent example is the title of the documentation (file `docs/index.rst`), where it reads "Welcome to oemof's documentation!".

As oemof is a framework containing multiple packages by now, I think it would be better to be precise on which part of oemof is meant. 

# Questions

- Which style would be best to use in regular text? I can think of:
  - solph 
    - it's the name of the package, after all
  - oemof.solph 
    - biggest resemblance to the in-code use
  - oemof-solph 
    - also used in the documentation from time to time
    - best solution for bringing the relation between oemof and solph across (imho)