### PR TITLE
Implement periodic behaviour into  `plumbing.sequence` 

### DIFF
--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -177,7 +177,10 @@ class _Sequence(UserList):
         return str([i for i in self])
 
     def __len__(self):
-        return max(len(self.data), self.highest_index + 1)
+        if self.periodic_values:
+            return self.highest_index
+        else:
+            return max(len(self.data), self.highest_index + 1)
 
     def __iter__(self):
         if self.periodic_values:


### PR DESCRIPTION
close #959 


A periodically changing `sequence` is handy for the multi-period investment, when the parameters should change per period.
For this I have adapted `plumbing.sequence` and `plumbing._sequence`. An additional distinction must be made for this behavior. 

Apparently, the approach with the distinction by variability of the passed iterables in `sequence` does not work, because pandas.series are interpreted as immutable sequence.

I therefore decided to specify periodic behavior only when a dictionary is passed. The explicit keys `len` and `values` also make it more clear

    >>> x = sequence({"len":9,"values":[1,2,3]})
    >>> print(x)
    [0, 0, 0, 1, 1, 1, 2, 2, 2]
    >>> x[1]
    0
    >>> x[4]
    1
    >>> x[7]
    2

I would appreciate your opinion on this @p-snft or @uvchik if this could break anything 


