### PR TITLE
Add storage_costs to GenericStorage

### DIFF
--- a/examples/storage_costs/storage_costs.py
+++ b/examples/storage_costs/storage_costs.py
@@ -52,21 +52,23 @@ def storage_costs_example():
         )
     )
 
-    electricity_price= np.array([
-        0.38,
-        0.31,
-        0.32,
-        0.33,
-        0.37,
-        0.32,
-        0.33,
-        0.34,
-        0.39,
-        0.38,
-        0.37,
-        0.35,
-        0.35,
-    ])
+    electricity_price = np.array(
+        [
+            0.38,
+            0.31,
+            0.32,
+            0.33,
+            0.37,
+            0.32,
+            0.33,
+            0.34,
+            0.39,
+            0.38,
+            0.37,
+            0.35,
+            0.35,
+        ]
+    )
 
     # Electric Storage 1
     # Costs are designed in a way that storing energy is benificial until the
@@ -74,14 +76,18 @@ def storage_costs_example():
     battery1 = solph.components.GenericStorage(
         label="battery 1",
         nominal_storage_capacity=10,
-        inputs={bel: solph.Flow(
-            nominal_value=1,
-            variable_costs=electricity_price,
-        )},
-        outputs={bel: solph.Flow(
-            nominal_value=1,
-            variable_costs=-electricity_price,
-        )},
+        inputs={
+            bel: solph.Flow(
+                nominal_value=1,
+                variable_costs=electricity_price,
+            )
+        },
+        outputs={
+            bel: solph.Flow(
+                nominal_value=1,
+                variable_costs=-electricity_price,
+            )
+        },
         initial_storage_level=0.5,
         balanced=False,
     )
@@ -92,15 +98,19 @@ def storage_costs_example():
     battery2 = solph.components.GenericStorage(
         label="battery 2",
         nominal_storage_capacity=10,
-        inputs={bel: solph.Flow(
-            nominal_value=1,
-            variable_costs=electricity_price,
-        )},
-        outputs={bel: solph.Flow(
-            nominal_value=1,
-            variable_costs=-electricity_price,
-        )},
-        storage_costs=12*[0] + [-np.mean(electricity_price)],
+        inputs={
+            bel: solph.Flow(
+                nominal_value=1,
+                variable_costs=electricity_price,
+            )
+        },
+        outputs={
+            bel: solph.Flow(
+                nominal_value=1,
+                variable_costs=-electricity_price,
+            )
+        },
+        storage_costs=12 * [0] + [-np.mean(electricity_price)],
         initial_storage_level=0.5,
         balanced=False,
     )
@@ -115,8 +125,14 @@ def storage_costs_example():
     # create result object
     results = solph.processing.results(model)
 
-    plt.plot(results[(battery1, None)]["sequences"], label="content w/o storage costs")
-    plt.plot(results[(battery2, None)]["sequences"], label="content w/ storage revenue")
+    plt.plot(
+        results[(battery1, None)]["sequences"],
+        label="content w/o storage costs",
+    )
+    plt.plot(
+        results[(battery2, None)]["sequences"],
+        label="content w/ storage revenue",
+    )
     plt.legend()
     plt.grid()
 

--- a/examples/storage_costs/storage_costs.py
+++ b/examples/storage_costs/storage_costs.py
@@ -29,7 +29,6 @@ def storage_costs_example():
     idx = pd.date_range("1/1/2023", periods=13, freq="H")
     es = solph.EnergySystem(timeindex=idx, infer_last_interval=False)
 
-    
     # power bus
     bel = solph.Bus(label="bel")
     es.add(bel)
@@ -53,7 +52,7 @@ def storage_costs_example():
     )
 
     # Electric Storage
-    battery =solph.components.GenericStorage(
+    battery = solph.components.GenericStorage(
         label="battery",
         nominal_storage_capacity=100,  # no effective limit
         storage_costs=-1,  # revenue for storing of 1/4 of the buying costs
@@ -74,7 +73,12 @@ def storage_costs_example():
     results = solph.processing.results(model)
 
     plt.plot(results[(battery, None)]["sequences"], "r--", label="content")
-    plt.step(results[(bel, battery)]["sequences"], "b-", label="inflow", where="post")
+    plt.step(
+        results[(bel, battery)]["sequences"],
+        "b-",
+        label="inflow",
+        where="post",
+    )
     plt.legend()
     plt.grid()
 

--- a/examples/storage_costs/storage_costs.py
+++ b/examples/storage_costs/storage_costs.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+"""
+General description
+-------------------
+Example that shows the parameter `storage_costs` of `GenericStorage`.
+
+
+Installation requirements
+-------------------------
+This example requires oemof.solph (v0.5.x), install by:
+
+    pip install oemof.solph[examples]
+
+
+License
+-------
+`MIT license <https://github.com/oemof/oemof-solph/blob/dev/LICENSE>`_
+"""
+
+import pandas as pd
+from matplotlib import pyplot as plt
+
+from oemof import solph
+
+
+def storage_costs_example():
+    # create an energy system
+    idx = pd.date_range("1/1/2023", periods=13, freq="H")
+    es = solph.EnergySystem(timeindex=idx, infer_last_interval=False)
+
+    
+    # power bus
+    bel = solph.Bus(label="bel")
+    es.add(bel)
+
+    es.add(
+        solph.components.Source(
+            label="source_el",
+            outputs={
+                bel: solph.Flow(nominal_value=1, variable_costs=4),
+            },
+        )
+    )
+
+    es.add(
+        solph.components.Sink(
+            label="sink_el",
+            inputs={
+                bel: solph.Flow(nominal_value=1, variable_costs=1),
+            },
+        )
+    )
+
+    # Electric Storage
+    battery =solph.components.GenericStorage(
+        label="battery",
+        nominal_storage_capacity=100,  # no effective limit
+        storage_costs=-1,  # revenue for storing of 1/4 of the buying costs
+        inputs={bel: solph.Flow()},
+        outputs={bel: solph.Flow(variable_costs=2)},
+        initial_storage_level=0,
+        balanced=False,
+    )
+    es.add(battery)
+
+    # create an optimization problem and solve it
+    model = solph.Model(es)
+
+    # solve model
+    model.solve(solver="cbc")
+
+    # create result object
+    results = solph.processing.results(model)
+
+    plt.plot(results[(battery, None)]["sequences"], "r--", label="content")
+    plt.step(results[(bel, battery)]["sequences"], "b-", label="inflow", where="post")
+    plt.legend()
+    plt.grid()
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    storage_costs_example()

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -108,7 +108,7 @@ class GenericStorage(network.Component):
         nominal_storage_capacity should not be set (or set to None) if an
         investment object is used.
     storage_costs : numeric (iterable or scalar), :math:`c_{storage}(t)`
-        Cost (per energy) for using the storage.
+        Cost (per energy) for having energy in the storage.
     lifetime_inflow : int, :math:`n_{in}`
         Determine the lifetime of an inflow; only applicable for multi-period
         models which can invest in storage capacity and have an
@@ -419,8 +419,8 @@ class GenericStorageBlock(ScalarBlock):
                                 :math:`\delta(t)` and
                                 timeincrement
                                 :math:`\tau(t)`
-    :math:`c_{storage}(t)`      costs for storaging     `storage_costs`
-                                energy
+    :math:`c_{storage}(t)`      costs of having         `storage_costs`
+                                energy stored
     =========================== ======================= =========
 
     **The following parts of the objective function are created:**

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -427,7 +427,7 @@ class GenericStorageBlock(ScalarBlock):
 
     *Standard model*
 
-    * :attr: `storage_costs`not 0
+    * :attr: `storage_costs` not 0
 
         ..math::
             \sum_{t \in \textrm{TIMESTEPS}} c_{storage}(t) \cdot E(t)

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -611,9 +611,13 @@ class GenericStorageBlock(ScalarBlock):
 
         for n in self.STORAGES:
             if n.storage_costs[0] is not None:
-                storage_costs += self.storage_content[n, 0] * n.storage_costs[0]
+                storage_costs += (
+                    self.storage_content[n, 0] * n.storage_costs[0]
+                )
                 for t in m.TIMESTEPS:
-                    storage_costs += self.storage_content[n, t+1] * n.storage_costs[t+1]
+                    storage_costs += (
+                        self.storage_content[n, t + 1] * n.storage_costs[t + 1]
+                    )
 
         self.storage_costs = Expression(expr=storage_costs)
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -280,6 +280,7 @@ class TestsConstraint:
             },
             nominal_storage_capacity=1e5,
             loss_rate=0.13,
+            storage_costs=0.1,
             inflow_conversion_factor=0.97,
             outflow_conversion_factor=0.86,
             initial_storage_level=0.4,

--- a/tests/lp_files/storage.lp
+++ b/tests/lp_files/storage.lp
@@ -2,6 +2,10 @@
 
 min 
 objective:
++4000.0 ONE_VAR_CONSTANT
++0.1 GenericStorageBlock_storage_content(storage_no_invest_1)
++0.1 GenericStorageBlock_storage_content(storage_no_invest_2)
++0.1 GenericStorageBlock_storage_content(storage_no_invest_3)
 +56 flow(electricityBus_storage_no_invest_0_0)
 +56 flow(electricityBus_storage_no_invest_0_1)
 +56 flow(electricityBus_storage_no_invest_0_2)
@@ -51,6 +55,7 @@ c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
 = 40000.0
 
 bounds
+   +1 <= ONE_VAR_CONSTANT <= 1
    0 <= flow(electricityBus_storage_no_invest_0_0) <= 16667
    0 <= flow(electricityBus_storage_no_invest_0_1) <= 16667
    0 <= flow(electricityBus_storage_no_invest_0_2) <= 16667


### PR DESCRIPTION
Implement parameter `storage_costs` for `GenericStorage`: `storage_costs` might exist, e.g. if space can be rented depending on the stored energy. So, this might be seen as an alternative to investment optimisation. A second use case is to incentivise using the storage in the last time step if the storage is not periodic. This can be done by giving `storage_costs=n_time_steps * [0] + [-energy_price]`, so that stored energy in the last time step is valued with the energy price.