### PR TITLE
Define multi-period investment storage level for very first time step of optimization

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -1032,21 +1032,20 @@ class GenericInvestmentStorageBlock(ScalarBlock):
         # ########################## CHECKS ###################################
         if m.es.periods is not None:
             for n in group:
-                error = (
+                error_fixed_absolute_losses = (
                     "For a multi-period investment model, fixed absolute"
                     " losses are not supported. Please remove parameter."
                 )
                 if n.fixed_losses_absolute.default != 0:
-                    raise ValueError(error)
-                warning = (
+                    raise ValueError(error_fixed_absolute_losses)
+                error_initial_storage_level = (
                     "For a multi-period model, initial_storage_level is"
-                    " not supported.\nIt is suggested to remove that"
-                    " parameter since it has no effect.\nstorage_content"
-                    " will be zero, until there is some usable storage "
-                    " capacity installed."
+                    " not supported.\nIt needs to be removed since it"
+                    " has no effect.\nstorage_content will be zero,"
+                    " until there is some usable storage capacity installed."
                 )
                 if n.initial_storage_level is not None:
-                    warn(warning, debugging.SuspiciousUsageWarning)
+                    raise ValueError(error_initial_storage_level)
 
         # ########################## SETS #####################################
 
@@ -1315,10 +1314,8 @@ class GenericInvestmentStorageBlock(ScalarBlock):
             def _initially_empty_rule(block):
                 """Ensure storage to be empty initially"""
                 for n in self.INVESTSTORAGES:
-                    for t in m.TIMESTEPS:
-                        if t == 0:
-                            expr = self.storage_content[n, 0] == 0
-                            self.initially_empty.add((n, t), expr)
+                    expr = self.storage_content[n, 0] == 0
+                    self.initially_empty.add((n, 0), expr)
 
             self.initially_empty = Constraint(
                 self.INVESTSTORAGES, m.TIMESTEPS, noruleinit=True

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -1312,6 +1312,22 @@ class GenericInvestmentStorageBlock(ScalarBlock):
 
             self.old_rule_build = BuildAction(rule=_old_storage_capacity_rule)
 
+            def _initially_empty_rule(block):
+                """Ensure storage to be empty initially"""
+                for n in self.INVESTSTORAGES:
+                    for t in m.TIMESTEPS:
+                        if t == 0:
+                            expr = self.storage_content[n, 0] == 0
+                            self.initially_empty.add((n, t), expr)
+
+            self.initially_empty = Constraint(
+                self.INVESTSTORAGES, m.TIMESTEPS, noruleinit=True
+            )
+
+            self.initially_empty_build = BuildAction(
+                rule=_initially_empty_rule
+            )
+
         # Standard storage implementation for discrete time points
         else:
 

--- a/tests/lp_files/connect_investment_multi_period.lp
+++ b/tests/lp_files/connect_investment_multi_period.lp
@@ -2,12 +2,12 @@
 
 min 
 objective:
-+520.1320088877258 InvestmentFlowBlock_invest(Bus1_Sink_0)
-+509.93334204678996 InvestmentFlowBlock_invest(Bus1_Sink_1)
-+499.9346490654803 InvestmentFlowBlock_invest(Bus1_Sink_2)
 +127.95247418638057 InvestmentFlowBlock_invest(Source_Bus1_0)
 +125.44360214351036 InvestmentFlowBlock_invest(Source_Bus1_1)
 +122.9839236701082 InvestmentFlowBlock_invest(Source_Bus1_2)
++520.1320088877258 InvestmentFlowBlock_invest(Bus1_Sink_0)
++509.93334204678996 InvestmentFlowBlock_invest(Bus1_Sink_1)
++499.9346490654803 InvestmentFlowBlock_invest(Bus1_Sink_2)
 +150.83828257744048 GenericInvestmentStorageBlock_invest(storage_0)
 +147.8806691935691 GenericInvestmentStorageBlock_invest(storage_1)
 +144.9810482289893 GenericInvestmentStorageBlock_invest(storage_2)
@@ -15,8 +15,8 @@ objective:
 s.t.
 
 c_e__equate_InvestmentFlowBlock_invest(Source_Bus1_0)_InvestmentFlowBlock_invest(Bus1_Sink_0)__:
--1 InvestmentFlowBlock_invest(Bus1_Sink_0)
 +2 InvestmentFlowBlock_invest(Source_Bus1_0)
+-1 InvestmentFlowBlock_invest(Bus1_Sink_0)
 = 0
 
 c_e__equate_InvestmentFlowBlock_invest(Source_Bus1_0)_GenericInvestmentStorageBlock_invest(storage_0)__:
@@ -25,83 +25,45 @@ c_e__equate_InvestmentFlowBlock_invest(Source_Bus1_0)_GenericInvestmentStorageBl
 = 0
 
 c_e_BusBlock_balance(Bus1_0_0)_:
-+1 flow(Source_Bus1_0_0)
 +1 flow(storage_Bus1_0_0)
++1 flow(Source_Bus1_0_0)
 -1 flow(Bus1_storage_0_0)
 -1 flow(Bus1_Sink_0_0)
 = 0
 
 c_e_BusBlock_balance(Bus1_0_1)_:
-+1 flow(Source_Bus1_0_1)
 +1 flow(storage_Bus1_0_1)
++1 flow(Source_Bus1_0_1)
 -1 flow(Bus1_storage_0_1)
 -1 flow(Bus1_Sink_0_1)
 = 0
 
 c_e_BusBlock_balance(Bus1_1_2)_:
-+1 flow(Source_Bus1_1_2)
 +1 flow(storage_Bus1_1_2)
++1 flow(Source_Bus1_1_2)
 -1 flow(Bus1_storage_1_2)
 -1 flow(Bus1_Sink_1_2)
 = 0
 
 c_e_BusBlock_balance(Bus1_1_3)_:
-+1 flow(Source_Bus1_1_3)
 +1 flow(storage_Bus1_1_3)
++1 flow(Source_Bus1_1_3)
 -1 flow(Bus1_storage_1_3)
 -1 flow(Bus1_Sink_1_3)
 = 0
 
 c_e_BusBlock_balance(Bus1_2_4)_:
-+1 flow(Source_Bus1_2_4)
 +1 flow(storage_Bus1_2_4)
++1 flow(Source_Bus1_2_4)
 -1 flow(Bus1_storage_2_4)
 -1 flow(Bus1_Sink_2_4)
 = 0
 
 c_e_BusBlock_balance(Bus1_2_5)_:
-+1 flow(Source_Bus1_2_5)
 +1 flow(storage_Bus1_2_5)
++1 flow(Source_Bus1_2_5)
 -1 flow(Bus1_storage_2_5)
 -1 flow(Bus1_Sink_2_5)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_Bus1_0)_:
-+1 InvestmentFlowBlock_total(storage_Bus1_0)
--1 InvestmentFlowBlock_invest(storage_Bus1_0)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_Bus1_1)_:
--1 InvestmentFlowBlock_total(storage_Bus1_0)
-+1 InvestmentFlowBlock_total(storage_Bus1_1)
--1 InvestmentFlowBlock_invest(storage_Bus1_1)
-+1 InvestmentFlowBlock_old(storage_Bus1_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_Bus1_2)_:
--1 InvestmentFlowBlock_total(storage_Bus1_1)
-+1 InvestmentFlowBlock_total(storage_Bus1_2)
--1 InvestmentFlowBlock_invest(storage_Bus1_2)
-+1 InvestmentFlowBlock_old(storage_Bus1_2)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_0)_:
--1 InvestmentFlowBlock_invest(Bus1_Sink_0)
-+1 InvestmentFlowBlock_total(Bus1_Sink_0)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_1)_:
--1 InvestmentFlowBlock_invest(Bus1_Sink_1)
--1 InvestmentFlowBlock_total(Bus1_Sink_0)
-+1 InvestmentFlowBlock_total(Bus1_Sink_1)
-+1 InvestmentFlowBlock_old(Bus1_Sink_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_2)_:
--1 InvestmentFlowBlock_invest(Bus1_Sink_2)
--1 InvestmentFlowBlock_total(Bus1_Sink_1)
-+1 InvestmentFlowBlock_total(Bus1_Sink_2)
-+1 InvestmentFlowBlock_old(Bus1_Sink_2)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(Source_Bus1_0)_:
@@ -142,28 +104,42 @@ c_e_InvestmentFlowBlock_total_rule(Bus1_storage_2)_:
 +1 InvestmentFlowBlock_old(Bus1_storage_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_0)_:
-+1 InvestmentFlowBlock_old_end(storage_Bus1_0)
+c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_0)_:
+-1 InvestmentFlowBlock_invest(Bus1_Sink_0)
++1 InvestmentFlowBlock_total(Bus1_Sink_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_1)_:
-+1 InvestmentFlowBlock_old_end(storage_Bus1_1)
+c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_1)_:
+-1 InvestmentFlowBlock_invest(Bus1_Sink_1)
+-1 InvestmentFlowBlock_total(Bus1_Sink_0)
++1 InvestmentFlowBlock_total(Bus1_Sink_1)
++1 InvestmentFlowBlock_old(Bus1_Sink_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_2)_:
-+1 InvestmentFlowBlock_old_end(storage_Bus1_2)
+c_e_InvestmentFlowBlock_total_rule(Bus1_Sink_2)_:
+-1 InvestmentFlowBlock_invest(Bus1_Sink_2)
+-1 InvestmentFlowBlock_total(Bus1_Sink_1)
++1 InvestmentFlowBlock_total(Bus1_Sink_2)
++1 InvestmentFlowBlock_old(Bus1_Sink_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_0)_:
-+1 InvestmentFlowBlock_old_end(Bus1_Sink_0)
+c_e_InvestmentFlowBlock_total_rule(storage_Bus1_0)_:
++1 InvestmentFlowBlock_total(storage_Bus1_0)
+-1 InvestmentFlowBlock_invest(storage_Bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_1)_:
-+1 InvestmentFlowBlock_old_end(Bus1_Sink_1)
+c_e_InvestmentFlowBlock_total_rule(storage_Bus1_1)_:
+-1 InvestmentFlowBlock_total(storage_Bus1_0)
++1 InvestmentFlowBlock_total(storage_Bus1_1)
+-1 InvestmentFlowBlock_invest(storage_Bus1_1)
++1 InvestmentFlowBlock_old(storage_Bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_2)_:
-+1 InvestmentFlowBlock_old_end(Bus1_Sink_2)
+c_e_InvestmentFlowBlock_total_rule(storage_Bus1_2)_:
+-1 InvestmentFlowBlock_total(storage_Bus1_1)
++1 InvestmentFlowBlock_total(storage_Bus1_2)
+-1 InvestmentFlowBlock_invest(storage_Bus1_2)
++1 InvestmentFlowBlock_old(storage_Bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(Source_Bus1_0)_:
@@ -190,28 +166,28 @@ c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_2)_:
 +1 InvestmentFlowBlock_old_end(Bus1_storage_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_0)_:
-+1 InvestmentFlowBlock_old_exo(storage_Bus1_0)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_0)_:
++1 InvestmentFlowBlock_old_end(Bus1_Sink_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_1)_:
-+1 InvestmentFlowBlock_old_exo(storage_Bus1_1)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_1)_:
++1 InvestmentFlowBlock_old_end(Bus1_Sink_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_2)_:
-+1 InvestmentFlowBlock_old_exo(storage_Bus1_2)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_Sink_2)_:
++1 InvestmentFlowBlock_old_end(Bus1_Sink_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_0)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_Sink_0)
+c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_0)_:
++1 InvestmentFlowBlock_old_end(storage_Bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_1)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_Sink_1)
+c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_1)_:
++1 InvestmentFlowBlock_old_end(storage_Bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_2)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_Sink_2)
+c_e_InvestmentFlowBlock_old_rule_end(storage_Bus1_2)_:
++1 InvestmentFlowBlock_old_end(storage_Bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(Source_Bus1_0)_:
@@ -238,40 +214,28 @@ c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_2)_:
 +1 InvestmentFlowBlock_old_exo(Bus1_storage_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_Bus1_0)_:
--1 InvestmentFlowBlock_old_end(storage_Bus1_0)
--1 InvestmentFlowBlock_old_exo(storage_Bus1_0)
-+1 InvestmentFlowBlock_old(storage_Bus1_0)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_0)_:
++1 InvestmentFlowBlock_old_exo(Bus1_Sink_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_Bus1_1)_:
-+1 InvestmentFlowBlock_old(storage_Bus1_1)
--1 InvestmentFlowBlock_old_end(storage_Bus1_1)
--1 InvestmentFlowBlock_old_exo(storage_Bus1_1)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_1)_:
++1 InvestmentFlowBlock_old_exo(Bus1_Sink_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_Bus1_2)_:
-+1 InvestmentFlowBlock_old(storage_Bus1_2)
--1 InvestmentFlowBlock_old_end(storage_Bus1_2)
--1 InvestmentFlowBlock_old_exo(storage_Bus1_2)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_Sink_2)_:
++1 InvestmentFlowBlock_old_exo(Bus1_Sink_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_0)_:
--1 InvestmentFlowBlock_old_end(Bus1_Sink_0)
--1 InvestmentFlowBlock_old_exo(Bus1_Sink_0)
-+1 InvestmentFlowBlock_old(Bus1_Sink_0)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_0)_:
++1 InvestmentFlowBlock_old_exo(storage_Bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_1)_:
-+1 InvestmentFlowBlock_old(Bus1_Sink_1)
--1 InvestmentFlowBlock_old_end(Bus1_Sink_1)
--1 InvestmentFlowBlock_old_exo(Bus1_Sink_1)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_1)_:
++1 InvestmentFlowBlock_old_exo(storage_Bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_2)_:
-+1 InvestmentFlowBlock_old(Bus1_Sink_2)
--1 InvestmentFlowBlock_old_end(Bus1_Sink_2)
--1 InvestmentFlowBlock_old_exo(Bus1_Sink_2)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_Bus1_2)_:
++1 InvestmentFlowBlock_old_exo(storage_Bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(Source_Bus1_0)_:
@@ -310,65 +274,41 @@ c_e_InvestmentFlowBlock_old_rule(Bus1_storage_2)_:
 -1 InvestmentFlowBlock_old_exo(Bus1_storage_2)
 = 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_0_0)_:
-+1 flow(storage_Bus1_0_0)
--1 InvestmentFlowBlock_total(storage_Bus1_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_0)_:
+-1 InvestmentFlowBlock_old_end(Bus1_Sink_0)
+-1 InvestmentFlowBlock_old_exo(Bus1_Sink_0)
++1 InvestmentFlowBlock_old(Bus1_Sink_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_0_1)_:
-+1 flow(storage_Bus1_0_1)
--1 InvestmentFlowBlock_total(storage_Bus1_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_1)_:
++1 InvestmentFlowBlock_old(Bus1_Sink_1)
+-1 InvestmentFlowBlock_old_end(Bus1_Sink_1)
+-1 InvestmentFlowBlock_old_exo(Bus1_Sink_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_1_2)_:
-+1 flow(storage_Bus1_1_2)
--1 InvestmentFlowBlock_total(storage_Bus1_1)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_Sink_2)_:
++1 InvestmentFlowBlock_old(Bus1_Sink_2)
+-1 InvestmentFlowBlock_old_end(Bus1_Sink_2)
+-1 InvestmentFlowBlock_old_exo(Bus1_Sink_2)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_1_3)_:
-+1 flow(storage_Bus1_1_3)
--1 InvestmentFlowBlock_total(storage_Bus1_1)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_Bus1_0)_:
+-1 InvestmentFlowBlock_old_end(storage_Bus1_0)
+-1 InvestmentFlowBlock_old_exo(storage_Bus1_0)
++1 InvestmentFlowBlock_old(storage_Bus1_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_2_4)_:
-+1 flow(storage_Bus1_2_4)
--1 InvestmentFlowBlock_total(storage_Bus1_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_Bus1_1)_:
++1 InvestmentFlowBlock_old(storage_Bus1_1)
+-1 InvestmentFlowBlock_old_end(storage_Bus1_1)
+-1 InvestmentFlowBlock_old_exo(storage_Bus1_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_Bus1_2_5)_:
-+1 flow(storage_Bus1_2_5)
--1 InvestmentFlowBlock_total(storage_Bus1_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_0_0)_:
-+1 flow(Bus1_Sink_0_0)
--1 InvestmentFlowBlock_total(Bus1_Sink_0)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_0_1)_:
-+1 flow(Bus1_Sink_0_1)
--1 InvestmentFlowBlock_total(Bus1_Sink_0)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_1_2)_:
-+1 flow(Bus1_Sink_1_2)
--1 InvestmentFlowBlock_total(Bus1_Sink_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_1_3)_:
-+1 flow(Bus1_Sink_1_3)
--1 InvestmentFlowBlock_total(Bus1_Sink_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_2_4)_:
-+1 flow(Bus1_Sink_2_4)
--1 InvestmentFlowBlock_total(Bus1_Sink_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_Sink_2_5)_:
-+1 flow(Bus1_Sink_2_5)
--1 InvestmentFlowBlock_total(Bus1_Sink_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_Bus1_2)_:
++1 InvestmentFlowBlock_old(storage_Bus1_2)
+-1 InvestmentFlowBlock_old_end(storage_Bus1_2)
+-1 InvestmentFlowBlock_old_exo(storage_Bus1_2)
+= 0
 
 c_u_InvestmentFlowBlock_max(Source_Bus1_0_0)_:
 +1 flow(Source_Bus1_0_0)
@@ -428,6 +368,66 @@ c_u_InvestmentFlowBlock_max(Bus1_storage_2_4)_:
 c_u_InvestmentFlowBlock_max(Bus1_storage_2_5)_:
 +1 flow(Bus1_storage_2_5)
 -1 InvestmentFlowBlock_total(Bus1_storage_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_0_0)_:
++1 flow(Bus1_Sink_0_0)
+-1 InvestmentFlowBlock_total(Bus1_Sink_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_0_1)_:
++1 flow(Bus1_Sink_0_1)
+-1 InvestmentFlowBlock_total(Bus1_Sink_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_1_2)_:
++1 flow(Bus1_Sink_1_2)
+-1 InvestmentFlowBlock_total(Bus1_Sink_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_1_3)_:
++1 flow(Bus1_Sink_1_3)
+-1 InvestmentFlowBlock_total(Bus1_Sink_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_2_4)_:
++1 flow(Bus1_Sink_2_4)
+-1 InvestmentFlowBlock_total(Bus1_Sink_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_Sink_2_5)_:
++1 flow(Bus1_Sink_2_5)
+-1 InvestmentFlowBlock_total(Bus1_Sink_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_0_0)_:
++1 flow(storage_Bus1_0_0)
+-1 InvestmentFlowBlock_total(storage_Bus1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_0_1)_:
++1 flow(storage_Bus1_0_1)
+-1 InvestmentFlowBlock_total(storage_Bus1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_1_2)_:
++1 flow(storage_Bus1_1_2)
+-1 InvestmentFlowBlock_total(storage_Bus1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_1_3)_:
++1 flow(storage_Bus1_1_3)
+-1 InvestmentFlowBlock_total(storage_Bus1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_2_4)_:
++1 flow(storage_Bus1_2_4)
+-1 InvestmentFlowBlock_total(storage_Bus1_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_Bus1_2_5)_:
++1 flow(storage_Bus1_2_5)
+-1 InvestmentFlowBlock_total(storage_Bus1_2)
 <= 0
 
 c_e_GenericInvestmentStorageBlock_total_storage_rule(storage_0)_:
@@ -491,11 +491,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage_0_1)_:
 +1 flow(storage_Bus1_0_1)
 -1 flow(Bus1_storage_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_1_2)_:
@@ -587,52 +591,39 @@ c_u_GenericInvestmentStorageBlock_max_storage_content(storage_2_5)_:
 <= 0
 
 bounds
-   0 <= InvestmentFlowBlock_invest(Bus1_Sink_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(Bus1_Sink_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(Bus1_Sink_2) <= +inf
    0 <= InvestmentFlowBlock_invest(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_invest(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_invest(Source_Bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_Sink_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_Sink_2) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= +inf
-   0 <= flow(Source_Bus1_0_0) <= +inf
    0 <= flow(storage_Bus1_0_0) <= +inf
+   0 <= flow(Source_Bus1_0_0) <= +inf
    0 <= flow(Bus1_storage_0_0) <= +inf
    0 <= flow(Bus1_Sink_0_0) <= +inf
-   0 <= flow(Source_Bus1_0_1) <= +inf
    0 <= flow(storage_Bus1_0_1) <= +inf
+   0 <= flow(Source_Bus1_0_1) <= +inf
    0 <= flow(Bus1_storage_0_1) <= +inf
    0 <= flow(Bus1_Sink_0_1) <= +inf
-   0 <= flow(Source_Bus1_1_2) <= +inf
    0 <= flow(storage_Bus1_1_2) <= +inf
+   0 <= flow(Source_Bus1_1_2) <= +inf
    0 <= flow(Bus1_storage_1_2) <= +inf
    0 <= flow(Bus1_Sink_1_2) <= +inf
-   0 <= flow(Source_Bus1_1_3) <= +inf
    0 <= flow(storage_Bus1_1_3) <= +inf
+   0 <= flow(Source_Bus1_1_3) <= +inf
    0 <= flow(Bus1_storage_1_3) <= +inf
    0 <= flow(Bus1_Sink_1_3) <= +inf
-   0 <= flow(Source_Bus1_2_4) <= +inf
    0 <= flow(storage_Bus1_2_4) <= +inf
+   0 <= flow(Source_Bus1_2_4) <= +inf
    0 <= flow(Bus1_storage_2_4) <= +inf
    0 <= flow(Bus1_Sink_2_4) <= +inf
-   0 <= flow(Source_Bus1_2_5) <= +inf
    0 <= flow(storage_Bus1_2_5) <= +inf
+   0 <= flow(Source_Bus1_2_5) <= +inf
    0 <= flow(Bus1_storage_2_5) <= +inf
    0 <= flow(Bus1_Sink_2_5) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_Bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_Bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_Bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_Bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_Bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_Sink_0) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_Sink_1) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_Sink_1) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_Sink_2) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_Sink_2) <= +inf
    0 <= InvestmentFlowBlock_total(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_total(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old(Source_Bus1_1) <= +inf
@@ -646,34 +637,47 @@ bounds
    0 <= InvestmentFlowBlock_total(Bus1_storage_2) <= +inf
    0 <= InvestmentFlowBlock_invest(Bus1_storage_2) <= +inf
    0 <= InvestmentFlowBlock_old(Bus1_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_Bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_Bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_Sink_1) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_Sink_1) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_Bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_Bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_Bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_Bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_Bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_Bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_Bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(Bus1_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(Bus1_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(Bus1_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_Bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_Bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Bus1_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Bus1_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Bus1_storage_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_Bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_Sink_2) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old(Bus1_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_Sink_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_Bus1_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf
@@ -686,8 +690,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_4) <= +inf

--- a/tests/lp_files/periodical_investment_limit.lp
+++ b/tests/lp_files/periodical_investment_limit.lp
@@ -27,58 +27,39 @@ c_u_investment_limit_per_period(2)_:
 <= 300
 
 c_e_BusBlock_balance(Bus1_0_0)_:
-+1 flow(Source_Bus1_0_0)
 +1 flow(storage_invest_limit_Bus1_0_0)
++1 flow(Source_Bus1_0_0)
 -1 flow(Bus1_storage_invest_limit_0_0)
 = 0
 
 c_e_BusBlock_balance(Bus1_0_1)_:
-+1 flow(Source_Bus1_0_1)
 +1 flow(storage_invest_limit_Bus1_0_1)
++1 flow(Source_Bus1_0_1)
 -1 flow(Bus1_storage_invest_limit_0_1)
 = 0
 
 c_e_BusBlock_balance(Bus1_1_2)_:
-+1 flow(Source_Bus1_1_2)
 +1 flow(storage_invest_limit_Bus1_1_2)
++1 flow(Source_Bus1_1_2)
 -1 flow(Bus1_storage_invest_limit_1_2)
 = 0
 
 c_e_BusBlock_balance(Bus1_1_3)_:
-+1 flow(Source_Bus1_1_3)
 +1 flow(storage_invest_limit_Bus1_1_3)
++1 flow(Source_Bus1_1_3)
 -1 flow(Bus1_storage_invest_limit_1_3)
 = 0
 
 c_e_BusBlock_balance(Bus1_2_4)_:
-+1 flow(Source_Bus1_2_4)
 +1 flow(storage_invest_limit_Bus1_2_4)
++1 flow(Source_Bus1_2_4)
 -1 flow(Bus1_storage_invest_limit_2_4)
 = 0
 
 c_e_BusBlock_balance(Bus1_2_5)_:
-+1 flow(Source_Bus1_2_5)
 +1 flow(storage_invest_limit_Bus1_2_5)
++1 flow(Source_Bus1_2_5)
 -1 flow(Bus1_storage_invest_limit_2_5)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_0)_:
-+1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
--1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_0)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_1)_:
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
-+1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
--1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_1)
-+1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_2)_:
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
-+1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
--1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_2)
-+1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_2)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(storage_invest_limit_Bus1_0)_:
@@ -119,16 +100,23 @@ c_e_InvestmentFlowBlock_total_rule(Source_Bus1_2)_:
 +1 InvestmentFlowBlock_old(Source_Bus1_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_0)_:
-+1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0)
+c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_0)_:
++1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
+-1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_1)_:
-+1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1)
+c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_1)_:
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
++1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
+-1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_1)
++1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_2)_:
-+1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2)
+c_e_InvestmentFlowBlock_total_rule(Bus1_storage_invest_limit_2)_:
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
++1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
+-1 InvestmentFlowBlock_invest(Bus1_storage_invest_limit_2)
++1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(storage_invest_limit_Bus1_0)_:
@@ -155,16 +143,16 @@ c_e_InvestmentFlowBlock_old_rule_end(Source_Bus1_2)_:
 +1 InvestmentFlowBlock_old_end(Source_Bus1_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_0)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_0)_:
++1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_1)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_1)_:
++1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_2)_:
-+1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2)
+c_e_InvestmentFlowBlock_old_rule_end(Bus1_storage_invest_limit_2)_:
++1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(storage_invest_limit_Bus1_0)_:
@@ -191,22 +179,16 @@ c_e_InvestmentFlowBlock_old_rule_exo(Source_Bus1_2)_:
 +1 InvestmentFlowBlock_old_exo(Source_Bus1_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_0)_:
--1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0)
--1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0)
-+1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_0)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_0)_:
++1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_1)_:
-+1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_1)
--1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1)
--1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_1)_:
++1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_2)_:
-+1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_2)
--1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2)
--1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2)
+c_e_InvestmentFlowBlock_old_rule_exo(Bus1_storage_invest_limit_2)_:
++1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(storage_invest_limit_Bus1_0)_:
@@ -245,35 +227,23 @@ c_e_InvestmentFlowBlock_old_rule(Source_Bus1_2)_:
 -1 InvestmentFlowBlock_old_exo(Source_Bus1_2)
 = 0
 
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_0_0)_:
-+1 flow(Bus1_storage_invest_limit_0_0)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_0)_:
+-1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0)
+-1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0)
++1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_0_1)_:
-+1 flow(Bus1_storage_invest_limit_0_1)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_1)_:
++1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_1)
+-1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1)
+-1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_1_2)_:
-+1 flow(Bus1_storage_invest_limit_1_2)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_1_3)_:
-+1 flow(Bus1_storage_invest_limit_1_3)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_2_4)_:
-+1 flow(Bus1_storage_invest_limit_2_4)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_2_5)_:
-+1 flow(Bus1_storage_invest_limit_2_5)
--1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(Bus1_storage_invest_limit_2)_:
++1 InvestmentFlowBlock_old(Bus1_storage_invest_limit_2)
+-1 InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2)
+-1 InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2)
+= 0
 
 c_u_InvestmentFlowBlock_max(storage_invest_limit_Bus1_0_0)_:
 +1 flow(storage_invest_limit_Bus1_0_0)
@@ -333,6 +303,36 @@ c_u_InvestmentFlowBlock_max(Source_Bus1_2_4)_:
 c_u_InvestmentFlowBlock_max(Source_Bus1_2_5)_:
 +1 flow(Source_Bus1_2_5)
 -1 InvestmentFlowBlock_total(Source_Bus1_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_0_0)_:
++1 flow(Bus1_storage_invest_limit_0_0)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_0_1)_:
++1 flow(Bus1_storage_invest_limit_0_1)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_1_2)_:
++1 flow(Bus1_storage_invest_limit_1_2)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_1_3)_:
++1 flow(Bus1_storage_invest_limit_1_3)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_2_4)_:
++1 flow(Bus1_storage_invest_limit_2_4)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(Bus1_storage_invest_limit_2_5)_:
++1 flow(Bus1_storage_invest_limit_2_5)
+-1 InvestmentFlowBlock_total(Bus1_storage_invest_limit_2)
 <= 0
 
 c_e_GenericInvestmentStorageBlock_total_storage_rule(storage_invest_limit_0)_:
@@ -396,11 +396,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage_invest_limit_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage_invest_limit_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage_invest_limit_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage_invest_limit_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage_invest_limit_0_1)_:
 +1 flow(storage_invest_limit_Bus1_0_1)
 -1 flow(Bus1_storage_invest_limit_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_invest_limit_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_invest_limit_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_invest_limit_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_invest_limit_1_2)_:
@@ -498,32 +502,24 @@ bounds
    0 <= GenericInvestmentStorageBlock_invest(storage_invest_limit_0) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_invest_limit_1) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_invest_limit_2) <= +inf
-   0 <= flow(Source_Bus1_0_0) <= +inf
    0 <= flow(storage_invest_limit_Bus1_0_0) <= +inf
+   0 <= flow(Source_Bus1_0_0) <= +inf
    0 <= flow(Bus1_storage_invest_limit_0_0) <= +inf
-   0 <= flow(Source_Bus1_0_1) <= +inf
    0 <= flow(storage_invest_limit_Bus1_0_1) <= +inf
+   0 <= flow(Source_Bus1_0_1) <= +inf
    0 <= flow(Bus1_storage_invest_limit_0_1) <= +inf
-   0 <= flow(Source_Bus1_1_2) <= +inf
    0 <= flow(storage_invest_limit_Bus1_1_2) <= +inf
+   0 <= flow(Source_Bus1_1_2) <= +inf
    0 <= flow(Bus1_storage_invest_limit_1_2) <= +inf
-   0 <= flow(Source_Bus1_1_3) <= +inf
    0 <= flow(storage_invest_limit_Bus1_1_3) <= +inf
+   0 <= flow(Source_Bus1_1_3) <= +inf
    0 <= flow(Bus1_storage_invest_limit_1_3) <= +inf
-   0 <= flow(Source_Bus1_2_4) <= +inf
    0 <= flow(storage_invest_limit_Bus1_2_4) <= +inf
+   0 <= flow(Source_Bus1_2_4) <= +inf
    0 <= flow(Bus1_storage_invest_limit_2_4) <= +inf
-   0 <= flow(Source_Bus1_2_5) <= +inf
    0 <= flow(storage_invest_limit_Bus1_2_5) <= +inf
+   0 <= flow(Source_Bus1_2_5) <= +inf
    0 <= flow(Bus1_storage_invest_limit_2_5) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_0) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_1) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_1) <= +inf
-   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_2) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage_invest_limit_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_invest(storage_invest_limit_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage_invest_limit_Bus1_1) <= +inf
@@ -537,27 +533,35 @@ bounds
    0 <= InvestmentFlowBlock_old(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_total(Source_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old(Source_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_0) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_1) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_1) <= +inf
+   0 <= InvestmentFlowBlock_total(Bus1_storage_invest_limit_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(Bus1_storage_invest_limit_2) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(storage_invest_limit_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(storage_invest_limit_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(storage_invest_limit_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(Source_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(Bus1_storage_invest_limit_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_invest_limit_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_invest_limit_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(storage_invest_limit_Bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(Source_Bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(Bus1_storage_invest_limit_2) <= +inf
    0 <= InvestmentFlowBlock_old(storage_invest_limit_Bus1_0) <= +inf
    0 <= InvestmentFlowBlock_old(Source_Bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old(Bus1_storage_invest_limit_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_invest_limit_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_invest_limit_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_invest_limit_1) <= +inf
@@ -570,8 +574,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_invest_limit_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_invest_limit_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_invest_limit_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_invest_limit_4) <= +inf

--- a/tests/lp_files/storage_invest_1_multi_period.lp
+++ b/tests/lp_files/storage_invest_1_multi_period.lp
@@ -293,11 +293,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage1_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage1_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage1_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage1_0_1)_:
 -0.97 flow(electricityBus_storage1_0_1)
 +1.1627906976744187 flow(storage1_electricityBus_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 -0.87 GenericInvestmentStorageBlock_storage_content(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage1_1_2)_:
@@ -492,8 +496,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage1_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_4) <= +inf

--- a/tests/lp_files/storage_invest_2_multi_period.lp
+++ b/tests/lp_files/storage_invest_2_multi_period.lp
@@ -287,11 +287,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage2_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage2_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage2_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage2_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage2_0_1)_:
 +1 flow(storage2_electricityBus_0_1)
 -1 flow(electricityBus_storage2_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage2_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage2_0)
++1 GenericInvestmentStorageBlock_storage_content(storage2_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage2_1_2)_:
@@ -410,8 +414,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage2_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage2_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage2_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage2_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage2_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage2_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage2_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage2_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage2_4) <= +inf

--- a/tests/lp_files/storage_invest_3_multi_period.lp
+++ b/tests/lp_files/storage_invest_3_multi_period.lp
@@ -2,12 +2,12 @@
 
 min 
 objective:
-+11.00820926255226 InvestmentFlowBlock_invest(storage3_electricityBus_0)
-+10.792362022110058 InvestmentFlowBlock_invest(storage3_electricityBus_1)
-+10.580747080500057 InvestmentFlowBlock_invest(storage3_electricityBus_2)
 +101.97980198019803 InvestmentFlowBlock_invest(electricityBus_storage3_0)
 +99.98019801980199 InvestmentFlowBlock_invest(electricityBus_storage3_1)
 +98.01980198019803 InvestmentFlowBlock_invest(electricityBus_storage3_2)
++11.00820926255226 InvestmentFlowBlock_invest(storage3_electricityBus_0)
++10.792362022110058 InvestmentFlowBlock_invest(storage3_electricityBus_1)
++10.580747080500057 InvestmentFlowBlock_invest(storage3_electricityBus_2)
 
 s.t.
 
@@ -41,25 +41,6 @@ c_e_BusBlock_balance(electricityBus_2_5)_:
 -1 flow(electricityBus_storage3_2_5)
 = 0
 
-c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_0)_:
--1 InvestmentFlowBlock_invest(storage3_electricityBus_0)
-+1 InvestmentFlowBlock_total(storage3_electricityBus_0)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_1)_:
--1 InvestmentFlowBlock_invest(storage3_electricityBus_1)
--1 InvestmentFlowBlock_total(storage3_electricityBus_0)
-+1 InvestmentFlowBlock_total(storage3_electricityBus_1)
-+1 InvestmentFlowBlock_old(storage3_electricityBus_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_2)_:
--1 InvestmentFlowBlock_invest(storage3_electricityBus_2)
--1 InvestmentFlowBlock_total(storage3_electricityBus_1)
-+1 InvestmentFlowBlock_total(storage3_electricityBus_2)
-+1 InvestmentFlowBlock_old(storage3_electricityBus_2)
-= 0
-
 c_e_InvestmentFlowBlock_total_rule(electricityBus_storage3_0)_:
 -1 InvestmentFlowBlock_invest(electricityBus_storage3_0)
 +1 InvestmentFlowBlock_total(electricityBus_storage3_0)
@@ -79,16 +60,23 @@ c_e_InvestmentFlowBlock_total_rule(electricityBus_storage3_2)_:
 +1 InvestmentFlowBlock_old(electricityBus_storage3_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_0)_:
-+1 InvestmentFlowBlock_old_end(storage3_electricityBus_0)
+c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_0)_:
+-1 InvestmentFlowBlock_invest(storage3_electricityBus_0)
++1 InvestmentFlowBlock_total(storage3_electricityBus_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_1)_:
-+1 InvestmentFlowBlock_old_end(storage3_electricityBus_1)
+c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_1)_:
+-1 InvestmentFlowBlock_invest(storage3_electricityBus_1)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_0)
++1 InvestmentFlowBlock_total(storage3_electricityBus_1)
++1 InvestmentFlowBlock_old(storage3_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_2)_:
-+1 InvestmentFlowBlock_old_end(storage3_electricityBus_2)
+c_e_InvestmentFlowBlock_total_rule(storage3_electricityBus_2)_:
+-1 InvestmentFlowBlock_invest(storage3_electricityBus_2)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_1)
++1 InvestmentFlowBlock_total(storage3_electricityBus_2)
++1 InvestmentFlowBlock_old(storage3_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage3_0)_:
@@ -104,16 +92,16 @@ c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage3_2)_:
 +1 InvestmentFlowBlock_old_end(electricityBus_storage3_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_0)_:
-+1 InvestmentFlowBlock_old_exo(storage3_electricityBus_0)
+c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_0)_:
++1 InvestmentFlowBlock_old_end(storage3_electricityBus_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_1)_:
-+1 InvestmentFlowBlock_old_exo(storage3_electricityBus_1)
+c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_1)_:
++1 InvestmentFlowBlock_old_end(storage3_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_2)_:
-+1 InvestmentFlowBlock_old_exo(storage3_electricityBus_2)
+c_e_InvestmentFlowBlock_old_rule_end(storage3_electricityBus_2)_:
++1 InvestmentFlowBlock_old_end(storage3_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage3_0)_:
@@ -128,22 +116,16 @@ c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage3_2)_:
 +1 InvestmentFlowBlock_old_exo(electricityBus_storage3_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_0)_:
--1 InvestmentFlowBlock_old_end(storage3_electricityBus_0)
--1 InvestmentFlowBlock_old_exo(storage3_electricityBus_0)
-+1 InvestmentFlowBlock_old(storage3_electricityBus_0)
+c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_0)_:
++1 InvestmentFlowBlock_old_exo(storage3_electricityBus_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_1)_:
-+1 InvestmentFlowBlock_old(storage3_electricityBus_1)
--1 InvestmentFlowBlock_old_end(storage3_electricityBus_1)
--1 InvestmentFlowBlock_old_exo(storage3_electricityBus_1)
+c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_1)_:
++1 InvestmentFlowBlock_old_exo(storage3_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_2)_:
-+1 InvestmentFlowBlock_old(storage3_electricityBus_2)
--1 InvestmentFlowBlock_old_end(storage3_electricityBus_2)
--1 InvestmentFlowBlock_old_exo(storage3_electricityBus_2)
+c_e_InvestmentFlowBlock_old_rule_exo(storage3_electricityBus_2)_:
++1 InvestmentFlowBlock_old_exo(storage3_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(electricityBus_storage3_0)_:
@@ -164,35 +146,23 @@ c_e_InvestmentFlowBlock_old_rule(electricityBus_storage3_2)_:
 -1 InvestmentFlowBlock_old_exo(electricityBus_storage3_2)
 = 0
 
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_0_0)_:
-+1 flow(storage3_electricityBus_0_0)
--1 InvestmentFlowBlock_total(storage3_electricityBus_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_0)_:
+-1 InvestmentFlowBlock_old_end(storage3_electricityBus_0)
+-1 InvestmentFlowBlock_old_exo(storage3_electricityBus_0)
++1 InvestmentFlowBlock_old(storage3_electricityBus_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_0_1)_:
-+1 flow(storage3_electricityBus_0_1)
--1 InvestmentFlowBlock_total(storage3_electricityBus_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_1)_:
++1 InvestmentFlowBlock_old(storage3_electricityBus_1)
+-1 InvestmentFlowBlock_old_end(storage3_electricityBus_1)
+-1 InvestmentFlowBlock_old_exo(storage3_electricityBus_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_1_2)_:
-+1 flow(storage3_electricityBus_1_2)
--1 InvestmentFlowBlock_total(storage3_electricityBus_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_1_3)_:
-+1 flow(storage3_electricityBus_1_3)
--1 InvestmentFlowBlock_total(storage3_electricityBus_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_2_4)_:
-+1 flow(storage3_electricityBus_2_4)
--1 InvestmentFlowBlock_total(storage3_electricityBus_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage3_electricityBus_2_5)_:
-+1 flow(storage3_electricityBus_2_5)
--1 InvestmentFlowBlock_total(storage3_electricityBus_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage3_electricityBus_2)_:
++1 InvestmentFlowBlock_old(storage3_electricityBus_2)
+-1 InvestmentFlowBlock_old_end(storage3_electricityBus_2)
+-1 InvestmentFlowBlock_old_exo(storage3_electricityBus_2)
+= 0
 
 c_u_InvestmentFlowBlock_max(electricityBus_storage3_0_0)_:
 +1 flow(electricityBus_storage3_0_0)
@@ -222,6 +192,36 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage3_2_4)_:
 c_u_InvestmentFlowBlock_max(electricityBus_storage3_2_5)_:
 +1 flow(electricityBus_storage3_2_5)
 -1 InvestmentFlowBlock_total(electricityBus_storage3_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_0_0)_:
++1 flow(storage3_electricityBus_0_0)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_0_1)_:
++1 flow(storage3_electricityBus_0_1)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_1_2)_:
++1 flow(storage3_electricityBus_1_2)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_1_3)_:
++1 flow(storage3_electricityBus_1_3)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_2_4)_:
++1 flow(storage3_electricityBus_2_4)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage3_electricityBus_2_5)_:
++1 flow(storage3_electricityBus_2_5)
+-1 InvestmentFlowBlock_total(storage3_electricityBus_2)
 <= 0
 
 c_e_GenericStorageBlock_balance(storage3_0_0)_:
@@ -272,12 +272,12 @@ c_e_GenericStorageBlock_balanced_cstr(storage3)_:
 = 0
 
 bounds
-   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_invest(electricityBus_storage3_0) <= +inf
    0 <= InvestmentFlowBlock_invest(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_invest(electricityBus_storage3_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage3_electricityBus_2) <= +inf
    0 <= flow(storage3_electricityBus_0_0) <= +inf
    0 <= flow(electricityBus_storage3_0_0) <= +inf
    0 <= flow(storage3_electricityBus_0_1) <= +inf
@@ -290,30 +290,30 @@ bounds
    0 <= flow(electricityBus_storage3_2_4) <= +inf
    0 <= flow(storage3_electricityBus_2_5) <= +inf
    0 <= flow(electricityBus_storage3_2_5) <= +inf
-   0 <= InvestmentFlowBlock_total(storage3_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_total(storage3_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage3_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_total(storage3_electricityBus_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_total(electricityBus_storage3_0) <= +inf
    0 <= InvestmentFlowBlock_total(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_old(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_total(electricityBus_storage3_2) <= +inf
    0 <= InvestmentFlowBlock_old(electricityBus_storage3_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_total(storage3_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_total(storage3_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage3_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_total(storage3_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage3_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage3_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage3_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old(electricityBus_storage3_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage3_electricityBus_0) <= +inf
    0 <= GenericStorageBlock_storage_content(storage3_1) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_0) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_2) <= 5000

--- a/tests/lp_files/storage_invest_4_multi_period.lp
+++ b/tests/lp_files/storage_invest_4_multi_period.lp
@@ -100,11 +100,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage4_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage4_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage4_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage4_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage4_0_1)_:
 +1 flow(storage4_electricityBus_0_1)
 -1 flow(electricityBus_storage4_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage4_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage4_0)
++1 GenericInvestmentStorageBlock_storage_content(storage4_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage4_1_2)_:
@@ -193,8 +197,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage4_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage4_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage4_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage4_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage4_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage4_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage4_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage4_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage4_4) <= +inf

--- a/tests/lp_files/storage_invest_5_multi_period.lp
+++ b/tests/lp_files/storage_invest_5_multi_period.lp
@@ -38,25 +38,6 @@ c_e_BusBlock_balance(electricityBus_2_5)_:
 -1 flow(electricityBus_storage5_2_5)
 = 0
 
-c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_0)_:
-+1 InvestmentFlowBlock_total(storage5_electricityBus_0)
--1 InvestmentFlowBlock_invest(storage5_electricityBus_0)
-= 100
-
-c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_1)_:
--1 InvestmentFlowBlock_total(storage5_electricityBus_0)
-+1 InvestmentFlowBlock_total(storage5_electricityBus_1)
--1 InvestmentFlowBlock_invest(storage5_electricityBus_1)
-+1 InvestmentFlowBlock_old(storage5_electricityBus_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_2)_:
--1 InvestmentFlowBlock_total(storage5_electricityBus_1)
-+1 InvestmentFlowBlock_total(storage5_electricityBus_2)
--1 InvestmentFlowBlock_invest(storage5_electricityBus_2)
-+1 InvestmentFlowBlock_old(storage5_electricityBus_2)
-= 0
-
 c_e_InvestmentFlowBlock_total_rule(electricityBus_storage5_0)_:
 -1 InvestmentFlowBlock_invest(electricityBus_storage5_0)
 +1 InvestmentFlowBlock_total(electricityBus_storage5_0)
@@ -76,16 +57,23 @@ c_e_InvestmentFlowBlock_total_rule(electricityBus_storage5_2)_:
 +1 InvestmentFlowBlock_old(electricityBus_storage5_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_0)_:
-+1 InvestmentFlowBlock_old_end(storage5_electricityBus_0)
+c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_0)_:
++1 InvestmentFlowBlock_total(storage5_electricityBus_0)
+-1 InvestmentFlowBlock_invest(storage5_electricityBus_0)
+= 100
+
+c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_1)_:
+-1 InvestmentFlowBlock_total(storage5_electricityBus_0)
++1 InvestmentFlowBlock_total(storage5_electricityBus_1)
+-1 InvestmentFlowBlock_invest(storage5_electricityBus_1)
++1 InvestmentFlowBlock_old(storage5_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_1)_:
-+1 InvestmentFlowBlock_old_end(storage5_electricityBus_1)
-= 0
-
-c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_2)_:
-+1 InvestmentFlowBlock_old_end(storage5_electricityBus_2)
+c_e_InvestmentFlowBlock_total_rule(storage5_electricityBus_2)_:
+-1 InvestmentFlowBlock_total(storage5_electricityBus_1)
++1 InvestmentFlowBlock_total(storage5_electricityBus_2)
+-1 InvestmentFlowBlock_invest(storage5_electricityBus_2)
++1 InvestmentFlowBlock_old(storage5_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage5_0)_:
@@ -100,16 +88,16 @@ c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage5_2)_:
 +1 InvestmentFlowBlock_old_end(electricityBus_storage5_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_0)_:
-+1 InvestmentFlowBlock_old_exo(storage5_electricityBus_0)
+c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_0)_:
++1 InvestmentFlowBlock_old_end(storage5_electricityBus_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_1)_:
-+1 InvestmentFlowBlock_old_exo(storage5_electricityBus_1)
+c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_1)_:
++1 InvestmentFlowBlock_old_end(storage5_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_2)_:
-+1 InvestmentFlowBlock_old_exo(storage5_electricityBus_2)
+c_e_InvestmentFlowBlock_old_rule_end(storage5_electricityBus_2)_:
++1 InvestmentFlowBlock_old_end(storage5_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage5_0)_:
@@ -124,22 +112,16 @@ c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage5_2)_:
 +1 InvestmentFlowBlock_old_exo(electricityBus_storage5_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_0)_:
--1 InvestmentFlowBlock_old_end(storage5_electricityBus_0)
--1 InvestmentFlowBlock_old_exo(storage5_electricityBus_0)
-+1 InvestmentFlowBlock_old(storage5_electricityBus_0)
+c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_0)_:
++1 InvestmentFlowBlock_old_exo(storage5_electricityBus_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_1)_:
-+1 InvestmentFlowBlock_old(storage5_electricityBus_1)
--1 InvestmentFlowBlock_old_end(storage5_electricityBus_1)
--1 InvestmentFlowBlock_old_exo(storage5_electricityBus_1)
+c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_1)_:
++1 InvestmentFlowBlock_old_exo(storage5_electricityBus_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_2)_:
-+1 InvestmentFlowBlock_old(storage5_electricityBus_2)
--1 InvestmentFlowBlock_old_end(storage5_electricityBus_2)
--1 InvestmentFlowBlock_old_exo(storage5_electricityBus_2)
+c_e_InvestmentFlowBlock_old_rule_exo(storage5_electricityBus_2)_:
++1 InvestmentFlowBlock_old_exo(storage5_electricityBus_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(electricityBus_storage5_0)_:
@@ -160,35 +142,23 @@ c_e_InvestmentFlowBlock_old_rule(electricityBus_storage5_2)_:
 -1 InvestmentFlowBlock_old_exo(electricityBus_storage5_2)
 = 0
 
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_0_0)_:
-+1 flow(storage5_electricityBus_0_0)
--1 InvestmentFlowBlock_total(storage5_electricityBus_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_0)_:
+-1 InvestmentFlowBlock_old_end(storage5_electricityBus_0)
+-1 InvestmentFlowBlock_old_exo(storage5_electricityBus_0)
++1 InvestmentFlowBlock_old(storage5_electricityBus_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_0_1)_:
-+1 flow(storage5_electricityBus_0_1)
--1 InvestmentFlowBlock_total(storage5_electricityBus_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_1)_:
++1 InvestmentFlowBlock_old(storage5_electricityBus_1)
+-1 InvestmentFlowBlock_old_end(storage5_electricityBus_1)
+-1 InvestmentFlowBlock_old_exo(storage5_electricityBus_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_1_2)_:
-+1 flow(storage5_electricityBus_1_2)
--1 InvestmentFlowBlock_total(storage5_electricityBus_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_1_3)_:
-+1 flow(storage5_electricityBus_1_3)
--1 InvestmentFlowBlock_total(storage5_electricityBus_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_2_4)_:
-+1 flow(storage5_electricityBus_2_4)
--1 InvestmentFlowBlock_total(storage5_electricityBus_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage5_electricityBus_2_5)_:
-+1 flow(storage5_electricityBus_2_5)
--1 InvestmentFlowBlock_total(storage5_electricityBus_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage5_electricityBus_2)_:
++1 InvestmentFlowBlock_old(storage5_electricityBus_2)
+-1 InvestmentFlowBlock_old_end(storage5_electricityBus_2)
+-1 InvestmentFlowBlock_old_exo(storage5_electricityBus_2)
+= 0
 
 c_u_InvestmentFlowBlock_max(electricityBus_storage5_0_0)_:
 +1 flow(electricityBus_storage5_0_0)
@@ -218,6 +188,36 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage5_2_4)_:
 c_u_InvestmentFlowBlock_max(electricityBus_storage5_2_5)_:
 +1 flow(electricityBus_storage5_2_5)
 -1 InvestmentFlowBlock_total(electricityBus_storage5_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_0_0)_:
++1 flow(storage5_electricityBus_0_0)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_0_1)_:
++1 flow(storage5_electricityBus_0_1)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_1_2)_:
++1 flow(storage5_electricityBus_1_2)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_1_3)_:
++1 flow(storage5_electricityBus_1_3)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_2_4)_:
++1 flow(storage5_electricityBus_2_4)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage5_electricityBus_2_5)_:
++1 flow(storage5_electricityBus_2_5)
+-1 InvestmentFlowBlock_total(storage5_electricityBus_2)
 <= 0
 
 c_e_GenericStorageBlock_balance(storage5_0_0)_:
@@ -268,18 +268,18 @@ c_e_GenericStorageBlock_balanced_cstr(storage5)_:
 = 0
 
 c_e_GenericStorageBlock_power_coupled(storage5_0)_:
-+1.1 InvestmentFlowBlock_total(storage5_electricityBus_0)
 -1 InvestmentFlowBlock_total(electricityBus_storage5_0)
++1.1 InvestmentFlowBlock_total(storage5_electricityBus_0)
 = 0
 
 c_e_GenericStorageBlock_power_coupled(storage5_1)_:
-+1.1 InvestmentFlowBlock_total(storage5_electricityBus_1)
 -1 InvestmentFlowBlock_total(electricityBus_storage5_1)
++1.1 InvestmentFlowBlock_total(storage5_electricityBus_1)
 = 0
 
 c_e_GenericStorageBlock_power_coupled(storage5_2)_:
-+1.1 InvestmentFlowBlock_total(storage5_electricityBus_2)
 -1 InvestmentFlowBlock_total(electricityBus_storage5_2)
++1.1 InvestmentFlowBlock_total(storage5_electricityBus_2)
 = 0
 
 bounds
@@ -298,6 +298,11 @@ bounds
    0 <= flow(electricityBus_storage5_2_4) <= +inf
    0 <= flow(storage5_electricityBus_2_5) <= +inf
    0 <= flow(electricityBus_storage5_2_5) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage5_0) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage5_1) <= +inf
+   0 <= InvestmentFlowBlock_old(electricityBus_storage5_1) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage5_2) <= +inf
+   0 <= InvestmentFlowBlock_old(electricityBus_storage5_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage5_electricityBus_0) <= +inf
    0 <= InvestmentFlowBlock_invest(storage5_electricityBus_0) <= +inf
    0 <= InvestmentFlowBlock_total(storage5_electricityBus_1) <= +inf
@@ -306,25 +311,20 @@ bounds
    0 <= InvestmentFlowBlock_total(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_invest(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old(storage5_electricityBus_2) <= +inf
-   0 <= InvestmentFlowBlock_total(electricityBus_storage5_0) <= +inf
-   0 <= InvestmentFlowBlock_total(electricityBus_storage5_1) <= +inf
-   0 <= InvestmentFlowBlock_old(electricityBus_storage5_1) <= +inf
-   0 <= InvestmentFlowBlock_total(electricityBus_storage5_2) <= +inf
-   0 <= InvestmentFlowBlock_old(electricityBus_storage5_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage5_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage5_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricityBus_storage5_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage5_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_old(electricityBus_storage5_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage5_electricityBus_0) <= +inf
    0 <= GenericStorageBlock_storage_content(storage5_1) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_0) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_2) <= 10000

--- a/tests/lp_files/storage_invest_6_multi_period.lp
+++ b/tests/lp_files/storage_invest_6_multi_period.lp
@@ -284,11 +284,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage6_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage6_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage6_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage6_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage6_0_1)_:
 +1 flow(storage6_electricityBus_0_1)
 -1 flow(electricityBus_storage6_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage6_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage6_0)
++1 GenericInvestmentStorageBlock_storage_content(storage6_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage6_1_2)_:
@@ -422,8 +426,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage6_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage6_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage6_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage6_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage6_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage6_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage6_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage6_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage6_4) <= +inf

--- a/tests/lp_files/storage_invest_all_nonconvex_multi_period.lp
+++ b/tests/lp_files/storage_invest_all_nonconvex_multi_period.lp
@@ -2,18 +2,18 @@
 
 min 
 objective:
-+12.231343625058066 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
-+15 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
-+11.991513357900065 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
-+14.705882352941176 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
-+11.756385645000064 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
-+14.41753171856978 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
 +12.231343625058066 InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_0)
 +10 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_0)
 +11.991513357900065 InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_1)
 +9.80392156862745 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_1)
 +11.756385645000064 InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_2)
 +9.611687812379854 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_2)
++12.231343625058066 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
++15 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
++11.991513357900065 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
++14.705882352941176 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
++11.756385645000064 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
++14.41753171856978 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
 +24.462687250116133 GenericInvestmentStorageBlock_invest(storage_all_nonconvex_0)
 +30 GenericInvestmentStorageBlock_invest_status(storage_all_nonconvex_0)
 +23.98302671580013 GenericInvestmentStorageBlock_invest(storage_all_nonconvex_1)
@@ -53,21 +53,6 @@ c_e_BusBlock_balance(bus1_2_5)_:
 -1 flow(bus1_storage_all_nonconvex_2_5)
 = 0
 
-c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_0)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
-+8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
-<= 0
-
-c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_1)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
-+8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
-<= 0
-
-c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_2)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
-+8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
-<= 0
-
 c_u_InvestmentFlowBlock_minimum_rule(bus1_storage_all_nonconvex_0)_:
 -1 InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_0)
 +5 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_0)
@@ -83,19 +68,19 @@ c_u_InvestmentFlowBlock_minimum_rule(bus1_storage_all_nonconvex_2)_:
 +5 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_2)
 <= 0
 
-c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_0)_:
-+1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
--20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
+c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_0)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
++8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
 <= 0
 
-c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_1)_:
-+1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
--20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
+c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_1)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
++8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
 <= 0
 
-c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_2)_:
-+1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
--20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
+c_u_InvestmentFlowBlock_minimum_rule(storage_all_nonconvex_bus1_2)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
++8 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
 <= 0
 
 c_u_InvestmentFlowBlock_maximum_rule(bus1_storage_all_nonconvex_0)_:
@@ -113,24 +98,20 @@ c_u_InvestmentFlowBlock_maximum_rule(bus1_storage_all_nonconvex_2)_:
 -30 InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_2)
 <= 0
 
-c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_0)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
-+1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
-= 0
+c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_0)_:
++1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
+-20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
+<= 0
 
-c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_1)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
-+1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
-+1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1)
-= 0
+c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_1)_:
++1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
+-20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
+<= 0
 
-c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_2)_:
--1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
-+1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
-+1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2)
-= 0
+c_u_InvestmentFlowBlock_maximum_rule(storage_all_nonconvex_bus1_2)_:
++1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
+-20 InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
+<= 0
 
 c_e_InvestmentFlowBlock_total_rule(bus1_storage_all_nonconvex_0)_:
 -1 InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_0)
@@ -151,16 +132,23 @@ c_e_InvestmentFlowBlock_total_rule(bus1_storage_all_nonconvex_2)_:
 +1 InvestmentFlowBlock_old(bus1_storage_all_nonconvex_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_0)_:
-+1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0)
+c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_0)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0)
++1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_1)_:
-+1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1)
+c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_1)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
++1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
++1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_2)_:
-+1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2)
+c_e_InvestmentFlowBlock_total_rule(storage_all_nonconvex_bus1_2)_:
+-1 InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
++1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
++1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(bus1_storage_all_nonconvex_0)_:
@@ -175,16 +163,16 @@ c_e_InvestmentFlowBlock_old_rule_end(bus1_storage_all_nonconvex_2)_:
 +1 InvestmentFlowBlock_old_end(bus1_storage_all_nonconvex_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_0)_:
-+1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0)
+c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_0)_:
++1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_1)_:
-+1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1)
+c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_1)_:
++1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_2)_:
-+1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2)
+c_e_InvestmentFlowBlock_old_rule_end(storage_all_nonconvex_bus1_2)_:
++1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(bus1_storage_all_nonconvex_0)_:
@@ -199,22 +187,16 @@ c_e_InvestmentFlowBlock_old_rule_exo(bus1_storage_all_nonconvex_2)_:
 +1 InvestmentFlowBlock_old_exo(bus1_storage_all_nonconvex_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_0)_:
--1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0)
--1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0)
-+1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_0)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_0)_:
++1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_1)_:
-+1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1)
--1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1)
--1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_1)_:
++1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_2)_:
-+1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2)
--1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2)
--1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_all_nonconvex_bus1_2)_:
++1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(bus1_storage_all_nonconvex_0)_:
@@ -235,35 +217,23 @@ c_e_InvestmentFlowBlock_old_rule(bus1_storage_all_nonconvex_2)_:
 -1 InvestmentFlowBlock_old_exo(bus1_storage_all_nonconvex_2)
 = 0
 
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_0_0)_:
-+1 flow(storage_all_nonconvex_bus1_0_0)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_0)_:
+-1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0)
+-1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0)
++1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_0_1)_:
-+1 flow(storage_all_nonconvex_bus1_0_1)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_1)_:
++1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1)
+-1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1)
+-1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_1_2)_:
-+1 flow(storage_all_nonconvex_bus1_1_2)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_1_3)_:
-+1 flow(storage_all_nonconvex_bus1_1_3)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_2_4)_:
-+1 flow(storage_all_nonconvex_bus1_2_4)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_2_5)_:
-+1 flow(storage_all_nonconvex_bus1_2_5)
--1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_all_nonconvex_bus1_2)_:
++1 InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2)
+-1 InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2)
+-1 InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2)
+= 0
 
 c_u_InvestmentFlowBlock_max(bus1_storage_all_nonconvex_0_0)_:
 +1 flow(bus1_storage_all_nonconvex_0_0)
@@ -293,6 +263,36 @@ c_u_InvestmentFlowBlock_max(bus1_storage_all_nonconvex_2_4)_:
 c_u_InvestmentFlowBlock_max(bus1_storage_all_nonconvex_2_5)_:
 +1 flow(bus1_storage_all_nonconvex_2_5)
 -1 InvestmentFlowBlock_total(bus1_storage_all_nonconvex_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_0_0)_:
++1 flow(storage_all_nonconvex_bus1_0_0)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_0_1)_:
++1 flow(storage_all_nonconvex_bus1_0_1)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_1_2)_:
++1 flow(storage_all_nonconvex_bus1_1_2)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_1_3)_:
++1 flow(storage_all_nonconvex_bus1_1_3)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_2_4)_:
++1 flow(storage_all_nonconvex_bus1_2_4)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_all_nonconvex_bus1_2_5)_:
++1 flow(storage_all_nonconvex_bus1_2_5)
+-1 InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2)
 <= 0
 
 c_e_GenericInvestmentStorageBlock_total_storage_rule(storage_all_nonconvex_0)_:
@@ -356,11 +356,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage_all_nonconvex_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage_all_nonconvex_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage_all_nonconvex_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage_all_nonconvex_0_1)_:
 +1 flow(storage_all_nonconvex_bus1_0_1)
 -1 flow(bus1_storage_all_nonconvex_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_all_nonconvex_1_2)_:
@@ -452,18 +456,18 @@ c_l_GenericInvestmentStorageBlock_limit_min(storage_all_nonconvex_2)_:
 >= 0
 
 bounds
-   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0) <= 20
-   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0) <= 1
-   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1) <= 20
-   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1) <= 1
-   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2) <= 20
-   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2) <= 1
    0 <= InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_0) <= 30
    0 <= InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_0) <= 1
    0 <= InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_1) <= 30
    0 <= InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_1) <= 1
    0 <= InvestmentFlowBlock_invest(bus1_storage_all_nonconvex_2) <= 30
    0 <= InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_2) <= 1
+   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_0) <= 20
+   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0) <= 1
+   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_1) <= 20
+   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1) <= 1
+   0 <= InvestmentFlowBlock_invest(storage_all_nonconvex_bus1_2) <= 20
+   0 <= InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2) <= 1
    0 <= GenericInvestmentStorageBlock_invest(storage_all_nonconvex_0) <= 100
    0 <= GenericInvestmentStorageBlock_invest_status(storage_all_nonconvex_0) <= 1
    0 <= GenericInvestmentStorageBlock_invest(storage_all_nonconvex_1) <= 100
@@ -482,30 +486,30 @@ bounds
    0 <= flow(bus1_storage_all_nonconvex_2_4) <= +inf
    0 <= flow(storage_all_nonconvex_bus1_2_5) <= +inf
    0 <= flow(bus1_storage_all_nonconvex_2_5) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2) <= +inf
    0 <= InvestmentFlowBlock_total(bus1_storage_all_nonconvex_0) <= +inf
    0 <= InvestmentFlowBlock_total(bus1_storage_all_nonconvex_1) <= +inf
    0 <= InvestmentFlowBlock_old(bus1_storage_all_nonconvex_1) <= +inf
    0 <= InvestmentFlowBlock_total(bus1_storage_all_nonconvex_2) <= +inf
    0 <= InvestmentFlowBlock_old(bus1_storage_all_nonconvex_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_all_nonconvex_bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus1_storage_all_nonconvex_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus1_storage_all_nonconvex_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(bus1_storage_all_nonconvex_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_all_nonconvex_bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old_exo(bus1_storage_all_nonconvex_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(bus1_storage_all_nonconvex_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(bus1_storage_all_nonconvex_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_all_nonconvex_bus1_2) <= +inf
    0 <= InvestmentFlowBlock_old(bus1_storage_all_nonconvex_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_all_nonconvex_bus1_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_all_nonconvex_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_all_nonconvex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_all_nonconvex_1) <= +inf
@@ -518,19 +522,19 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_all_nonconvex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_all_nonconvex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_all_nonconvex_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_4) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_all_nonconvex_5) <= +inf
 binary
-  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
-  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
-  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
   InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_0)
   InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_1)
   InvestmentFlowBlock_invest_status(bus1_storage_all_nonconvex_2)
+  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_0)
+  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_1)
+  InvestmentFlowBlock_invest_status(storage_all_nonconvex_bus1_2)
   GenericInvestmentStorageBlock_invest_status(storage_all_nonconvex_0)
   GenericInvestmentStorageBlock_invest_status(storage_all_nonconvex_1)
   GenericInvestmentStorageBlock_invest_status(storage_all_nonconvex_2)

--- a/tests/lp_files/storage_invest_minimum_multi_period.lp
+++ b/tests/lp_files/storage_invest_minimum_multi_period.lp
@@ -99,11 +99,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage1_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage1_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage1_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage1_0_1)_:
 +1 flow(storage1_electricityBus_0_1)
 -1 flow(electricityBus_storage1_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage1_1_2)_:
@@ -192,8 +196,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage1_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_4) <= +inf

--- a/tests/lp_files/storage_invest_multi_period.lp
+++ b/tests/lp_files/storage_invest_multi_period.lp
@@ -100,11 +100,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage1_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage1_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage1_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage1_0_1)_:
 +1 flow(storage1_electricityBus_0_1)
 -1 flow(electricityBus_storage1_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 -1 GenericInvestmentStorageBlock_storage_content(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage1_1_2)_:
@@ -210,8 +214,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage1_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage1_4) <= +inf

--- a/tests/lp_files/storage_invest_with_offset_multi_period.lp
+++ b/tests/lp_files/storage_invest_with_offset_multi_period.lp
@@ -296,11 +296,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage_non_convex_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage_non_convex_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage_non_convex_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage_non_convex_0_1)_:
 -0.97 flow(electricityBus_storage_non_convex_0_1)
 +1.1627906976744187 flow(storage_non_convex_electricityBus_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_1)
 -0.87 GenericInvestmentStorageBlock_storage_content(storage_non_convex_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_non_convex_1_2)_:
@@ -512,8 +516,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_non_convex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_non_convex_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_4) <= +inf

--- a/tests/lp_files/storage_invest_without_offset_multi_period.lp
+++ b/tests/lp_files/storage_invest_without_offset_multi_period.lp
@@ -293,11 +293,15 @@ c_e_GenericInvestmentStorageBlock_old_rule(storage_non_convex_2)_:
 -1 GenericInvestmentStorageBlock_old_exo(storage_non_convex_2)
 = 0
 
+c_e_GenericInvestmentStorageBlock_initially_empty(storage_non_convex_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_0)
+= 0
+
 c_e_GenericInvestmentStorageBlock_balance(storage_non_convex_0_1)_:
 -0.97 flow(electricityBus_storage_non_convex_0_1)
 +1.1627906976744187 flow(storage_non_convex_electricityBus_0_1)
-+1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_1)
 -0.87 GenericInvestmentStorageBlock_storage_content(storage_non_convex_0)
++1 GenericInvestmentStorageBlock_storage_content(storage_non_convex_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_balance(storage_non_convex_1_2)_:
@@ -506,8 +510,8 @@ bounds
    0 <= GenericInvestmentStorageBlock_old_exo(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old_exo(storage_non_convex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_non_convex_0) <= +inf
-   0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_1) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_2) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_3) <= +inf
    0 <= GenericInvestmentStorageBlock_storage_content(storage_non_convex_4) <= +inf

--- a/tests/multi_period_constraint_tests.py
+++ b/tests/multi_period_constraint_tests.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: MIT
 
 import logging
 import re
-import warnings
 from os import path as ospath
 
 import pandas as pd

--- a/tests/multi_period_constraint_tests.py
+++ b/tests/multi_period_constraint_tests.py
@@ -385,7 +385,6 @@ class TestsMultiPeriodConstraint:
             investment=solph.Investment(
                 ep_costs=145, lifetime=20, existing=20, age=19
             ),
-            initial_storage_level=0.5,
         )
         self.energysystem.add(bel, storage)
         self.compare_lp_files("storage_invest_2_multi_period.lp")
@@ -612,7 +611,7 @@ class TestsMultiPeriodConstraint:
             self.get_om()
 
     def test_storage_invest_1_initial_storage_level(self):
-        """Test warning for initial storage level
+        """Test error for initial storage level
         with multi-period investments"""
         bel = solph.buses.Bus(label="electricityBus")
         storage = solph.components.GenericStorage(
@@ -642,14 +641,12 @@ class TestsMultiPeriodConstraint:
         self.energysystem.add(bel, storage)
         msg = (
             "For a multi-period model, initial_storage_level is"
-            " not supported.\nIt is suggested to remove that"
-            " parameter since it has no effect.\nstorage_content"
-            " will be zero, until there is some usable storage "
-            " capacity installed."
+            " not supported.\nIt needs to be removed since it"
+            " has no effect.\nstorage_content will be zero,"
+            " until there is some usable storage capacity installed."
         )
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.raises(ValueError, match=msg):
             self.get_om()
-            assert msg in str(w[1].message)
 
     def test_storage_invest_1_missing_lifetime(self):
         """Test error thrown if storage misses necessary lifetime"""

--- a/tests/test_scripts/test_solph/test_multi_period_model/test_multi_period_investment_model.py
+++ b/tests/test_scripts/test_solph/test_multi_period_model/test_multi_period_investment_model.py
@@ -242,7 +242,6 @@ def test_multi_period_investment_model(solver="cbc"):
                 )
             },
             loss_rate=0,
-            initial_storage_level=0,
             max_storage_level=1,
             min_storage_level=0,
             inflow_conversion_factor=1,


### PR DESCRIPTION
Add a constraint to force initial storage level to 0 in case of multi-period investment modelling to prevent storage from being filled without any associated costs in case of investments in the first period.
