### PR TITLE
Prepare for changes at readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,11 @@ sphinx>=1.3
 sphinx-rtd-theme
 setuptools
 matplotlib
+blinker
+dill
+numpy
+pandas >= 1.5.3
+pyomo >= 6.6.0, < 7.0
+networkx
+oemof.tools >= 0.4.2
+oemof.network >= 0.5.0a1


### PR DESCRIPTION
Starting Aughust 29th, readthedocs does not provide system-wide Python packages any more, so we need to add the dependencies explicitly.