### PR TITLE
Fix/add custom attributes link

### DIFF
--- a/docs/whatsnew/v0-5-1.rst
+++ b/docs/whatsnew/v0-5-1.rst
@@ -43,6 +43,7 @@ Bug fixes
 
 * Fixed error when calling `oemof_installation_test` as console script.
 * Corrected several typos in the docs.
+* Add missing 'custom_attributes' for the link component
 
 Testing
 #######

--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -84,6 +84,7 @@ class Link(on.Transformer):
         inputs=None,
         outputs=None,
         conversion_factors=None,
+        custom_attributes=None,
     ):
         if inputs is None:
             warn_if_missing_attribute(self, "inputs")
@@ -94,10 +95,13 @@ class Link(on.Transformer):
         if conversion_factors is None:
             warn_if_missing_attribute(self, "conversion_factors")
             conversion_factors = {}
+        if custom_attributes is None:
+            custom_attributes = {}
         super().__init__(
             label=label,
             inputs=inputs,
             outputs=outputs,
+            **custom_attributes,
         )
         self.conversion_factors = {
             k: sequence(v) for k, v in conversion_factors.items()


### PR DESCRIPTION
With this PR the Link component gets the argument `custom_attributes`.


--------------------------------------------------------------------------------------
Because I can't create an issue - here's the description:
The link component is missing the argument `custom_attributes` in its [class](https://github.com/oemof/oemof-solph/blob/dev/src/oemof/solph/components/_link.py).

I've discovered this using the link component in [oemof-tabular](https://github.com/oemof/oemof-tabular). During the postprocessing I've been losing the `type = 'link'`. Instead it was set to None. This is due to [these lines](https://github.com/oemof/oemof-tabular/blob/8d26a4891461006901fa6178d8ecb44d73c6d8f8/src/oemof/tabular/_facade.py#L85-L91) where `kwargs_unexpected` are lost if the component does not have the argument "custom_attributes".

**Local system and env info**
 -   Linux Mint 20.2
 -   Python version 3.10