### PR TITLE
Replace setup.py invocation by build

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -26,9 +26,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip setuptools setuptools_scm twine wheel
+        python -m pip install --upgrade pip setuptools setuptools_scm twine wheel build
     - name: Create packages
-      run: python setup.py sdist bdist_wheel
+      run: python -m build .
     - name: Run twine check
       run: twine check dist/*
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install -U pip
-          python -m pip install -U setuptools wheel
+          python -m pip install -U setuptools wheel build
           python -m pip install -U tox
 
       - name: Run ${{ matrix.toxenv }}

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ deps =
     isort
 skip_install = true
 commands =
-    python setup.py sdist
+    python -m build .
     twine check dist/oemof*
     check-manifest {toxinidir}
     flake8 src tests setup.py


### PR DESCRIPTION
Direct invocation of `setup.py` seems to be long deprecated (e.g. https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html), it can be replaced with the `build` package.