### PR TITLE
BUGFIX: GenericStorage investment initialization

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -217,7 +217,7 @@ class GenericStorage(network.Component):
         if isinstance(nominal_storage_capacity, numbers.Real):
             self.nominal_storage_capacity = nominal_storage_capacity
         elif isinstance(nominal_storage_capacity, Investment):
-            self.investment = investment
+            self.investment = nominal_storage_capacity
             self._invest_group = True
 
         self.initial_storage_level = initial_storage_level
@@ -235,11 +235,9 @@ class GenericStorage(network.Component):
         self.min_storage_level = solph_sequence(min_storage_level)
         self.fixed_costs = solph_sequence(fixed_costs)
         self.storage_costs = solph_sequence(storage_costs)
-        self.investment = investment
         self.invest_relation_input_output = invest_relation_input_output
         self.invest_relation_input_capacity = invest_relation_input_capacity
         self.invest_relation_output_capacity = invest_relation_output_capacity
-        self._invest_group = isinstance(self.investment, Investment)
         self.lifetime_inflow = lifetime_inflow
         self.lifetime_outflow = lifetime_outflow
 


### PR DESCRIPTION
The __init__ method was malfunctioning with the preferred way to declare investments in the attr nominal_storage_capacity. Probably due to code legacy from older versions.

The investment and nominal_storage_capacity attributes were mixed together and assigned in different parts of the initialization.

