### PR TITLE
Remove obsolete fixed costs parameter for GenericCAES initialization

### DIFF
--- a/src/oemof/solph/components/experimental/_generic_caes.py
+++ b/src/oemof/solph/components/experimental/_generic_caes.py
@@ -92,7 +92,7 @@ class GenericCAES(on.Transformer):
     ...    electrical_input={bel: solph.flows.Flow()},
     ...    fuel_input={bgas: solph.flows.Flow()},
     ...    electrical_output={bel: solph.flows.Flow()},
-    ...    params=concept, fixed_costs=0)
+    ...    params=concept)
     >>> type(caes)
     <class 'oemof.solph.components.experimental._generic_caes.GenericCAES'>
     """

--- a/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
+++ b/tests/test_scripts/test_solph/test_generic_caes/test_generic_caes.py
@@ -97,7 +97,6 @@ def test_gen_caes():
             fuel_input={bgas: Flow()},
             electrical_output={bel_sink: Flow()},
             params=concept,
-            fixed_costs=0,
         )
     )
 


### PR DESCRIPTION
Remove the obsolete `fixed_costs` parameter for instances of the `GenericCAES` which does not (resp. no longer?) support it.

Closes #994 
