### PR TITLE
Compare differences in remaining value vs. actual value

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1270,6 +1270,11 @@ Besides the `invest` variable, new variables are introduced as well. These are:
       has not yet been tested.
     * For now, both, the `timeindex` as well as the `timeincrement` of an energy system have to be defined since they
       have to be of the same length for a multi-period model.
+    * You can choose whether or not to re-evaluate assets at the end of the optimization horizon. If you set attribute
+      `use_remaining_value` of the energy system to True (defaults to False), this leads to the model evaluating the
+      different in value at the end of the optimization horizon vs. at the time the investment was made. The difference
+      in value is added to or subtracted from the respective investment costs increment, assuming assets are to be
+      liquidated / re-evaluated at the end of the optimization horizon.
     * Also please be aware, that periods correspond to years by default. You could also choose
       monthly periods, but you would need to be very careful in parameterizing your energy system and your model and also,
       this would mean monthly discounting (if applicable) as well as specifying your plants lifetimes in months.

--- a/docs/whatsnew/v0-5-2.rst
+++ b/docs/whatsnew/v0-5-2.rst
@@ -4,8 +4,13 @@ v0.5.2 (????)
 API changes
 ###########
 
+* New bool attribute `use_remaining_value` of `oemof.solph.EnergySystem`
+
 New features
 ############
+
+* Allow for evaluating differences in the remaining vs. the original value
+  for multi-period investments.
 
 Documentation
 #############

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -62,6 +62,10 @@ class EnergySystem(es.EnergySystem):
         For a standard model, periods are not (to be) declared, i.e. None.
         A list with one entry is derived, i.e. [0].
 
+    use_remaining_value : bool
+        If True, compare the remaining value of an investment to the
+        original value (only applicable for multi-period models)
+
     kwargs
     """
 
@@ -71,6 +75,7 @@ class EnergySystem(es.EnergySystem):
         timeincrement=None,
         infer_last_interval=None,
         periods=None,
+        use_remaining_value=False,
         **kwargs,
     ):
         # Doing imports at runtime is generally frowned upon, but should work
@@ -160,7 +165,8 @@ class EnergySystem(es.EnergySystem):
             timeindex=timeindex, timeincrement=timeincrement, **kwargs
         )
 
-        if periods is not None:
+        self.periods = periods
+        if self.periods is not None:
             msg = (
                 "CAUTION! You specified the 'periods' attribute for your "
                 "energy system.\n This will lead to creating "
@@ -171,11 +177,10 @@ class EnergySystem(es.EnergySystem):
                 "please report them."
             )
             warnings.warn(msg, debugging.SuspiciousUsageWarning)
-        self.periods = periods
-        if self.periods is not None:
             self._extract_periods_years()
             self._extract_periods_matrix()
             self._extract_end_year_of_optimization()
+            self.use_remaining_value = use_remaining_value
 
     def _extract_periods_years(self):
         """Map years in optimization to respective period based on time indices

--- a/src/oemof/solph/components/experimental/_sink_dsm.py
+++ b/src/oemof/solph/components/experimental/_sink_dsm.py
@@ -794,6 +794,21 @@ class SinkDSMOemofInvestmentBlock(ScalarBlock):
                 &
                 \forall p \in \mathbb{P}
 
+        In case, the remaining lifetime of a DSM unit is greater than 0 and
+        attribute `use_remaining_value` of the energy system is True,
+        the difference in value for the investment period compared to the
+        last period of the optimization horizon is accounted for
+        as an adder to the investment costs:
+
+            .. math::
+                &
+                P_{invest}(p) \cdot (A(c_{invest,var}(p), l_{r}, ir) -
+                A(c_{invest,var}(|P|), l_{r}, ir)\\
+                & \cdot \frac {1}{ANF(l_{r}, ir)} \cdot DF^{-|P|}\\
+                &\\
+                &
+                \forall p \in \textrm{PERIODS}
+
         * :attr:`fixed_costs` not None for investments
 
             .. math::
@@ -1381,7 +1396,20 @@ class SinkDSMOemofInvestmentBlock(ScalarBlock):
                         investment_costs_increment = (
                             self.invest[g, p] * annuity * present_value_factor
                         ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
-                        investment_costs += investment_costs_increment
+                        remaining_value_difference = (
+                            self._evaluate_remaining_value_difference(
+                                m,
+                                p,
+                                g,
+                                m.es.end_year_of_optimization,
+                                lifetime,
+                                interest,
+                            )
+                        )
+                        investment_costs += (
+                            investment_costs_increment
+                            + remaining_value_difference
+                        )
                         period_investment_costs[
                             p
                         ] += investment_costs_increment
@@ -1444,6 +1472,69 @@ class SinkDSMOemofInvestmentBlock(ScalarBlock):
         )
 
         return self.costs
+
+    def _evaluate_remaining_value_difference(
+        self,
+        m,
+        p,
+        g,
+        end_year_of_optimization,
+        lifetime,
+        interest,
+    ):
+        """Evaluate and return the remaining value difference of an investment
+
+        The remaining value difference in the net present values if the asset
+        was to be liquidated at the end of the optimization horizon and the
+        net present value using the original investment expenses.
+
+        Parameters
+        ----------
+        m : oemof.solph.models.Model
+            Optimization model
+
+        p : int
+            Period in which investment occurs
+
+        g : oemof.solph.components.experimental.SinkDSM
+            storage unit
+
+        end_year_of_optimization : int
+            Last year of the optimization horizon
+
+        lifetime : int
+            lifetime of investment considered
+
+        interest : float
+            Demanded interest rate for investment
+        """
+        if m.es.use_remaining_value:
+            if end_year_of_optimization - m.es.periods_years[p] < lifetime:
+                remaining_lifetime = lifetime - (
+                    end_year_of_optimization - m.es.periods_years[p]
+                )
+                remaining_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[-1],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                original_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[p],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                present_value_factor_remaining = 1 / economics.annuity(
+                    capex=1, n=remaining_lifetime, wacc=interest
+                )
+                return (
+                    self.invest[g, p]
+                    * (remaining_annuity - original_annuity)
+                    * present_value_factor_remaining
+                ) * (1 + m.discount_rate) ** (-end_year_of_optimization)
+            else:
+                return 0
+        else:
+            return 0
 
 
 class SinkDSMDIWBlock(ScalarBlock):
@@ -2223,6 +2314,21 @@ class SinkDSMDIWInvestmentBlock(ScalarBlock):
                 \frac {1}{ANF(d, ir)} \cdot DF^{-p} \\
                 &\\
                 & \quad \quad \quad \quad \forall p \in \mathbb{P}
+
+        In case, the remaining lifetime of a DSM unit is greater than 0 and
+        attribute `use_remaining_value` of the energy system is True,
+        the difference in value for the investment period compared to the
+        last period of the optimization horizon is accounted for
+        as an adder to the investment costs:
+
+            .. math::
+                &
+                P_{invest}(p) \cdot (A(c_{invest,var}(p), l_{r}, ir) -
+                A(c_{invest,var}(|P|), l_{r}, ir)\\
+                & \cdot \frac {1}{ANF(l_{r}, ir)} \cdot DF^{-|P|}\\
+                &\\
+                &
+                \forall p \in \textrm{PERIODS}
 
         * :attr:`fixed_costs` not None for investments
 
@@ -3140,7 +3246,20 @@ class SinkDSMDIWInvestmentBlock(ScalarBlock):
                         investment_costs_increment = (
                             self.invest[g, p] * annuity * present_value_factor
                         ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
-                        investment_costs += investment_costs_increment
+                        remaining_value_difference = (
+                            self._evaluate_remaining_value_difference(
+                                m,
+                                p,
+                                g,
+                                m.es.end_year_of_optimization,
+                                lifetime,
+                                interest,
+                            )
+                        )
+                        investment_costs += (
+                            investment_costs_increment
+                            + remaining_value_difference
+                        )
                         period_investment_costs[
                             p
                         ] += investment_costs_increment
@@ -3207,6 +3326,69 @@ class SinkDSMDIWInvestmentBlock(ScalarBlock):
         )
 
         return self.costs
+
+    def _evaluate_remaining_value_difference(
+        self,
+        m,
+        p,
+        g,
+        end_year_of_optimization,
+        lifetime,
+        interest,
+    ):
+        """Evaluate and return the remaining value difference of an investment
+
+        The remaining value difference in the net present values if the asset
+        was to be liquidated at the end of the optimization horizon and the
+        net present value using the original investment expenses.
+
+        Parameters
+        ----------
+        m : oemof.solph.models.Model
+            Optimization model
+
+        p : int
+            Period in which investment occurs
+
+        g : oemof.solph.components.experimental.SinkDSM
+            storage unit
+
+        end_year_of_optimization : int
+            Last year of the optimization horizon
+
+        lifetime : int
+            lifetime of investment considered
+
+        interest : float
+            Demanded interest rate for investment
+        """
+        if m.es.use_remaining_value:
+            if end_year_of_optimization - m.es.periods_years[p] < lifetime:
+                remaining_lifetime = lifetime - (
+                    end_year_of_optimization - m.es.periods_years[p]
+                )
+                remaining_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[-1],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                original_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[p],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                present_value_factor_remaining = 1 / economics.annuity(
+                    capex=1, n=remaining_lifetime, wacc=interest
+                )
+                return (
+                    self.invest[g, p]
+                    * (remaining_annuity - original_annuity)
+                    * present_value_factor_remaining
+                ) * (1 + m.discount_rate) ** (-end_year_of_optimization)
+            else:
+                return 0
+        else:
+            return 0
 
 
 class SinkDSMDLRBlock(ScalarBlock):
@@ -4399,6 +4581,21 @@ class SinkDSMDLRInvestmentBlock(ScalarBlock):
                 &
                 \forall p \in \mathbb{P}
 
+        In case, the remaining lifetime of a DSM unit is greater than 0 and
+        attribute `use_remaining_value` of the energy system is True,
+        the difference in value for the investment period compared to the
+        last period of the optimization horizon is accounted for
+        as an adder to the investment costs:
+
+            .. math::
+                &
+                P_{invest}(p) \cdot (A(c_{invest,var}(p), l_{r}, ir) -
+                A(c_{invest,var}(|P|), l_{r}, ir)\\
+                & \cdot \frac {1}{ANF(l_{r}, ir)} \cdot DF^{-|P|}\\
+                &\\
+                &
+                \forall p \in \textrm{PERIODS}
+
         * :attr:`fixed_costs` not None for investments
 
             .. math::
@@ -5541,7 +5738,20 @@ class SinkDSMDLRInvestmentBlock(ScalarBlock):
                         investment_costs_increment = (
                             self.invest[g, p] * annuity * present_value_factor
                         ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
-                        investment_costs += investment_costs_increment
+                        remaining_value_difference = (
+                            self._evaluate_remaining_value_difference(
+                                m,
+                                p,
+                                g,
+                                m.es.end_year_of_optimization,
+                                lifetime,
+                                interest,
+                            )
+                        )
+                        investment_costs += (
+                            investment_costs_increment
+                            + remaining_value_difference
+                        )
                         period_investment_costs[
                             p
                         ] += investment_costs_increment
@@ -5615,3 +5825,66 @@ class SinkDSMDLRInvestmentBlock(ScalarBlock):
         )
 
         return self.costs
+
+    def _evaluate_remaining_value_difference(
+        self,
+        m,
+        p,
+        g,
+        end_year_of_optimization,
+        lifetime,
+        interest,
+    ):
+        """Evaluate and return the remaining value difference of an investment
+
+        The remaining value difference in the net present values if the asset
+        was to be liquidated at the end of the optimization horizon and the
+        net present value using the original investment expenses.
+
+        Parameters
+        ----------
+        m : oemof.solph.models.Model
+            Optimization model
+
+        p : int
+            Period in which investment occurs
+
+        g : oemof.solph.components.experimental.SinkDSM
+            storage unit
+
+        end_year_of_optimization : int
+            Last year of the optimization horizon
+
+        lifetime : int
+            lifetime of investment considered
+
+        interest : float
+            Demanded interest rate for investment
+        """
+        if m.es.use_remaining_value:
+            if end_year_of_optimization - m.es.periods_years[p] < lifetime:
+                remaining_lifetime = lifetime - (
+                    end_year_of_optimization - m.es.periods_years[p]
+                )
+                remaining_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[-1],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                original_annuity = economics.annuity(
+                    capex=g.investment.ep_costs[p],
+                    n=remaining_lifetime,
+                    wacc=interest,
+                )
+                present_value_factor_remaining = 1 / economics.annuity(
+                    capex=1, n=remaining_lifetime, wacc=interest
+                )
+                return (
+                    self.invest[g, p]
+                    * (remaining_annuity - original_annuity)
+                    * present_value_factor_remaining
+                ) * (1 + m.discount_rate) ** (-end_year_of_optimization)
+            else:
+                return 0
+        else:
+            return 0

--- a/src/oemof/solph/flows/_investment_flow_block.py
+++ b/src/oemof/solph/flows/_investment_flow_block.py
@@ -785,6 +785,20 @@ class InvestmentFlowBlock(ScalarBlock):
                     &
                     \forall p \in \textrm{PERIODS}
 
+            In case, the remaining lifetime of an asset is greater than 0,
+            the difference in value for the investment period compared to the
+            last period of the optimization horizon is accounted for
+            as an adder to the investment costs:
+
+                .. math::
+                    &
+                    P_{invest}(p) \cdot (A(c_{invest,var}(p), l_{r}, ir) -
+                    A(c_{invest,var}(|P|), l_{r}, ir)\\
+                    & \cdot \frac {1}{ANF(l_{r}, dr)} \cdot DF^{-|P|}\\
+                    &\\
+                    &
+                    \forall p \in \textrm{PERIODS}
+
             * :attr:`nonconvex = True`
 
                 .. math::
@@ -793,6 +807,23 @@ class InvestmentFlowBlock(ScalarBlock):
                     \cdot \frac {1}{ANF(d, ir)}\\
                     &
                     +  c_{invest,fix}(p) \cdot b_{invest}(p)) \cdot DF^{-p}\\
+                    &\\
+                    &
+                    \forall p \in \textrm{PERIODS}
+
+            In case, the remaining lifetime of an asset is greater than 0,
+            the difference in value for the investment period compared to the
+            last period of the optimization horizon is accounted for
+            as an adder to the investment costs:
+
+                .. math::
+                    &
+                    (P_{invest}(p) \cdot (A(c_{invest,var}(p), l_{r}, ir) -
+                    A(c_{invest,var}(|P|), l_{r}, ir)\\
+                    & \cdot \frac {1}{ANF(l_{r}, dr)} \cdot DF^{-|P|}\\
+                    &
+                    +  (c_{invest,fix}(p) - c_{invest,fix}(|P|))
+                    \cdot b_{invest}(p)) \cdot DF^{-p}\\
                     &\\
                     &
                     \forall p \in \textrm{PERIODS}
@@ -820,6 +851,9 @@ class InvestmentFlowBlock(ScalarBlock):
         * :math:`A(c_{invest,var}(p), l, ir)` A is the annuity for
           investment expenses :math:`c_{invest,var}(p)`, lifetime :math:`l`
           and interest rate :math:`ir`.
+        * :math:`l_{r}` is the remaining lifetime at the end of the optimization
+          horizon (in case it is greater than 0 and smaller than the actual
+          lifetime).
         * :math:`ANF(d, ir)` is the annuity factor for duration :math:`d`
           and interest rate :math:`ir`.
         * :math:`d=min\{year_{max} - year(p), l\}` defines the
@@ -903,13 +937,22 @@ class InvestmentFlowBlock(ScalarBlock):
                         m.es.end_year_of_optimization - m.es.periods_years[p],
                         lifetime,
                     )
-                    present_value_factor = 1 / economics.annuity(
+                    present_value_factor_remaining = 1 / economics.annuity(
                         capex=1, n=duration, wacc=interest
                     )
                     investment_costs_increment = (
-                        self.invest[i, o, p] * annuity * present_value_factor
+                        self.invest[i, o, p]
+                        * annuity
+                        * present_value_factor_remaining
                     ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
-                    investment_costs += investment_costs_increment
+                    remaining_value_difference = (
+                        self._evaluate_remaining_value_difference(
+                            m, p, i, o, end_of_optimization, lifetime, interest
+                        )
+                    )
+                    investment_costs += (
+                        investment_costs_increment + remaining_value_difference
+                    )
                     period_investment_costs[p] += investment_costs_increment
 
             for i, o in self.NON_CONVEX_INVESTFLOWS:
@@ -931,15 +974,31 @@ class InvestmentFlowBlock(ScalarBlock):
                         m.es.end_year_of_optimization - m.es.periods_years[p],
                         lifetime,
                     )
-                    present_value_factor = 1 / economics.annuity(
+                    present_value_factor_remaining = 1 / economics.annuity(
                         capex=1, n=duration, wacc=interest
                     )
                     investment_costs_increment = (
-                        self.invest[i, o, p] * annuity * present_value_factor
+                        self.invest[i, o, p]
+                        * annuity
+                        * present_value_factor_remaining
                         + self.invest_status[i, o, p]
                         * m.flows[i, o].investment.offset[p]
                     ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
-                    investment_costs += investment_costs_increment
+                    remaining_value_difference = (
+                        self._evaluate_remaining_value_difference(
+                            m,
+                            p,
+                            i,
+                            o,
+                            end_of_optimization,
+                            lifetime,
+                            interest,
+                            nonconvex=True,
+                        )
+                    )
+                    investment_costs += (
+                        investment_costs_increment + remaining_value_difference
+                    )
                     period_investment_costs[p] += investment_costs_increment
 
             for i, o in self.INVESTFLOWS:
@@ -980,6 +1039,85 @@ class InvestmentFlowBlock(ScalarBlock):
         self.costs = Expression(expr=investment_costs + fixed_costs)
 
         return self.costs
+
+    def _evaluate_remaining_value_difference(
+        self,
+        m,
+        p,
+        i,
+        o,
+        end_of_optimization,
+        lifetime,
+        interest,
+        nonconvex=False,
+    ):
+        """Evaluate and return the remaining value difference of an investment
+
+        The remaining value difference in the net present values if the asset
+        was to be liquidated at the end of the optimization horizon and the
+        net present value using the original investment expenses.
+
+        Parameters
+        ----------
+        m : oemof.solph.models.Model
+            Optimization model
+
+        p : int
+            Period in which investment occurs
+
+        # How to reference any type of module?
+        i : oemof.solph.components.__all__
+            start node of flow
+
+        o : oemof.solph.components.__all__
+            end node of flow
+
+        end_of_optimization : int
+            Last year of the optimization horizon
+
+        lifetime : int
+            lifetime of investment considered
+
+        interest : float
+            Demanded interest rate for investment
+
+        nonconvex : bool
+            Indicating whether considered flow is nonconvex.
+        """
+        if end_of_optimization - m.es.periods_years[p] < lifetime:
+            remaining_lifetime = end_of_optimization - m.es.periods_years[p]
+            remaining_annuity = economics.annuity(
+                capex=m.flows[i, o].investment.ep_costs[-1],
+                n=remaining_lifetime,
+                wacc=interest,
+            )
+            original_annuity = economics.annuity(
+                capex=m.flows[i, o].investment.ep_costs[p],
+                n=remaining_lifetime,
+                wacc=interest,
+            )
+            present_value_factor_remaining = 1 / economics.annuity(
+                capex=1, n=remaining_lifetime, wacc=m.discount_rate
+            )
+            if nonconvex:
+                return (
+                    self.invest[i, o, p]
+                    * (remaining_annuity - original_annuity)
+                    * present_value_factor_remaining
+                    + self.invest_status[i, o, p]
+                    * (
+                        m.flows[i, o].investment.offset[-1]
+                        - m.flows[i, o].investment.offset[p]
+                    )
+                ) * (1 + m.discount_rate) ** (-end_of_optimization)
+            else:
+                return (
+                    self.invest[i, o, p]
+                    * (remaining_annuity - original_annuity)
+                    * present_value_factor_remaining
+                ) * (1 + m.discount_rate) ** (-end_of_optimization)
+        else:
+            return 0
 
     def _minimum_investment_constraint(self):
         """Constraint factory for a minimum investment"""

--- a/tests/lp_files/dsm_module_DIW_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_DIW_invest_multi_period_remaining_value.lp
@@ -1,0 +1,487 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++2941.5609381007307 ONE_VAR_CONSTANT
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_0)
++100 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_1)
++100 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_2)
++98.0392156862745 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3)
++0.9803921568627451 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_3)
++98.0392156862745 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4)
++96.11687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5)
++0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
++96.11687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
++57.62165571222974 SinkDSMDIWInvestmentBlock_invest(demand_dsm_0)
++39.12361323621548 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
++23.087255832295018 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
+
+s.t.
+
+c_e_BusBlock_balance(bus_elec_0_0)_:
++1 flow(bus_elec_demand_dsm_0_0)
+= 0
+
+c_e_BusBlock_balance(bus_elec_0_1)_:
++1 flow(bus_elec_demand_dsm_0_1)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_2)_:
++1 flow(bus_elec_demand_dsm_1_2)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_3)_:
++1 flow(bus_elec_demand_dsm_1_3)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_4)_:
++1 flow(bus_elec_demand_dsm_2_4)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_5)_:
++1 flow(bus_elec_demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_total_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMDIWInvestmentBlock_invest(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+= 50
+
+c_e_SinkDSMDIWInvestmentBlock_total_dsm_rule(demand_dsm_1)_:
+-1 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
+-1 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_old(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_total_dsm_rule(demand_dsm_2)_:
+-1 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
+-1 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDIWInvestmentBlock_old(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_end(demand_dsm_0)_:
++1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_end(demand_dsm_1)_:
++1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_end(demand_dsm_2)_:
++1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_exo(demand_dsm_0)_:
++1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_exo(demand_dsm_1)_:
++1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule_exo(demand_dsm_2)_:
++1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_0)
+-1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_old(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule(demand_dsm_1)_:
++1 SinkDSMDIWInvestmentBlock_old(demand_dsm_1)
+-1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_1)
+-1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_old_dsm_rule(demand_dsm_2)_:
++1 SinkDSMDIWInvestmentBlock_old(demand_dsm_2)
+-1 SinkDSMDIWInvestmentBlock_old_end(demand_dsm_2)
+-1 SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_0_0)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0)
++1 flow(bus_elec_demand_dsm_0_0)
+= 1
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_0_1)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
++1 flow(bus_elec_demand_dsm_0_1)
+= 1
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_1_2)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
++1 flow(bus_elec_demand_dsm_1_2)
+= 2
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_1_3)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
++1 flow(bus_elec_demand_dsm_1_3)
+= 2
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_2_4)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
++1 flow(bus_elec_demand_dsm_2_4)
+= 3
+
+c_e_SinkDSMDIWInvestmentBlock_input_output_relation(demand_dsm_2_5)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
++1 flow(bus_elec_demand_dsm_2_5)
+= 3
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_0)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_1)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_2)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_3)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_4)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5)
+= 0
+
+c_e_SinkDSMDIWInvestmentBlock_dsm_updo_constraint(demand_dsm_5)_:
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5)
+-1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
+= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_0_0)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_0_1)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_1_2)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_1_3)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_2_4)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_up_constraint(demand_dsm_2_5)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_0_0)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_0_1)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_1_2)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_1_3)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_2_4)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_dsm_do_constraint(demand_dsm_2_5)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_0_0)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_0_1)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_1_2)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_1_3)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_2_4)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_C2_constraint(demand_dsm_2_5)_:
++1 SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-0.5 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_0_0)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_0_1)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_1_2)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_1_3)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_2_4)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4)
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_shed_limit_constraint(demand_dsm_2_5)_:
++1 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-1.0 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDIWInvestmentBlock_overall_dsm_maximum(demand_dsm_0)_:
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_0)
+<= 1000
+
+c_u_SinkDSMDIWInvestmentBlock_overall_dsm_maximum(demand_dsm_1)_:
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_1)
+<= 1000
+
+c_u_SinkDSMDIWInvestmentBlock_overall_dsm_maximum(demand_dsm_2)_:
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+<= 1000
+
+c_l_SinkDSMDIWInvestmentBlock_overall_minimum(demand_dsm)_:
++1 SinkDSMDIWInvestmentBlock_total(demand_dsm_2)
+>= 5
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_3) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_4) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_up(demand_dsm_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_0_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_1_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_3_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_4_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5) <= +inf
+   33 <= SinkDSMDIWInvestmentBlock_invest(demand_dsm_0) <= 100
+   33 <= SinkDSMDIWInvestmentBlock_invest(demand_dsm_1) <= 100
+   33 <= SinkDSMDIWInvestmentBlock_invest(demand_dsm_2) <= 100
+   0 <= flow(bus_elec_demand_dsm_0_0) <= +inf
+   0 <= flow(bus_elec_demand_dsm_0_1) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_2) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_3) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_4) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_total(demand_dsm_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_total(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_total(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_end(demand_dsm_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_end(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_end(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_0) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_1) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old_exo(demand_dsm_2) <= +inf
+   0 <= SinkDSMDIWInvestmentBlock_old(demand_dsm_0) <= +inf
+end

--- a/tests/lp_files/dsm_module_DLR_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_DLR_invest_multi_period_remaining_value.lp
@@ -1,0 +1,824 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++2941.5609381007307 ONE_VAR_CONSTANT
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0)
++100 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1)
++100 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
++98.0392156862745 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++0.9803921568627451 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
++98.0392156862745 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
++96.11687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
++96.11687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
++57.62165571222974 SinkDSMDLRInvestmentBlock_invest(demand_dsm_0)
++39.12361323621548 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
++23.087255832295018 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
+
+s.t.
+
+c_e_BusBlock_balance(bus_elec_0_0)_:
++1 flow(bus_elec_demand_dsm_0_0)
+= 0
+
+c_e_BusBlock_balance(bus_elec_0_1)_:
++1 flow(bus_elec_demand_dsm_0_1)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_2)_:
++1 flow(bus_elec_demand_dsm_1_2)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_3)_:
++1 flow(bus_elec_demand_dsm_1_3)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_4)_:
++1 flow(bus_elec_demand_dsm_2_4)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_5)_:
++1 flow(bus_elec_demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_total_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMDLRInvestmentBlock_invest(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+= 50
+
+c_e_SinkDSMDLRInvestmentBlock_total_dsm_rule(demand_dsm_1)_:
+-1 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
+-1 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_old(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_total_dsm_rule(demand_dsm_2)_:
+-1 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
+-1 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_old(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_end(demand_dsm_0)_:
++1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_end(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_end(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_exo(demand_dsm_0)_:
++1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_exo(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule_exo(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_0)
+-1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_old(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_old(demand_dsm_1)
+-1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_1)
+-1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_old_dsm_rule(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_old(demand_dsm_2)
+-1 SinkDSMDLRInvestmentBlock_old_end(demand_dsm_2)
+-1 SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_0_0)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 flow(bus_elec_demand_dsm_0_0)
+= 1
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_0_1)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
++1 flow(bus_elec_demand_dsm_0_1)
+= 1
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_1_2)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
++1 flow(bus_elec_demand_dsm_1_2)
+= 2
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_1_3)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
++1 flow(bus_elec_demand_dsm_1_3)
+= 2
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_2_4)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
++1 flow(bus_elec_demand_dsm_2_4)
+= 3
+
+c_e_SinkDSMDLRInvestmentBlock_input_output_relation(demand_dsm_2_5)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
++1 flow(bus_elec_demand_dsm_2_5)
+= 3
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_0)_:
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_1)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_2)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_3)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_4)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_1_5)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_2_0)_:
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_2_2)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_2_3)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_2_4)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_red(demand_dsm_2_5)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_0)_:
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_1)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_2)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_3)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_4)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_1_5)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_2_0)_:
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_2_2)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_2_3)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_2_4)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_capacity_balance_inc(demand_dsm_2_5)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_red(demand_dsm_1_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_red(demand_dsm_2_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_red(demand_dsm_2_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_inc(demand_dsm_1_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_inc(demand_dsm_2_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_no_comp_inc(demand_dsm_2_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
+= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_0_0)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_0_1)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_1_2)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_1_3)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_2_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_red(demand_dsm_2_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_0_0)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_0_1)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_1_2)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_1_3)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_2_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_availability_inc(demand_dsm_2_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_0)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_1)_:
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_0)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_2)_:
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_1)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_3)_:
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_2)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_4)_:
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_3)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_red(demand_dsm_5)_:
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_4)
+-1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_5)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_0)_:
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
+-1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_0)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_0)
+-1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_1)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_1)
+-1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_2)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_3)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_2)
+-1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_3)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_3)
+-1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_4)
+= 0
+
+c_e_SinkDSMDLRInvestmentBlock_dr_storage_inc(demand_dsm_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
+-1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_4)
+-1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_5)
+= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_0_0)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_0_1)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_1_2)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_1_3)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_3)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_2_4)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_4)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_red(demand_dsm_2_5)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_5)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_0_0)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_0_1)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_1_2)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_1_3)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_3)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_2_4)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_4)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_storage_limit_inc(demand_dsm_2_5)_:
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_5)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_0)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-50.0 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-50.0 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_yearly_limit_shed(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-50.0 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_0_0)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_0_1)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_1_2)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_1_3)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_2_4)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_dr_logical_constraint(demand_dsm_2_5)_:
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
++1 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-0.5 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMDLRInvestmentBlock_overall_dsm_maximum(demand_dsm_0)_:
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_0)
+<= 1000
+
+c_u_SinkDSMDLRInvestmentBlock_overall_dsm_maximum(demand_dsm_1)_:
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_1)
+<= 1000
+
+c_u_SinkDSMDLRInvestmentBlock_overall_dsm_maximum(demand_dsm_2)_:
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+<= 1000
+
+c_l_SinkDSMDLRInvestmentBlock_overall_minimum(demand_dsm)_:
++1 SinkDSMDLRInvestmentBlock_total(demand_dsm_2)
+>= 5
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_1_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_1_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_1_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_1_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shift(demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5) <= +inf
+   33 <= SinkDSMDLRInvestmentBlock_invest(demand_dsm_0) <= 100
+   33 <= SinkDSMDLRInvestmentBlock_invest(demand_dsm_1) <= 100
+   33 <= SinkDSMDLRInvestmentBlock_invest(demand_dsm_2) <= 100
+   0 <= flow(bus_elec_demand_dsm_0_0) <= +inf
+   0 <= flow(bus_elec_demand_dsm_0_1) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_2) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_3) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_4) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_total(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_total(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_total(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_end(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_end(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_end(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old_exo(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_old(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_do_level(demand_dsm_5) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_0) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_1) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_2) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_3) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_4) <= +inf
+   0 <= SinkDSMDLRInvestmentBlock_dsm_up_level(demand_dsm_5) <= +inf
+end

--- a/tests/lp_files/dsm_module_oemof_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_oemof_invest_multi_period_remaining_value.lp
@@ -1,0 +1,301 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++2941.5609381007307 ONE_VAR_CONSTANT
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_0)
++100 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_1)
++100 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_1)
++0.9803921568627451 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_2)
++0.9803921568627451 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_2)
++98.0392156862745 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_2)
++0.9803921568627451 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_3)
++0.9803921568627451 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_3)
++98.0392156862745 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_3)
++0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_4)
++0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_4)
++96.11687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_4)
++0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_5)
++0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
++96.11687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5)
++57.62165571222974 SinkDSMOemofInvestmentBlock_invest(demand_dsm_0)
++39.12361323621548 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
++23.087255832295018 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
+
+s.t.
+
+c_e_BusBlock_balance(bus_elec_0_0)_:
++1 flow(bus_elec_demand_dsm_0_0)
+= 0
+
+c_e_BusBlock_balance(bus_elec_0_1)_:
++1 flow(bus_elec_demand_dsm_0_1)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_2)_:
++1 flow(bus_elec_demand_dsm_1_2)
+= 0
+
+c_e_BusBlock_balance(bus_elec_1_3)_:
++1 flow(bus_elec_demand_dsm_1_3)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_4)_:
++1 flow(bus_elec_demand_dsm_2_4)
+= 0
+
+c_e_BusBlock_balance(bus_elec_2_5)_:
++1 flow(bus_elec_demand_dsm_2_5)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_total_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMOemofInvestmentBlock_invest(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+= 50
+
+c_e_SinkDSMOemofInvestmentBlock_total_dsm_rule(demand_dsm_1)_:
+-1 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
+-1 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_old(demand_dsm_1)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_total_dsm_rule(demand_dsm_2)_:
+-1 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
+-1 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
++1 SinkDSMOemofInvestmentBlock_old(demand_dsm_2)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_end(demand_dsm_0)_:
++1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_0)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_end(demand_dsm_1)_:
++1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_1)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_end(demand_dsm_2)_:
++1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_2)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_exo(demand_dsm_0)_:
++1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_0)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_exo(demand_dsm_1)_:
++1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule_exo(demand_dsm_2)_:
++1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule(demand_dsm_0)_:
+-1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_0)
+-1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_old(demand_dsm_0)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule(demand_dsm_1)_:
++1 SinkDSMOemofInvestmentBlock_old(demand_dsm_1)
+-1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_1)
+-1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_1)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_old_dsm_rule(demand_dsm_2)_:
++1 SinkDSMOemofInvestmentBlock_old(demand_dsm_2)
+-1 SinkDSMOemofInvestmentBlock_old_end(demand_dsm_2)
+-1 SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_2)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_0_0)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_0)
++1 flow(bus_elec_demand_dsm_0_0)
+= 1
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_0_1)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_1)
++1 flow(bus_elec_demand_dsm_0_1)
+= 1
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_1_2)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_2)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_2)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_2)
++1 flow(bus_elec_demand_dsm_1_2)
+= 2
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_1_3)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_3)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_3)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_3)
++1 flow(bus_elec_demand_dsm_1_3)
+= 2
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_2_4)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_4)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_4)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_4)
++1 flow(bus_elec_demand_dsm_2_4)
+= 3
+
+c_e_SinkDSMOemofInvestmentBlock_input_output_relation(demand_dsm_2_5)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_5)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5)
++1 flow(bus_elec_demand_dsm_2_5)
+= 3
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_0_0)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_0)
+-0.5 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_0_1)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_1)
+-0.4 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_1_2)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_2)
+-0.5 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_1_3)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_3)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_2_4)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_4)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_up_constraint(demand_dsm_2_5)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_5)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_0_0)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_0)
+-0.5 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_0_1)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_1)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_1)
+-0.4 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_1_2)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_2)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_2)
+-0.5 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_1_3)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_3)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_3)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_2_4)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_4)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_4)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_u_SinkDSMOemofInvestmentBlock_dsm_down_constraint(demand_dsm_2_5)_:
++1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
++1 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5)
+-0.3 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+<= 0
+
+c_e_SinkDSMOemofInvestmentBlock_dsm_sum_constraint(demand_dsm_0)_:
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_0)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_1)
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_1)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_dsm_sum_constraint(demand_dsm_2)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_2)
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_2)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_3)
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_3)
+= 0
+
+c_e_SinkDSMOemofInvestmentBlock_dsm_sum_constraint(demand_dsm_4)_:
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_4)
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_4)
++1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_5)
+-1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
+= 0
+
+c_u_SinkDSMOemofInvestmentBlock_overall_dsm_maximum(demand_dsm_0)_:
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_0)
+<= 1000
+
+c_u_SinkDSMOemofInvestmentBlock_overall_dsm_maximum(demand_dsm_1)_:
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_1)
+<= 1000
+
+c_u_SinkDSMOemofInvestmentBlock_overall_dsm_maximum(demand_dsm_2)_:
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+<= 1000
+
+c_l_SinkDSMOemofInvestmentBlock_overall_minimum(demand_dsm)_:
++1 SinkDSMOemofInvestmentBlock_total(demand_dsm_2)
+>= 5
+
+bounds
+   1 <= ONE_VAR_CONSTANT <= 1
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_3) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_3) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_3) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_4) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_4) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_4) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_5) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5) <= +inf
+   33 <= SinkDSMOemofInvestmentBlock_invest(demand_dsm_0) <= 100
+   33 <= SinkDSMOemofInvestmentBlock_invest(demand_dsm_1) <= 100
+   33 <= SinkDSMOemofInvestmentBlock_invest(demand_dsm_2) <= 100
+   0 <= flow(bus_elec_demand_dsm_0_0) <= +inf
+   0 <= flow(bus_elec_demand_dsm_0_1) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_2) <= +inf
+   0 <= flow(bus_elec_demand_dsm_1_3) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_4) <= +inf
+   0 <= flow(bus_elec_demand_dsm_2_5) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_total(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_total(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_total(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_end(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_end(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_end(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_0) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_1) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old_exo(demand_dsm_2) <= +inf
+   0 <= SinkDSMOemofInvestmentBlock_old(demand_dsm_0) <= +inf
+end

--- a/tests/lp_files/linear_converter_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/linear_converter_invest_multi_period_remaining_value.lp
@@ -1,0 +1,230 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++0.22380552274393728 InvestmentFlowBlock_invest(powerplant_gas_electricity_0)
++0.37976494755240464 InvestmentFlowBlock_invest(powerplant_gas_electricity_1)
++0.6200513568991706 InvestmentFlowBlock_invest(powerplant_gas_electricity_2)
++50 flow(powerplant_gas_electricity_0_0)
++50 flow(powerplant_gas_electricity_0_1)
++49.01960784313725 flow(powerplant_gas_electricity_1_2)
++49.01960784313725 flow(powerplant_gas_electricity_1_3)
++48.058439061899264 flow(powerplant_gas_electricity_2_4)
++48.058439061899264 flow(powerplant_gas_electricity_2_5)
+
+s.t.
+
+c_e_BusBlock_balance(gas_0_0)_:
++1 flow(gas_powerplant_gas_0_0)
+= 0
+
+c_e_BusBlock_balance(gas_0_1)_:
++1 flow(gas_powerplant_gas_0_1)
+= 0
+
+c_e_BusBlock_balance(gas_1_2)_:
++1 flow(gas_powerplant_gas_1_2)
+= 0
+
+c_e_BusBlock_balance(gas_1_3)_:
++1 flow(gas_powerplant_gas_1_3)
+= 0
+
+c_e_BusBlock_balance(gas_2_4)_:
++1 flow(gas_powerplant_gas_2_4)
+= 0
+
+c_e_BusBlock_balance(gas_2_5)_:
++1 flow(gas_powerplant_gas_2_5)
+= 0
+
+c_e_BusBlock_balance(electricity_0_0)_:
++1 flow(powerplant_gas_electricity_0_0)
+= 0
+
+c_e_BusBlock_balance(electricity_0_1)_:
++1 flow(powerplant_gas_electricity_0_1)
+= 0
+
+c_e_BusBlock_balance(electricity_1_2)_:
++1 flow(powerplant_gas_electricity_1_2)
+= 0
+
+c_e_BusBlock_balance(electricity_1_3)_:
++1 flow(powerplant_gas_electricity_1_3)
+= 0
+
+c_e_BusBlock_balance(electricity_2_4)_:
++1 flow(powerplant_gas_electricity_2_4)
+= 0
+
+c_e_BusBlock_balance(electricity_2_5)_:
++1 flow(powerplant_gas_electricity_2_5)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_0_0)_:
+-1 flow(powerplant_gas_electricity_0_0)
++0.58 flow(gas_powerplant_gas_0_0)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_0_1)_:
+-1 flow(powerplant_gas_electricity_0_1)
++0.58 flow(gas_powerplant_gas_0_1)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_1_2)_:
+-1 flow(powerplant_gas_electricity_1_2)
++0.58 flow(gas_powerplant_gas_1_2)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_1_3)_:
+-1 flow(powerplant_gas_electricity_1_3)
++0.58 flow(gas_powerplant_gas_1_3)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_2_4)_:
+-1 flow(powerplant_gas_electricity_2_4)
++0.58 flow(gas_powerplant_gas_2_4)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_gas_electricity_2_5)_:
+-1 flow(powerplant_gas_electricity_2_5)
++0.58 flow(gas_powerplant_gas_2_5)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(powerplant_gas_electricity_0)_:
+-1 InvestmentFlowBlock_invest(powerplant_gas_electricity_0)
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_0)
+= 50
+
+c_e_InvestmentFlowBlock_total_rule(powerplant_gas_electricity_1)_:
+-1 InvestmentFlowBlock_invest(powerplant_gas_electricity_1)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_0)
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_1)
++1 InvestmentFlowBlock_old(powerplant_gas_electricity_1)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(powerplant_gas_electricity_2)_:
+-1 InvestmentFlowBlock_invest(powerplant_gas_electricity_2)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_1)
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_2)
++1 InvestmentFlowBlock_old(powerplant_gas_electricity_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(powerplant_gas_electricity_0)_:
++1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(powerplant_gas_electricity_1)_:
++1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(powerplant_gas_electricity_2)_:
++1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(powerplant_gas_electricity_0)_:
++1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(powerplant_gas_electricity_1)_:
++1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(powerplant_gas_electricity_2)_:
++1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(powerplant_gas_electricity_0)_:
+-1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_0)
+-1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_0)
++1 InvestmentFlowBlock_old(powerplant_gas_electricity_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(powerplant_gas_electricity_1)_:
++1 InvestmentFlowBlock_old(powerplant_gas_electricity_1)
+-1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_1)
+-1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(powerplant_gas_electricity_2)_:
++1 InvestmentFlowBlock_old(powerplant_gas_electricity_2)
+-1 InvestmentFlowBlock_old_end(powerplant_gas_electricity_2)
+-1 InvestmentFlowBlock_old_exo(powerplant_gas_electricity_2)
+= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_0_0)_:
++1 flow(powerplant_gas_electricity_0_0)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_0_1)_:
++1 flow(powerplant_gas_electricity_0_1)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_1_2)_:
++1 flow(powerplant_gas_electricity_1_2)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_1_3)_:
++1 flow(powerplant_gas_electricity_1_3)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_2_4)_:
++1 flow(powerplant_gas_electricity_2_4)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(powerplant_gas_electricity_2_5)_:
++1 flow(powerplant_gas_electricity_2_5)
+-1 InvestmentFlowBlock_total(powerplant_gas_electricity_2)
+<= 0
+
+c_u_InvestmentFlowBlock_overall_maximum(powerplant_gas_electricity_0)_:
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_0)
+<= 10000
+
+c_u_InvestmentFlowBlock_overall_maximum(powerplant_gas_electricity_1)_:
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_1)
+<= 10000
+
+c_u_InvestmentFlowBlock_overall_maximum(powerplant_gas_electricity_2)_:
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_2)
+<= 10000
+
+c_l_InvestmentFlowBlock_overall_minimum(powerplant_gas_electricity)_:
++1 InvestmentFlowBlock_total(powerplant_gas_electricity_2)
+>= 200
+
+bounds
+   0 <= InvestmentFlowBlock_invest(powerplant_gas_electricity_0) <= 1000
+   0 <= InvestmentFlowBlock_invest(powerplant_gas_electricity_1) <= 1000
+   0 <= InvestmentFlowBlock_invest(powerplant_gas_electricity_2) <= 1000
+   0 <= flow(powerplant_gas_electricity_0_0) <= +inf
+   0 <= flow(powerplant_gas_electricity_0_1) <= +inf
+   0 <= flow(powerplant_gas_electricity_1_2) <= +inf
+   0 <= flow(powerplant_gas_electricity_1_3) <= +inf
+   0 <= flow(powerplant_gas_electricity_2_4) <= +inf
+   0 <= flow(powerplant_gas_electricity_2_5) <= +inf
+   0 <= flow(gas_powerplant_gas_0_0) <= +inf
+   0 <= flow(gas_powerplant_gas_0_1) <= +inf
+   0 <= flow(gas_powerplant_gas_1_2) <= +inf
+   0 <= flow(gas_powerplant_gas_1_3) <= +inf
+   0 <= flow(gas_powerplant_gas_2_4) <= +inf
+   0 <= flow(gas_powerplant_gas_2_5) <= +inf
+   0 <= InvestmentFlowBlock_total(powerplant_gas_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_total(powerplant_gas_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old(powerplant_gas_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_total(powerplant_gas_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(powerplant_gas_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(powerplant_gas_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(powerplant_gas_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(powerplant_gas_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(powerplant_gas_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(powerplant_gas_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(powerplant_gas_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(powerplant_gas_electricity_0) <= +inf
+end

--- a/tests/lp_files/storage_invest_1_multi_period_remaining_value.lp
+++ b/tests/lp_files/storage_invest_1_multi_period_remaining_value.lp
@@ -1,0 +1,505 @@
+\* Source Pyomo model name=Model *\
+
+min 
+objective:
++56 flow(electricityBus_storage1_0_0)
++56 flow(electricityBus_storage1_0_1)
++54.90196078431372 flow(electricityBus_storage1_1_2)
++54.90196078431372 flow(electricityBus_storage1_1_3)
++53.82545174932718 flow(electricityBus_storage1_2_4)
++53.82545174932718 flow(electricityBus_storage1_2_5)
++24 flow(storage1_electricityBus_0_0)
++24 flow(storage1_electricityBus_0_1)
++23.52941176470588 flow(storage1_electricityBus_1_2)
++23.52941176470588 flow(storage1_electricityBus_1_3)
++23.06805074971165 flow(storage1_electricityBus_2_4)
++23.06805074971165 flow(storage1_electricityBus_2_5)
++3.415797742191323 GenericInvestmentStorageBlock_invest(storage1_0)
++4.881348776484851 GenericInvestmentStorageBlock_invest(storage1_1)
++8.44720668509319 GenericInvestmentStorageBlock_invest(storage1_2)
+
+s.t.
+
+c_e_BusBlock_balance(electricityBus_0_0)_:
+-1 flow(electricityBus_storage1_0_0)
++1 flow(storage1_electricityBus_0_0)
+= 0
+
+c_e_BusBlock_balance(electricityBus_0_1)_:
+-1 flow(electricityBus_storage1_0_1)
++1 flow(storage1_electricityBus_0_1)
+= 0
+
+c_e_BusBlock_balance(electricityBus_1_2)_:
+-1 flow(electricityBus_storage1_1_2)
++1 flow(storage1_electricityBus_1_2)
+= 0
+
+c_e_BusBlock_balance(electricityBus_1_3)_:
+-1 flow(electricityBus_storage1_1_3)
++1 flow(storage1_electricityBus_1_3)
+= 0
+
+c_e_BusBlock_balance(electricityBus_2_4)_:
+-1 flow(electricityBus_storage1_2_4)
++1 flow(storage1_electricityBus_2_4)
+= 0
+
+c_e_BusBlock_balance(electricityBus_2_5)_:
+-1 flow(electricityBus_storage1_2_5)
++1 flow(storage1_electricityBus_2_5)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage1_electricityBus_0)_:
++1 InvestmentFlowBlock_total(storage1_electricityBus_0)
+-1 InvestmentFlowBlock_invest(storage1_electricityBus_0)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage1_electricityBus_1)_:
+-1 InvestmentFlowBlock_total(storage1_electricityBus_0)
++1 InvestmentFlowBlock_total(storage1_electricityBus_1)
+-1 InvestmentFlowBlock_invest(storage1_electricityBus_1)
++1 InvestmentFlowBlock_old(storage1_electricityBus_1)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage1_electricityBus_2)_:
+-1 InvestmentFlowBlock_total(storage1_electricityBus_1)
++1 InvestmentFlowBlock_total(storage1_electricityBus_2)
+-1 InvestmentFlowBlock_invest(storage1_electricityBus_2)
++1 InvestmentFlowBlock_old(storage1_electricityBus_2)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(electricityBus_storage1_0)_:
++1 InvestmentFlowBlock_total(electricityBus_storage1_0)
+-1 InvestmentFlowBlock_invest(electricityBus_storage1_0)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(electricityBus_storage1_1)_:
+-1 InvestmentFlowBlock_total(electricityBus_storage1_0)
++1 InvestmentFlowBlock_total(electricityBus_storage1_1)
+-1 InvestmentFlowBlock_invest(electricityBus_storage1_1)
++1 InvestmentFlowBlock_old(electricityBus_storage1_1)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(electricityBus_storage1_2)_:
+-1 InvestmentFlowBlock_total(electricityBus_storage1_1)
++1 InvestmentFlowBlock_total(electricityBus_storage1_2)
+-1 InvestmentFlowBlock_invest(electricityBus_storage1_2)
++1 InvestmentFlowBlock_old(electricityBus_storage1_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(storage1_electricityBus_0)_:
++1 InvestmentFlowBlock_old_end(storage1_electricityBus_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(storage1_electricityBus_1)_:
++1 InvestmentFlowBlock_old_end(storage1_electricityBus_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(storage1_electricityBus_2)_:
++1 InvestmentFlowBlock_old_end(storage1_electricityBus_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage1_0)_:
++1 InvestmentFlowBlock_old_end(electricityBus_storage1_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage1_1)_:
++1 InvestmentFlowBlock_old_end(electricityBus_storage1_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_end(electricityBus_storage1_2)_:
++1 InvestmentFlowBlock_old_end(electricityBus_storage1_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(storage1_electricityBus_0)_:
++1 InvestmentFlowBlock_old_exo(storage1_electricityBus_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(storage1_electricityBus_1)_:
++1 InvestmentFlowBlock_old_exo(storage1_electricityBus_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(storage1_electricityBus_2)_:
++1 InvestmentFlowBlock_old_exo(storage1_electricityBus_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage1_0)_:
++1 InvestmentFlowBlock_old_exo(electricityBus_storage1_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage1_1)_:
++1 InvestmentFlowBlock_old_exo(electricityBus_storage1_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule_exo(electricityBus_storage1_2)_:
++1 InvestmentFlowBlock_old_exo(electricityBus_storage1_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(storage1_electricityBus_0)_:
+-1 InvestmentFlowBlock_old_end(storage1_electricityBus_0)
+-1 InvestmentFlowBlock_old_exo(storage1_electricityBus_0)
++1 InvestmentFlowBlock_old(storage1_electricityBus_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(storage1_electricityBus_1)_:
++1 InvestmentFlowBlock_old(storage1_electricityBus_1)
+-1 InvestmentFlowBlock_old_end(storage1_electricityBus_1)
+-1 InvestmentFlowBlock_old_exo(storage1_electricityBus_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(storage1_electricityBus_2)_:
++1 InvestmentFlowBlock_old(storage1_electricityBus_2)
+-1 InvestmentFlowBlock_old_end(storage1_electricityBus_2)
+-1 InvestmentFlowBlock_old_exo(storage1_electricityBus_2)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(electricityBus_storage1_0)_:
+-1 InvestmentFlowBlock_old_end(electricityBus_storage1_0)
+-1 InvestmentFlowBlock_old_exo(electricityBus_storage1_0)
++1 InvestmentFlowBlock_old(electricityBus_storage1_0)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(electricityBus_storage1_1)_:
++1 InvestmentFlowBlock_old(electricityBus_storage1_1)
+-1 InvestmentFlowBlock_old_end(electricityBus_storage1_1)
+-1 InvestmentFlowBlock_old_exo(electricityBus_storage1_1)
+= 0
+
+c_e_InvestmentFlowBlock_old_rule(electricityBus_storage1_2)_:
++1 InvestmentFlowBlock_old(electricityBus_storage1_2)
+-1 InvestmentFlowBlock_old_end(electricityBus_storage1_2)
+-1 InvestmentFlowBlock_old_exo(electricityBus_storage1_2)
+= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_0_0)_:
++1 flow(storage1_electricityBus_0_0)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_0_1)_:
++1 flow(storage1_electricityBus_0_1)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_1_2)_:
++1 flow(storage1_electricityBus_1_2)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_1_3)_:
++1 flow(storage1_electricityBus_1_3)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_2_4)_:
++1 flow(storage1_electricityBus_2_4)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage1_electricityBus_2_5)_:
++1 flow(storage1_electricityBus_2_5)
+-1 InvestmentFlowBlock_total(storage1_electricityBus_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_0_0)_:
++1 flow(electricityBus_storage1_0_0)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_0_1)_:
++1 flow(electricityBus_storage1_0_1)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_1_2)_:
++1 flow(electricityBus_storage1_1_2)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_1_3)_:
++1 flow(electricityBus_storage1_1_3)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_2_4)_:
++1 flow(electricityBus_storage1_2_4)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(electricityBus_storage1_2_5)_:
++1 flow(electricityBus_storage1_2_5)
+-1 InvestmentFlowBlock_total(electricityBus_storage1_2)
+<= 0
+
+c_e_GenericInvestmentStorageBlock_total_storage_rule(storage1_0)_:
+-1 GenericInvestmentStorageBlock_invest(storage1_0)
++1 GenericInvestmentStorageBlock_total(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_total_storage_rule(storage1_1)_:
+-1 GenericInvestmentStorageBlock_invest(storage1_1)
+-1 GenericInvestmentStorageBlock_total(storage1_0)
++1 GenericInvestmentStorageBlock_total(storage1_1)
++1 GenericInvestmentStorageBlock_old(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_total_storage_rule(storage1_2)_:
+-1 GenericInvestmentStorageBlock_invest(storage1_2)
+-1 GenericInvestmentStorageBlock_total(storage1_1)
++1 GenericInvestmentStorageBlock_total(storage1_2)
++1 GenericInvestmentStorageBlock_old(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_end(storage1_0)_:
++1 GenericInvestmentStorageBlock_old_end(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_end(storage1_1)_:
++1 GenericInvestmentStorageBlock_old_end(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_end(storage1_2)_:
++1 GenericInvestmentStorageBlock_old_end(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_exo(storage1_0)_:
++1 GenericInvestmentStorageBlock_old_exo(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_exo(storage1_1)_:
++1 GenericInvestmentStorageBlock_old_exo(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule_exo(storage1_2)_:
++1 GenericInvestmentStorageBlock_old_exo(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule(storage1_0)_:
+-1 GenericInvestmentStorageBlock_old_end(storage1_0)
+-1 GenericInvestmentStorageBlock_old_exo(storage1_0)
++1 GenericInvestmentStorageBlock_old(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule(storage1_1)_:
++1 GenericInvestmentStorageBlock_old(storage1_1)
+-1 GenericInvestmentStorageBlock_old_end(storage1_1)
+-1 GenericInvestmentStorageBlock_old_exo(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_old_rule(storage1_2)_:
++1 GenericInvestmentStorageBlock_old(storage1_2)
+-1 GenericInvestmentStorageBlock_old_end(storage1_2)
+-1 GenericInvestmentStorageBlock_old_exo(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_initially_empty(storage1_0)_:
++1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_balance(storage1_0_1)_:
+-0.97 flow(electricityBus_storage1_0_1)
++1.1627906976744187 flow(storage1_electricityBus_0_1)
+-0.87 GenericInvestmentStorageBlock_storage_content(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_balance(storage1_1_2)_:
+-0.97 flow(electricityBus_storage1_1_2)
++1.1627906976744187 flow(storage1_electricityBus_1_2)
+-0.87 GenericInvestmentStorageBlock_storage_content(storage1_1)
++1 GenericInvestmentStorageBlock_storage_content(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_balance(storage1_1_3)_:
+-0.97 flow(electricityBus_storage1_1_3)
++1.1627906976744187 flow(storage1_electricityBus_1_3)
+-0.87 GenericInvestmentStorageBlock_storage_content(storage1_2)
++1 GenericInvestmentStorageBlock_storage_content(storage1_3)
+= 0
+
+c_e_GenericInvestmentStorageBlock_balance(storage1_2_4)_:
+-0.97 flow(electricityBus_storage1_2_4)
++1.1627906976744187 flow(storage1_electricityBus_2_4)
+-0.87 GenericInvestmentStorageBlock_storage_content(storage1_3)
++1 GenericInvestmentStorageBlock_storage_content(storage1_4)
+= 0
+
+c_e_GenericInvestmentStorageBlock_balance(storage1_2_5)_:
+-0.97 flow(electricityBus_storage1_2_5)
++1.1627906976744187 flow(storage1_electricityBus_2_5)
+-0.87 GenericInvestmentStorageBlock_storage_content(storage1_4)
++1 GenericInvestmentStorageBlock_storage_content(storage1_5)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_inflow(storage1_0)_:
++1 InvestmentFlowBlock_total(electricityBus_storage1_0)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_inflow(storage1_1)_:
++1 InvestmentFlowBlock_total(electricityBus_storage1_1)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_inflow(storage1_2)_:
++1 InvestmentFlowBlock_total(electricityBus_storage1_2)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_2)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_outflow(storage1_0)_:
++1 InvestmentFlowBlock_total(storage1_electricityBus_0)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_0)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_outflow(storage1_1)_:
++1 InvestmentFlowBlock_total(storage1_electricityBus_1)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_1)
+= 0
+
+c_e_GenericInvestmentStorageBlock_storage_capacity_outflow(storage1_2)_:
++1 InvestmentFlowBlock_total(storage1_electricityBus_2)
+-0.16666666666666666 GenericInvestmentStorageBlock_total(storage1_2)
+= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_0_0)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_0_1)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_0)
++1 GenericInvestmentStorageBlock_storage_content(storage1_1)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_1_2)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_1)
++1 GenericInvestmentStorageBlock_storage_content(storage1_2)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_1_3)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_1)
++1 GenericInvestmentStorageBlock_storage_content(storage1_3)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_2_4)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_2)
++1 GenericInvestmentStorageBlock_storage_content(storage1_4)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_max_storage_content(storage1_2_5)_:
+-0.9 GenericInvestmentStorageBlock_total(storage1_2)
++1 GenericInvestmentStorageBlock_storage_content(storage1_5)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_0_0)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_0)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_0)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_0_1)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_0)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_1)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_1_2)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_1)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_2)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_1_3)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_1)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_3)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_2_4)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_2)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_4)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_min_storage_content(storage1_2_5)_:
++0.1 GenericInvestmentStorageBlock_total(storage1_2)
+-1 GenericInvestmentStorageBlock_storage_content(storage1_5)
+<= 0
+
+c_u_GenericInvestmentStorageBlock_overall_storage_maximum(storage1_0)_:
++1 GenericInvestmentStorageBlock_total(storage1_0)
+<= 1000
+
+c_u_GenericInvestmentStorageBlock_overall_storage_maximum(storage1_1)_:
++1 GenericInvestmentStorageBlock_total(storage1_1)
+<= 1000
+
+c_u_GenericInvestmentStorageBlock_overall_storage_maximum(storage1_2)_:
++1 GenericInvestmentStorageBlock_total(storage1_2)
+<= 1000
+
+c_l_GenericInvestmentStorageBlock_overall_minimum(storage1)_:
++1 GenericInvestmentStorageBlock_total(storage1_2)
+>= 2
+
+bounds
+   0 <= flow(electricityBus_storage1_0_0) <= +inf
+   0 <= flow(electricityBus_storage1_0_1) <= +inf
+   0 <= flow(electricityBus_storage1_1_2) <= +inf
+   0 <= flow(electricityBus_storage1_1_3) <= +inf
+   0 <= flow(electricityBus_storage1_2_4) <= +inf
+   0 <= flow(electricityBus_storage1_2_5) <= +inf
+   0 <= flow(storage1_electricityBus_0_0) <= +inf
+   0 <= flow(storage1_electricityBus_0_1) <= +inf
+   0 <= flow(storage1_electricityBus_1_2) <= +inf
+   0 <= flow(storage1_electricityBus_1_3) <= +inf
+   0 <= flow(storage1_electricityBus_2_4) <= +inf
+   0 <= flow(storage1_electricityBus_2_5) <= +inf
+   0 <= GenericInvestmentStorageBlock_invest(storage1_0) <= 234
+   0 <= GenericInvestmentStorageBlock_invest(storage1_1) <= 234
+   0 <= GenericInvestmentStorageBlock_invest(storage1_2) <= 234
+   0 <= InvestmentFlowBlock_total(storage1_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage1_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_total(storage1_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage1_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage1_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_total(storage1_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage1_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage1_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage1_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(electricityBus_storage1_0) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage1_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(electricityBus_storage1_1) <= +inf
+   0 <= InvestmentFlowBlock_old(electricityBus_storage1_1) <= +inf
+   0 <= InvestmentFlowBlock_total(electricityBus_storage1_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(electricityBus_storage1_2) <= +inf
+   0 <= InvestmentFlowBlock_old(electricityBus_storage1_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage1_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage1_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage1_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(electricityBus_storage1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(electricityBus_storage1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(electricityBus_storage1_2) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage1_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage1_electricityBus_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage1_electricityBus_2) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(electricityBus_storage1_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(electricityBus_storage1_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(electricityBus_storage1_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage1_electricityBus_0) <= +inf
+   0 <= InvestmentFlowBlock_old(electricityBus_storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_total(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_total(storage1_1) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage1_1) <= +inf
+   0 <= GenericInvestmentStorageBlock_total(storage1_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage1_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_end(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_end(storage1_1) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_end(storage1_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_exo(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_exo(storage1_1) <= +inf
+   0 <= GenericInvestmentStorageBlock_old_exo(storage1_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_old(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_0) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_1) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_2) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_3) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_4) <= +inf
+   0 <= GenericInvestmentStorageBlock_storage_content(storage1_5) <= +inf
+end

--- a/tests/multi_period_constraint_tests.py
+++ b/tests/multi_period_constraint_tests.py
@@ -147,6 +147,39 @@ class TestsMultiPeriodConstraint:
         self.energysystem.add(bgas, bel, converter)
         self.compare_lp_files("linear_converter_invest_multi_period.lp")
 
+    def test_linear_converter_invest_remaining_value(self):
+        """Constraint test of a Converter with Investment."""
+
+        bgas = solph.buses.Bus(label="gas")
+
+        bel = solph.buses.Bus(label="electricity")
+
+        converter = solph.components.Converter(
+            label="powerplant_gas",
+            inputs={bgas: solph.flows.Flow()},
+            outputs={
+                bel: solph.flows.Flow(
+                    variable_costs=50,
+                    investment=solph.Investment(
+                        existing=50,
+                        maximum=1000,
+                        overall_maximum=10000,
+                        overall_minimum=200,
+                        ep_costs=[20, 19, 18],
+                        age=5,
+                        lifetime=40,
+                    ),
+                )
+            },
+            conversion_factors={bel: 0.58},
+        )
+        self.energysystem.use_remaining_value = True
+        self.energysystem.add(bgas, bel, converter)
+        self.compare_lp_files(
+            "linear_converter_invest_multi_period_remaining_value.lp"
+        )
+        self.energysystem.use_remaining_value = False
+
     def test_linear_converter_invest_old_capacity(self):
         """Constraint test of a Converter with Investment."""
 
@@ -364,6 +397,42 @@ class TestsMultiPeriodConstraint:
         )
         self.energysystem.add(bel, storage)
         self.compare_lp_files("storage_invest_1_multi_period.lp")
+
+    def test_storage_invest_1_remaining_value(self):
+        """All invest variables are coupled. The invest variables of the Flows
+        will be created during the initialisation of the storage e.g. battery
+        """
+        bel = solph.buses.Bus(label="electricityBus")
+
+        storage = solph.components.GenericStorage(
+            label="storage1",
+            inputs={bel: solph.flows.Flow(variable_costs=56)},
+            outputs={bel: solph.flows.Flow(variable_costs=24)},
+            nominal_storage_capacity=None,
+            loss_rate=0.13,
+            max_storage_level=0.9,
+            min_storage_level=0.1,
+            invest_relation_input_capacity=1 / 6,
+            invest_relation_output_capacity=1 / 6,
+            lifetime_inflow=20,
+            lifetime_outflow=20,
+            inflow_conversion_factor=0.97,
+            outflow_conversion_factor=0.86,
+            investment=solph.Investment(
+                ep_costs=[145, 130, 115],
+                maximum=234,
+                lifetime=20,
+                interest_rate=0.05,
+                overall_maximum=1000,
+                overall_minimum=2,
+            ),
+        )
+        self.energysystem.use_remaining_value = True
+        self.energysystem.add(bel, storage)
+        self.compare_lp_files(
+            "storage_invest_1_multi_period_remaining_value.lp"
+        )
+        self.energysystem.use_remaining_value = False
 
     def test_storage_invest_2(self):
         """All can be free extended to their own cost."""
@@ -1631,6 +1700,44 @@ class TestsMultiPeriodConstraint:
         self.energysystem.add(b_elec, sinkdsm)
         self.compare_lp_files("dsm_module_DIW_invest_multi_period.lp")
 
+    def test_dsm_module_DIW_invest_remaining_value(self):
+        """Constraint test of SinkDSM with approach=DLR and investments"""
+
+        b_elec = solph.buses.Bus(label="bus_elec")
+        sinkdsm = solph.components.experimental.SinkDSM(
+            label="demand_dsm",
+            inputs={b_elec: solph.flows.Flow()},
+            demand=[1] * 6,
+            capacity_up=[0.5] * 6,
+            capacity_down=[0.5] * 6,
+            approach="DIW",
+            max_demand=[1, 2, 3],
+            delay_time=1,
+            cost_dsm_down_shift=1,
+            cost_dsm_up=1,
+            cost_dsm_down_shed=100,
+            shed_eligibility=True,
+            recovery_time_shed=2,
+            shed_time=2,
+            investment=solph.Investment(
+                ep_costs=[100, 90, 80],
+                existing=50,
+                minimum=33,
+                maximum=100,
+                age=1,
+                lifetime=20,
+                fixed_costs=20,
+                overall_maximum=1000,
+                overall_minimum=5,
+            ),
+        )
+        self.energysystem.use_remaining_value = True
+        self.energysystem.add(b_elec, sinkdsm)
+        self.compare_lp_files(
+            "dsm_module_DIW_invest_multi_period_remaining_value.lp"
+        )
+        self.energysystem.use_remaining_value = False
+
     def test_dsm_module_DLR_invest(self):
         """Constraint test of SinkDSM with approach=DLR and investments"""
 
@@ -1667,6 +1774,46 @@ class TestsMultiPeriodConstraint:
         self.energysystem.add(b_elec, sinkdsm)
         self.compare_lp_files("dsm_module_DLR_invest_multi_period.lp")
 
+    def test_dsm_module_DLR_invest_remaining_value(self):
+        """Constraint test of SinkDSM with approach=DLR and investments"""
+
+        b_elec = solph.buses.Bus(label="bus_elec")
+        sinkdsm = solph.components.experimental.SinkDSM(
+            label="demand_dsm",
+            inputs={b_elec: solph.flows.Flow()},
+            demand=[1] * 6,
+            capacity_up=[0.5] * 6,
+            capacity_down=[0.5] * 6,
+            approach="DLR",
+            max_demand=[1, 2, 3],
+            delay_time=2,
+            shift_time=1,
+            cost_dsm_down_shift=1,
+            cost_dsm_up=1,
+            cost_dsm_down_shed=100,
+            shed_eligibility=True,
+            recovery_time_shed=2,
+            shed_time=2,
+            n_yearLimit_shed=50,
+            investment=solph.Investment(
+                ep_costs=[100, 90, 80],
+                existing=50,
+                minimum=33,
+                maximum=100,
+                age=1,
+                lifetime=20,
+                fixed_costs=20,
+                overall_maximum=1000,
+                overall_minimum=5,
+            ),
+        )
+        self.energysystem.use_remaining_value = True
+        self.energysystem.add(b_elec, sinkdsm)
+        self.compare_lp_files(
+            "dsm_module_DLR_invest_multi_period_remaining_value.lp"
+        )
+        self.energysystem.use_remaining_value = False
+
     def test_dsm_module_oemof_invest(self):
         """Constraint test of SinkDSM with approach=oemof and investments"""
 
@@ -1700,6 +1847,44 @@ class TestsMultiPeriodConstraint:
         )
         self.energysystem.add(b_elec, sinkdsm)
         self.compare_lp_files("dsm_module_oemof_invest_multi_period.lp")
+
+    def test_dsm_module_oemof_invest_remaining_value(self):
+        """Constraint test of SinkDSM with approach=oemof and investments"""
+
+        b_elec = solph.buses.Bus(label="bus_elec")
+        sinkdsm = solph.components.experimental.SinkDSM(
+            label="demand_dsm",
+            inputs={b_elec: solph.flows.Flow()},
+            demand=[1] * 6,
+            capacity_up=[0.5, 0.4, 0.5, 0.3, 0.3, 0.3],
+            capacity_down=[0.5, 0.4, 0.5, 0.3, 0.3, 0.3],
+            approach="oemof",
+            max_demand=[1, 2, 3],
+            shift_interval=2,
+            cost_dsm_down_shift=1,
+            cost_dsm_up=1,
+            cost_dsm_down_shed=100,
+            shed_eligibility=True,
+            recovery_time_shed=2,
+            shed_time=2,
+            investment=solph.Investment(
+                ep_costs=[100, 90, 80],
+                existing=50,
+                minimum=33,
+                maximum=100,
+                age=1,
+                lifetime=20,
+                fixed_costs=20,
+                overall_maximum=1000,
+                overall_minimum=5,
+            ),
+        )
+        self.energysystem.use_remaining_value = True
+        self.energysystem.add(b_elec, sinkdsm)
+        self.compare_lp_files(
+            "dsm_module_oemof_invest_multi_period_remaining_value.lp"
+        )
+        self.energysystem.use_remaining_value = False
 
     def test_nonconvex_investment_storage_without_offset(self):
         """All invest variables are coupled. The invest variables of the Flows


### PR DESCRIPTION
This PR extends #982 

It actually allows for compating the original value of an asset vs. the remaining one and allows for the consideration of changes in investment expenses over time.

In order not to force this as a default behaviour, a boolean switch has been included to switch the functionality on or off as desired.
