### PR TITLE
Fix / update storage investment examples

### DIFF
--- a/examples/storage_investment/v1_invest_optimize_all_technologies.py
+++ b/examples/storage_investment/v1_invest_optimize_all_technologies.py
@@ -191,7 +191,7 @@ def main():
         invest_relation_output_capacity=1 / 6,
         inflow_conversion_factor=1,
         outflow_conversion_factor=0.8,
-        nominal_value=solph.Investment(ep_costs=epc_storage),
+        nominal_storage_capacity=solph.Investment(ep_costs=epc_storage),
     )
 
     energysystem.add(excess, gas_resource, wind, pv, demand, pp_gas, storage)

--- a/examples/storage_investment/v2_invest_optimize_only_gas_and_storage.py
+++ b/examples/storage_investment/v2_invest_optimize_only_gas_and_storage.py
@@ -184,7 +184,7 @@ def main():
         invest_relation_output_capacity=1 / 6,
         inflow_conversion_factor=1,
         outflow_conversion_factor=0.8,
-        nominal_value=solph.Investment(ep_costs=epc_storage),
+        nominal_storage_capacity=solph.Investment(ep_costs=epc_storage),
     )
 
     energysystem.add(excess, gas_resource, wind, pv, demand, pp_gas, storage)

--- a/examples/storage_investment/v3_invest_optimize_only_storage_with_fossil_share.py
+++ b/examples/storage_investment/v3_invest_optimize_only_storage_with_fossil_share.py
@@ -194,7 +194,7 @@ def main():
         invest_relation_output_capacity=1 / 6,
         inflow_conversion_factor=1,
         outflow_conversion_factor=0.8,
-        nominal_value=solph.Investment(ep_costs=epc_storage),
+        nominal_storage_capacity=solph.Investment(ep_costs=epc_storage),
     )
 
     energysystem.add(excess, gas_resource, wind, pv, demand, pp_gas, storage)

--- a/examples/storage_investment/v4_invest_optimize_all_technologies_with_fossil_share.py
+++ b/examples/storage_investment/v4_invest_optimize_all_technologies_with_fossil_share.py
@@ -202,7 +202,7 @@ def main():
         invest_relation_output_capacity=1 / 6,
         inflow_conversion_factor=1,
         outflow_conversion_factor=0.8,
-        investment=solph.Investment(ep_costs=epc_storage),
+        nominal_storage_capacity=solph.Investment(ep_costs=epc_storage),
     )
 
     energysystem.add(excess, gas_resource, wind, pv, demand, pp_gas, storage)


### PR DESCRIPTION
Closes #1014

* Fixes errouneous usage of `nominal_capacity` instead of `nominal_storage_capacity` for storage examples.
* Replaces `investment` attribute for example v4 as this is the upcoming standard.
