### PR TITLE
Remove duplicated discounting

### DIFF
--- a/docs/whatsnew/v0-5-2.rst
+++ b/docs/whatsnew/v0-5-2.rst
@@ -23,6 +23,7 @@ Bug fixes
   bias towards investments happening earlier in the optimization horizon.
 * Fix bugs in multi-period documentation.
 * Fix y intersect of OffsetConverter
+* Fix duplicated discounting of fixed costs for multi-period investment
 
 Testing
 #######

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -1869,7 +1869,7 @@ class GenericInvestmentStorageBlock(ScalarBlock):
                                 m.es.periods_years[p],
                                 range_limit,
                             )
-                        ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
+                        )
 
             for n in self.EXISTING_INVESTSTORAGES:
                 if n.investment.fixed_costs[0] is not None:

--- a/src/oemof/solph/components/experimental/_sink_dsm.py
+++ b/src/oemof/solph/components/experimental/_sink_dsm.py
@@ -1447,7 +1447,7 @@ class SinkDSMOemofInvestmentBlock(ScalarBlock):
                                 m.es.periods_years[p],
                                 range_limit,
                             )
-                        ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
+                        )
 
             for g in self.EXISTING_INVESTDSM:
                 if g.investment.fixed_costs[0] is not None:
@@ -3301,7 +3301,7 @@ class SinkDSMDIWInvestmentBlock(ScalarBlock):
                                 m.es.periods_years[p],
                                 range_limit,
                             )
-                        ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
+                        )
 
             for g in self.EXISTING_INVESTDSM:
                 if g.investment.fixed_costs[0] is not None:
@@ -5800,7 +5800,7 @@ class SinkDSMDLRInvestmentBlock(ScalarBlock):
                                 m.es.periods_years[p],
                                 range_limit,
                             )
-                        ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
+                        )
 
             for g in self.EXISTING_INVESTDSM:
                 if g.investment.fixed_costs[0] is not None:

--- a/src/oemof/solph/flows/_investment_flow_block.py
+++ b/src/oemof/solph/flows/_investment_flow_block.py
@@ -1026,7 +1026,7 @@ class InvestmentFlowBlock(ScalarBlock):
                                 m.es.periods_years[p],
                                 range_limit,
                             )
-                        ) * (1 + m.discount_rate) ** (-m.es.periods_years[p])
+                        )
 
             for i, o in self.EXISTING_INVESTFLOWS:
                 if m.flows[i, o].investment.fixed_costs[0] is not None:

--- a/src/oemof/solph/flows/_investment_flow_block.py
+++ b/src/oemof/solph/flows/_investment_flow_block.py
@@ -1022,9 +1022,7 @@ class InvestmentFlowBlock(ScalarBlock):
                             self.invest[i, o, p]
                             * m.flows[i, o].investment.fixed_costs[pp]
                             * (1 + m.discount_rate) ** (-pp)
-                            for pp in range(
-                                m.es.periods_years[p],
-                                range_limit)
+                            for pp in range(m.es.periods_years[p], range_limit)
                         )
 
             for i, o in self.EXISTING_INVESTFLOWS:

--- a/src/oemof/solph/flows/_investment_flow_block.py
+++ b/src/oemof/solph/flows/_investment_flow_block.py
@@ -1024,8 +1024,7 @@ class InvestmentFlowBlock(ScalarBlock):
                             * (1 + m.discount_rate) ** (-pp)
                             for pp in range(
                                 m.es.periods_years[p],
-                                range_limit,
-                            )
+                                range_limit)
                         )
 
             for i, o in self.EXISTING_INVESTFLOWS:

--- a/tests/lp_files/converter_invest_multi_period.lp
+++ b/tests/lp_files/converter_invest_multi_period.lp
@@ -2,9 +2,9 @@
 
 min 
 objective:
-+3.5273767282312036 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_0)
-+2.328225392441188 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_1)
-+1.1525868279411837 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_2)
++32.94298610923851 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_0)
++21.74383477344849 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_1)
++10.764274640321037 InvestmentFlowBlock_invest(powerplant_gas_coal_electricityBus_2)
 +50 flow(powerplant_gas_coal_electricityBus_0_0)
 +50 flow(powerplant_gas_coal_electricityBus_0_1)
 +49.01960784313725 flow(powerplant_gas_coal_electricityBus_1_2)
@@ -44,28 +44,28 @@ c_e_BusBlock_balance(electricityBus_2_5)_:
 +1 flow(powerplant_gas_coal_electricityBus_2_5)
 = 0
 
-c_e_BusBlock_balance(gasBus_0_0)_:
-+1 flow(gasBus_powerplant_gas_coal_0_0)
+c_e_BusBlock_balance(coalBus_0_0)_:
++1 flow(coalBus_powerplant_gas_coal_0_0)
 = 0
 
-c_e_BusBlock_balance(gasBus_0_1)_:
-+1 flow(gasBus_powerplant_gas_coal_0_1)
+c_e_BusBlock_balance(coalBus_0_1)_:
++1 flow(coalBus_powerplant_gas_coal_0_1)
 = 0
 
-c_e_BusBlock_balance(gasBus_1_2)_:
-+1 flow(gasBus_powerplant_gas_coal_1_2)
+c_e_BusBlock_balance(coalBus_1_2)_:
++1 flow(coalBus_powerplant_gas_coal_1_2)
 = 0
 
-c_e_BusBlock_balance(gasBus_1_3)_:
-+1 flow(gasBus_powerplant_gas_coal_1_3)
+c_e_BusBlock_balance(coalBus_1_3)_:
++1 flow(coalBus_powerplant_gas_coal_1_3)
 = 0
 
-c_e_BusBlock_balance(gasBus_2_4)_:
-+1 flow(gasBus_powerplant_gas_coal_2_4)
+c_e_BusBlock_balance(coalBus_2_4)_:
++1 flow(coalBus_powerplant_gas_coal_2_4)
 = 0
 
-c_e_BusBlock_balance(gasBus_2_5)_:
-+1 flow(gasBus_powerplant_gas_coal_2_5)
+c_e_BusBlock_balance(coalBus_2_5)_:
++1 flow(coalBus_powerplant_gas_coal_2_5)
 = 0
 
 c_e_BusBlock_balance(thermalBus_0_0)_:
@@ -92,33 +92,28 @@ c_e_BusBlock_balance(thermalBus_2_5)_:
 +1 flow(powerplant_gas_coal_thermalBus_2_5)
 = 0
 
-c_e_BusBlock_balance(coalBus_0_0)_:
-+1 flow(coalBus_powerplant_gas_coal_0_0)
+c_e_BusBlock_balance(gasBus_0_0)_:
++1 flow(gasBus_powerplant_gas_coal_0_0)
 = 0
 
-c_e_BusBlock_balance(coalBus_0_1)_:
-+1 flow(coalBus_powerplant_gas_coal_0_1)
+c_e_BusBlock_balance(gasBus_0_1)_:
++1 flow(gasBus_powerplant_gas_coal_0_1)
 = 0
 
-c_e_BusBlock_balance(coalBus_1_2)_:
-+1 flow(coalBus_powerplant_gas_coal_1_2)
+c_e_BusBlock_balance(gasBus_1_2)_:
++1 flow(gasBus_powerplant_gas_coal_1_2)
 = 0
 
-c_e_BusBlock_balance(coalBus_1_3)_:
-+1 flow(coalBus_powerplant_gas_coal_1_3)
+c_e_BusBlock_balance(gasBus_1_3)_:
++1 flow(gasBus_powerplant_gas_coal_1_3)
 = 0
 
-c_e_BusBlock_balance(coalBus_2_4)_:
-+1 flow(coalBus_powerplant_gas_coal_2_4)
+c_e_BusBlock_balance(gasBus_2_4)_:
++1 flow(gasBus_powerplant_gas_coal_2_4)
 = 0
 
-c_e_BusBlock_balance(coalBus_2_5)_:
-+1 flow(coalBus_powerplant_gas_coal_2_5)
-= 0
-
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_0_0)_:
--0.58 flow(powerplant_gas_coal_electricityBus_0_0)
-+0.3 flow(gasBus_powerplant_gas_coal_0_0)
+c_e_BusBlock_balance(gasBus_2_5)_:
++1 flow(gasBus_powerplant_gas_coal_2_5)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_0_0)_:
@@ -126,9 +121,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_0_0)_:
 +0.3 flow(coalBus_powerplant_gas_coal_0_0)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_0_0)_:
--0.58 flow(powerplant_gas_coal_thermalBus_0_0)
-+0.5 flow(gasBus_powerplant_gas_coal_0_0)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_0_0)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_0_0)
++0.3 flow(gasBus_powerplant_gas_coal_0_0)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_0_0)_:
@@ -136,9 +131,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_0_0)_:
 +0.5 flow(coalBus_powerplant_gas_coal_0_0)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_0_1)_:
--0.58 flow(powerplant_gas_coal_electricityBus_0_1)
-+0.3 flow(gasBus_powerplant_gas_coal_0_1)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_0_0)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_0_0)
++0.5 flow(gasBus_powerplant_gas_coal_0_0)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_0_1)_:
@@ -146,9 +141,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_0_1)_:
 +0.3 flow(coalBus_powerplant_gas_coal_0_1)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_0_1)_:
--0.58 flow(powerplant_gas_coal_thermalBus_0_1)
-+0.5 flow(gasBus_powerplant_gas_coal_0_1)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_0_1)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_0_1)
++0.3 flow(gasBus_powerplant_gas_coal_0_1)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_0_1)_:
@@ -156,9 +151,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_0_1)_:
 +0.5 flow(coalBus_powerplant_gas_coal_0_1)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_1_2)_:
--0.58 flow(powerplant_gas_coal_electricityBus_1_2)
-+0.3 flow(gasBus_powerplant_gas_coal_1_2)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_0_1)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_0_1)
++0.5 flow(gasBus_powerplant_gas_coal_0_1)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_1_2)_:
@@ -166,9 +161,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_1_2)_:
 +0.3 flow(coalBus_powerplant_gas_coal_1_2)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_1_2)_:
--0.58 flow(powerplant_gas_coal_thermalBus_1_2)
-+0.5 flow(gasBus_powerplant_gas_coal_1_2)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_1_2)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_1_2)
++0.3 flow(gasBus_powerplant_gas_coal_1_2)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_1_2)_:
@@ -176,9 +171,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_1_2)_:
 +0.5 flow(coalBus_powerplant_gas_coal_1_2)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_1_3)_:
--0.58 flow(powerplant_gas_coal_electricityBus_1_3)
-+0.3 flow(gasBus_powerplant_gas_coal_1_3)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_1_2)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_1_2)
++0.5 flow(gasBus_powerplant_gas_coal_1_2)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_1_3)_:
@@ -186,9 +181,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_1_3)_:
 +0.3 flow(coalBus_powerplant_gas_coal_1_3)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_1_3)_:
--0.58 flow(powerplant_gas_coal_thermalBus_1_3)
-+0.5 flow(gasBus_powerplant_gas_coal_1_3)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_1_3)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_1_3)
++0.3 flow(gasBus_powerplant_gas_coal_1_3)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_1_3)_:
@@ -196,9 +191,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_1_3)_:
 +0.5 flow(coalBus_powerplant_gas_coal_1_3)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_2_4)_:
--0.58 flow(powerplant_gas_coal_electricityBus_2_4)
-+0.3 flow(gasBus_powerplant_gas_coal_2_4)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_1_3)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_1_3)
++0.5 flow(gasBus_powerplant_gas_coal_1_3)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_2_4)_:
@@ -206,9 +201,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_2_4)_:
 +0.3 flow(coalBus_powerplant_gas_coal_2_4)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_2_4)_:
--0.58 flow(powerplant_gas_coal_thermalBus_2_4)
-+0.5 flow(gasBus_powerplant_gas_coal_2_4)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_2_4)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_2_4)
++0.3 flow(gasBus_powerplant_gas_coal_2_4)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_2_4)_:
@@ -216,9 +211,9 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_2_4)_:
 +0.5 flow(coalBus_powerplant_gas_coal_2_4)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_2_5)_:
--0.58 flow(powerplant_gas_coal_electricityBus_2_5)
-+0.3 flow(gasBus_powerplant_gas_coal_2_5)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_2_4)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_2_4)
++0.5 flow(gasBus_powerplant_gas_coal_2_4)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_2_5)_:
@@ -226,14 +221,19 @@ c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_electricityBus_2_5)_:
 +0.3 flow(coalBus_powerplant_gas_coal_2_5)
 = 0
 
-c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_2_5)_:
--0.58 flow(powerplant_gas_coal_thermalBus_2_5)
-+0.5 flow(gasBus_powerplant_gas_coal_2_5)
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_electricityBus_2_5)_:
+-0.58 flow(powerplant_gas_coal_electricityBus_2_5)
++0.3 flow(gasBus_powerplant_gas_coal_2_5)
 = 0
 
 c_e_ConverterBlock_relation(powerplant_gas_coal_coalBus_thermalBus_2_5)_:
 -0.2 flow(powerplant_gas_coal_thermalBus_2_5)
 +0.5 flow(coalBus_powerplant_gas_coal_2_5)
+= 0
+
+c_e_ConverterBlock_relation(powerplant_gas_coal_gasBus_thermalBus_2_5)_:
+-0.58 flow(powerplant_gas_coal_thermalBus_2_5)
++0.5 flow(gasBus_powerplant_gas_coal_2_5)
 = 0
 
 c_e_InvestmentFlowBlock_total_rule(powerplant_gas_coal_electricityBus_0)_:
@@ -343,18 +343,18 @@ bounds
    0 <= flow(powerplant_gas_coal_thermalBus_1_3) <= +inf
    0 <= flow(powerplant_gas_coal_thermalBus_2_4) <= +inf
    0 <= flow(powerplant_gas_coal_thermalBus_2_5) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_0_0) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_0_1) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_1_2) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_1_3) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_2_4) <= +inf
-   0 <= flow(gasBus_powerplant_gas_coal_2_5) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_0_0) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_0_1) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_1_2) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_1_3) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_2_4) <= +inf
    0 <= flow(coalBus_powerplant_gas_coal_2_5) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_0_0) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_0_1) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_1_2) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_1_3) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_2_4) <= +inf
+   0 <= flow(gasBus_powerplant_gas_coal_2_5) <= +inf
    0 <= InvestmentFlowBlock_total(powerplant_gas_coal_electricityBus_0) <= +inf
    0 <= InvestmentFlowBlock_total(powerplant_gas_coal_electricityBus_1) <= +inf
    0 <= InvestmentFlowBlock_old(powerplant_gas_coal_electricityBus_1) <= +inf

--- a/tests/lp_files/dsm_module_DIW_invest_multi_period.lp
+++ b/tests/lp_files/dsm_module_DIW_invest_multi_period.lp
@@ -52,8 +52,8 @@ objective:
 +0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
 +96.11687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +76.46810240317063 SinkDSMDIWInvestmentBlock_invest(demand_dsm_0)
-+49.710949277906536 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
-+24.239842660236203 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
++50.47234572422055 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
++24.986309764465627 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/dsm_module_DIW_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_DIW_invest_multi_period_remaining_value.lp
@@ -52,8 +52,8 @@ objective:
 +0.9611687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_5_5)
 +96.11687812379853 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +57.62165571222974 SinkDSMDIWInvestmentBlock_invest(demand_dsm_0)
-+39.12361323621548 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
-+23.087255832295018 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
++39.8850096825295 SinkDSMDIWInvestmentBlock_invest(demand_dsm_1)
++23.833722936524442 SinkDSMDIWInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
+++ b/tests/lp_files/dsm_module_DLR_invest_multi_period.lp
@@ -58,8 +58,8 @@ objective:
 +0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
 +96.11687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +76.46810240317063 SinkDSMDLRInvestmentBlock_invest(demand_dsm_0)
-+49.710949277906536 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
-+24.239842660236203 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
++50.47234572422055 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
++24.986309764465627 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/dsm_module_DLR_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_DLR_invest_multi_period_remaining_value.lp
@@ -58,8 +58,8 @@ objective:
 +0.9611687812379853 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_2_5)
 +96.11687812379853 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +57.62165571222974 SinkDSMDLRInvestmentBlock_invest(demand_dsm_0)
-+39.12361323621548 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
-+23.087255832295018 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
++39.8850096825295 SinkDSMDLRInvestmentBlock_invest(demand_dsm_1)
++23.833722936524442 SinkDSMDLRInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/dsm_module_oemof_extended.lp
+++ b/tests/lp_files/dsm_module_oemof_extended.lp
@@ -79,7 +79,7 @@ c_e_SinkDSMOemofBlock_dsm_sum_constraint(demand_dsm_0)_:
 +0.99 SinkDSMOemofBlock_dsm_up(demand_dsm_0)
 +0.99 SinkDSMOemofBlock_dsm_up(demand_dsm_1)
 -1 SinkDSMOemofBlock_dsm_do_shift(demand_dsm_1)
-= 0.0
+= 0
 
 bounds
    0 <= SinkDSMOemofBlock_dsm_do_shift(demand_dsm_0) <= +inf

--- a/tests/lp_files/dsm_module_oemof_invest_multi_period.lp
+++ b/tests/lp_files/dsm_module_oemof_invest_multi_period.lp
@@ -22,8 +22,8 @@ objective:
 +0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
 +96.11687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +76.46810240317063 SinkDSMOemofInvestmentBlock_invest(demand_dsm_0)
-+49.710949277906536 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
-+24.239842660236203 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
++50.47234572422055 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
++24.986309764465627 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/dsm_module_oemof_invest_multi_period_remaining_value.lp
+++ b/tests/lp_files/dsm_module_oemof_invest_multi_period_remaining_value.lp
@@ -22,8 +22,8 @@ objective:
 +0.9611687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_5)
 +96.11687812379853 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_5)
 +57.62165571222974 SinkDSMOemofInvestmentBlock_invest(demand_dsm_0)
-+39.12361323621548 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
-+23.087255832295018 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
++39.8850096825295 SinkDSMOemofInvestmentBlock_invest(demand_dsm_1)
++23.833722936524442 SinkDSMOemofInvestmentBlock_invest(demand_dsm_2)
 
 s.t.
 

--- a/tests/lp_files/multi_period_period_length.lp
+++ b/tests/lp_files/multi_period_period_length.lp
@@ -3,14 +3,6 @@
 min 
 objective:
 +15992.031251718836 ONE_VAR_CONSTANT
-+9.999999999999998 InvestmentFlowBlock_invest(storage_electricity_0)
-+6.729713331080573 InvestmentFlowBlock_invest(storage_electricity_1)
-+5.000276133592968 InvestmentFlowBlock_invest(storage_electricity_2)
-+4.101968025099305 InvestmentFlowBlock_invest(storage_electricity_3)
-+3.7152788212696146 InvestmentFlowBlock_invest(storage_electricity_4)
-+3.0478226645906985 InvestmentFlowBlock_invest(storage_electricity_5)
-+2.264577134183746 InvestmentFlowBlock_invest(storage_electricity_6)
-+0.09137506155350818 InvestmentFlowBlock_invest(storage_electricity_7)
 +9.999999999999998 InvestmentFlowBlock_invest(electricity_storage_0)
 +6.729713331080573 InvestmentFlowBlock_invest(electricity_storage_1)
 +5.000276133592968 InvestmentFlowBlock_invest(electricity_storage_2)
@@ -19,6 +11,14 @@ objective:
 +3.0478226645906985 InvestmentFlowBlock_invest(electricity_storage_5)
 +2.264577134183746 InvestmentFlowBlock_invest(electricity_storage_6)
 +0.09137506155350818 InvestmentFlowBlock_invest(electricity_storage_7)
++9.999999999999998 InvestmentFlowBlock_invest(storage_electricity_0)
++6.729713331080573 InvestmentFlowBlock_invest(storage_electricity_1)
++5.000276133592968 InvestmentFlowBlock_invest(storage_electricity_2)
++4.101968025099305 InvestmentFlowBlock_invest(storage_electricity_3)
++3.7152788212696146 InvestmentFlowBlock_invest(storage_electricity_4)
++3.0478226645906985 InvestmentFlowBlock_invest(storage_electricity_5)
++2.264577134183746 InvestmentFlowBlock_invest(storage_electricity_6)
++0.09137506155350818 InvestmentFlowBlock_invest(storage_electricity_7)
 +9.999999999999998 GenericInvestmentStorageBlock_invest(storage_0)
 +6.729713331080573 GenericInvestmentStorageBlock_invest(storage_1)
 +5.000276133592968 GenericInvestmentStorageBlock_invest(storage_2)
@@ -652,13 +652,13 @@ objective:
 +0.15239954929176602 SinkDSMDIWInvestmentBlock_dsm_do_shift(demand_dsm_diw_23_23)
 +15.239954929176601 SinkDSMDIWInvestmentBlock_dsm_do_shed(demand_dsm_diw_23)
 +433.5692402297811 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_0)
-+218.36744501149502 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_1)
-+133.4042826150016 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_2)
-+97.1465132094101 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_3)
-+83.19634020751037 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_4)
-+61.46421721288727 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_5)
-+39.75223470007343 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_6)
-+1.3782630680217502 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_7)
++291.77966959208334 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_1)
++216.7965924181011 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_2)
++177.8487160089162 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_3)
++161.08306157796636 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_4)
++132.1442157041696 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_5)
++98.1850987509782 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_6)
++3.9617416013704023 SinkDSMDIWInvestmentBlock_invest(demand_dsm_diw_7)
 +1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_dlr_1_0)
 +1 SinkDSMDLRInvestmentBlock_balance_dsm_do(demand_dsm_dlr_1_0)
 +1 SinkDSMDLRInvestmentBlock_dsm_up(demand_dsm_dlr_2_0)
@@ -876,13 +876,13 @@ objective:
 +0.15239954929176602 SinkDSMDLRInvestmentBlock_balance_dsm_up(demand_dsm_dlr_2_23)
 +15.239954929176601 SinkDSMDLRInvestmentBlock_dsm_do_shed(demand_dsm_dlr_23)
 +433.5692402297811 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_0)
-+218.36744501149502 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_1)
-+133.4042826150016 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_2)
-+97.1465132094101 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_3)
-+83.19634020751037 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_4)
-+61.46421721288727 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_5)
-+39.75223470007343 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_6)
-+1.3782630680217502 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_7)
++291.77966959208334 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_1)
++216.7965924181011 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_2)
++177.8487160089162 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_3)
++161.08306157796636 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_4)
++132.1442157041696 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_5)
++98.1850987509782 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_6)
++3.9617416013704023 SinkDSMDLRInvestmentBlock_invest(demand_dsm_dlr_7)
 +1 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_oemof_0)
 +100 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_oemof_0)
 +1 SinkDSMOemofInvestmentBlock_dsm_up(demand_dsm_oemof_0)
@@ -956,13 +956,13 @@ objective:
 +0.15239954929176602 SinkDSMOemofInvestmentBlock_dsm_do_shift(demand_dsm_oemof_23)
 +15.239954929176601 SinkDSMOemofInvestmentBlock_dsm_do_shed(demand_dsm_oemof_23)
 +433.5692402297811 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_0)
-+218.36744501149502 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_1)
-+133.4042826150016 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_2)
-+97.1465132094101 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_3)
-+83.19634020751037 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_4)
-+61.46421721288727 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_5)
-+39.75223470007343 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_6)
-+1.3782630680217502 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_7)
++291.77966959208334 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_1)
++216.7965924181011 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_2)
++177.8487160089162 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_3)
++161.08306157796636 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_4)
++132.1442157041696 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_5)
++98.1850987509782 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_6)
++3.9617416013704023 SinkDSMOemofInvestmentBlock_invest(demand_dsm_oemof_7)
 
 s.t.
 
@@ -1158,60 +1158,6 @@ c_e_BusBlock_balance(electricity_7_23)_:
 -1 flow(electricity_demand_dsm_oemof_7_23)
 = 0
 
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_0)_:
--1 InvestmentFlowBlock_invest(storage_electricity_0)
-+1 InvestmentFlowBlock_total(storage_electricity_0)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_1)_:
--1 InvestmentFlowBlock_invest(storage_electricity_1)
--1 InvestmentFlowBlock_total(storage_electricity_0)
-+1 InvestmentFlowBlock_total(storage_electricity_1)
-+1 InvestmentFlowBlock_old(storage_electricity_1)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_2)_:
--1 InvestmentFlowBlock_invest(storage_electricity_2)
--1 InvestmentFlowBlock_total(storage_electricity_1)
-+1 InvestmentFlowBlock_total(storage_electricity_2)
-+1 InvestmentFlowBlock_old(storage_electricity_2)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_3)_:
--1 InvestmentFlowBlock_invest(storage_electricity_3)
--1 InvestmentFlowBlock_total(storage_electricity_2)
-+1 InvestmentFlowBlock_total(storage_electricity_3)
-+1 InvestmentFlowBlock_old(storage_electricity_3)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_4)_:
--1 InvestmentFlowBlock_invest(storage_electricity_4)
--1 InvestmentFlowBlock_total(storage_electricity_3)
-+1 InvestmentFlowBlock_total(storage_electricity_4)
-+1 InvestmentFlowBlock_old(storage_electricity_4)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_5)_:
--1 InvestmentFlowBlock_invest(storage_electricity_5)
--1 InvestmentFlowBlock_total(storage_electricity_4)
-+1 InvestmentFlowBlock_total(storage_electricity_5)
-+1 InvestmentFlowBlock_old(storage_electricity_5)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_6)_:
--1 InvestmentFlowBlock_invest(storage_electricity_6)
--1 InvestmentFlowBlock_total(storage_electricity_5)
-+1 InvestmentFlowBlock_total(storage_electricity_6)
-+1 InvestmentFlowBlock_old(storage_electricity_6)
-= 0
-
-c_e_InvestmentFlowBlock_total_rule(storage_electricity_7)_:
--1 InvestmentFlowBlock_invest(storage_electricity_7)
--1 InvestmentFlowBlock_total(storage_electricity_6)
-+1 InvestmentFlowBlock_total(storage_electricity_7)
-+1 InvestmentFlowBlock_old(storage_electricity_7)
-= 0
-
 c_e_InvestmentFlowBlock_total_rule(electricity_storage_0)_:
 -1 InvestmentFlowBlock_invest(electricity_storage_0)
 +1 InvestmentFlowBlock_total(electricity_storage_0)
@@ -1266,43 +1212,58 @@ c_e_InvestmentFlowBlock_total_rule(electricity_storage_7)_:
 +1 InvestmentFlowBlock_old(electricity_storage_7)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_0)_:
-+1 InvestmentFlowBlock_old_end(storage_electricity_0)
-= 0
-
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_1)_:
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_0)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_0)
-+1 InvestmentFlowBlock_old_end(storage_electricity_1)
++1 InvestmentFlowBlock_total(storage_electricity_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_2)_:
-+1 InvestmentFlowBlock_old_end(storage_electricity_2)
-= 0
-
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_3)_:
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_1)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_1)
-+1 InvestmentFlowBlock_old_end(storage_electricity_3)
+-1 InvestmentFlowBlock_total(storage_electricity_0)
++1 InvestmentFlowBlock_total(storage_electricity_1)
++1 InvestmentFlowBlock_old(storage_electricity_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_4)_:
-+1 InvestmentFlowBlock_old_end(storage_electricity_4)
-= 0
-
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_5)_:
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_2)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_2)
-+1 InvestmentFlowBlock_old_end(storage_electricity_5)
+-1 InvestmentFlowBlock_total(storage_electricity_1)
++1 InvestmentFlowBlock_total(storage_electricity_2)
++1 InvestmentFlowBlock_old(storage_electricity_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_6)_:
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_3)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_3)
--1 InvestmentFlowBlock_invest(storage_electricity_4)
-+1 InvestmentFlowBlock_old_end(storage_electricity_6)
+-1 InvestmentFlowBlock_total(storage_electricity_2)
++1 InvestmentFlowBlock_total(storage_electricity_3)
++1 InvestmentFlowBlock_old(storage_electricity_3)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_7)_:
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_4)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_4)
+-1 InvestmentFlowBlock_total(storage_electricity_3)
++1 InvestmentFlowBlock_total(storage_electricity_4)
++1 InvestmentFlowBlock_old(storage_electricity_4)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_5)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_5)
+-1 InvestmentFlowBlock_total(storage_electricity_4)
++1 InvestmentFlowBlock_total(storage_electricity_5)
++1 InvestmentFlowBlock_old(storage_electricity_5)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_6)_:
 -1 InvestmentFlowBlock_invest(storage_electricity_6)
-+1 InvestmentFlowBlock_old_end(storage_electricity_7)
+-1 InvestmentFlowBlock_total(storage_electricity_5)
++1 InvestmentFlowBlock_total(storage_electricity_6)
++1 InvestmentFlowBlock_old(storage_electricity_6)
+= 0
+
+c_e_InvestmentFlowBlock_total_rule(storage_electricity_7)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_7)
+-1 InvestmentFlowBlock_total(storage_electricity_6)
++1 InvestmentFlowBlock_total(storage_electricity_7)
++1 InvestmentFlowBlock_old(storage_electricity_7)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_end(electricity_storage_0)_:
@@ -1344,36 +1305,43 @@ c_e_InvestmentFlowBlock_old_rule_end(electricity_storage_7)_:
 +1 InvestmentFlowBlock_old_end(electricity_storage_7)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_0)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_0)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_0)_:
++1 InvestmentFlowBlock_old_end(storage_electricity_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_1)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_1)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_1)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_0)
++1 InvestmentFlowBlock_old_end(storage_electricity_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_2)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_2)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_2)_:
++1 InvestmentFlowBlock_old_end(storage_electricity_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_3)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_3)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_3)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_1)
++1 InvestmentFlowBlock_old_end(storage_electricity_3)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_4)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_4)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_4)_:
++1 InvestmentFlowBlock_old_end(storage_electricity_4)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_5)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_5)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_5)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_2)
++1 InvestmentFlowBlock_old_end(storage_electricity_5)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_6)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_6)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_6)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_3)
+-1 InvestmentFlowBlock_invest(storage_electricity_4)
++1 InvestmentFlowBlock_old_end(storage_electricity_6)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_7)_:
-+1 InvestmentFlowBlock_old_exo(storage_electricity_7)
+c_e_InvestmentFlowBlock_old_rule_end(storage_electricity_7)_:
+-1 InvestmentFlowBlock_invest(storage_electricity_5)
+-1 InvestmentFlowBlock_invest(storage_electricity_6)
++1 InvestmentFlowBlock_old_end(storage_electricity_7)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule_exo(electricity_storage_0)_:
@@ -1408,52 +1376,36 @@ c_e_InvestmentFlowBlock_old_rule_exo(electricity_storage_7)_:
 +1 InvestmentFlowBlock_old_exo(electricity_storage_7)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_0)_:
--1 InvestmentFlowBlock_old_end(storage_electricity_0)
--1 InvestmentFlowBlock_old_exo(storage_electricity_0)
-+1 InvestmentFlowBlock_old(storage_electricity_0)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_0)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_0)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_1)_:
-+1 InvestmentFlowBlock_old(storage_electricity_1)
--1 InvestmentFlowBlock_old_end(storage_electricity_1)
--1 InvestmentFlowBlock_old_exo(storage_electricity_1)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_1)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_1)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_2)_:
-+1 InvestmentFlowBlock_old(storage_electricity_2)
--1 InvestmentFlowBlock_old_end(storage_electricity_2)
--1 InvestmentFlowBlock_old_exo(storage_electricity_2)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_2)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_2)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_3)_:
-+1 InvestmentFlowBlock_old(storage_electricity_3)
--1 InvestmentFlowBlock_old_end(storage_electricity_3)
--1 InvestmentFlowBlock_old_exo(storage_electricity_3)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_3)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_3)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_4)_:
-+1 InvestmentFlowBlock_old(storage_electricity_4)
--1 InvestmentFlowBlock_old_end(storage_electricity_4)
--1 InvestmentFlowBlock_old_exo(storage_electricity_4)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_4)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_4)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_5)_:
-+1 InvestmentFlowBlock_old(storage_electricity_5)
--1 InvestmentFlowBlock_old_end(storage_electricity_5)
--1 InvestmentFlowBlock_old_exo(storage_electricity_5)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_5)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_5)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_6)_:
-+1 InvestmentFlowBlock_old(storage_electricity_6)
--1 InvestmentFlowBlock_old_end(storage_electricity_6)
--1 InvestmentFlowBlock_old_exo(storage_electricity_6)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_6)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_6)
 = 0
 
-c_e_InvestmentFlowBlock_old_rule(storage_electricity_7)_:
-+1 InvestmentFlowBlock_old(storage_electricity_7)
--1 InvestmentFlowBlock_old_end(storage_electricity_7)
--1 InvestmentFlowBlock_old_exo(storage_electricity_7)
+c_e_InvestmentFlowBlock_old_rule_exo(storage_electricity_7)_:
++1 InvestmentFlowBlock_old_exo(storage_electricity_7)
 = 0
 
 c_e_InvestmentFlowBlock_old_rule(electricity_storage_0)_:
@@ -1504,125 +1456,53 @@ c_e_InvestmentFlowBlock_old_rule(electricity_storage_7)_:
 -1 InvestmentFlowBlock_old_exo(electricity_storage_7)
 = 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_0_0)_:
-+1 flow(storage_electricity_0_0)
--1 InvestmentFlowBlock_total(storage_electricity_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_0)_:
+-1 InvestmentFlowBlock_old_end(storage_electricity_0)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_0)
++1 InvestmentFlowBlock_old(storage_electricity_0)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_0_1)_:
-+1 flow(storage_electricity_0_1)
--1 InvestmentFlowBlock_total(storage_electricity_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_1)_:
++1 InvestmentFlowBlock_old(storage_electricity_1)
+-1 InvestmentFlowBlock_old_end(storage_electricity_1)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_1)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_0_2)_:
-+1 flow(storage_electricity_0_2)
--1 InvestmentFlowBlock_total(storage_electricity_0)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_2)_:
++1 InvestmentFlowBlock_old(storage_electricity_2)
+-1 InvestmentFlowBlock_old_end(storage_electricity_2)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_2)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_1_3)_:
-+1 flow(storage_electricity_1_3)
--1 InvestmentFlowBlock_total(storage_electricity_1)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_3)_:
++1 InvestmentFlowBlock_old(storage_electricity_3)
+-1 InvestmentFlowBlock_old_end(storage_electricity_3)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_3)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_1_4)_:
-+1 flow(storage_electricity_1_4)
--1 InvestmentFlowBlock_total(storage_electricity_1)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_4)_:
++1 InvestmentFlowBlock_old(storage_electricity_4)
+-1 InvestmentFlowBlock_old_end(storage_electricity_4)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_4)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_1_5)_:
-+1 flow(storage_electricity_1_5)
--1 InvestmentFlowBlock_total(storage_electricity_1)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_5)_:
++1 InvestmentFlowBlock_old(storage_electricity_5)
+-1 InvestmentFlowBlock_old_end(storage_electricity_5)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_5)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_2_6)_:
-+1 flow(storage_electricity_2_6)
--1 InvestmentFlowBlock_total(storage_electricity_2)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_6)_:
++1 InvestmentFlowBlock_old(storage_electricity_6)
+-1 InvestmentFlowBlock_old_end(storage_electricity_6)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_6)
+= 0
 
-c_u_InvestmentFlowBlock_max(storage_electricity_2_7)_:
-+1 flow(storage_electricity_2_7)
--1 InvestmentFlowBlock_total(storage_electricity_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_2_8)_:
-+1 flow(storage_electricity_2_8)
--1 InvestmentFlowBlock_total(storage_electricity_2)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_3_9)_:
-+1 flow(storage_electricity_3_9)
--1 InvestmentFlowBlock_total(storage_electricity_3)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_3_10)_:
-+1 flow(storage_electricity_3_10)
--1 InvestmentFlowBlock_total(storage_electricity_3)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_3_11)_:
-+1 flow(storage_electricity_3_11)
--1 InvestmentFlowBlock_total(storage_electricity_3)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_4_12)_:
-+1 flow(storage_electricity_4_12)
--1 InvestmentFlowBlock_total(storage_electricity_4)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_4_13)_:
-+1 flow(storage_electricity_4_13)
--1 InvestmentFlowBlock_total(storage_electricity_4)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_4_14)_:
-+1 flow(storage_electricity_4_14)
--1 InvestmentFlowBlock_total(storage_electricity_4)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_5_15)_:
-+1 flow(storage_electricity_5_15)
--1 InvestmentFlowBlock_total(storage_electricity_5)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_5_16)_:
-+1 flow(storage_electricity_5_16)
--1 InvestmentFlowBlock_total(storage_electricity_5)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_5_17)_:
-+1 flow(storage_electricity_5_17)
--1 InvestmentFlowBlock_total(storage_electricity_5)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_6_18)_:
-+1 flow(storage_electricity_6_18)
--1 InvestmentFlowBlock_total(storage_electricity_6)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_6_19)_:
-+1 flow(storage_electricity_6_19)
--1 InvestmentFlowBlock_total(storage_electricity_6)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_6_20)_:
-+1 flow(storage_electricity_6_20)
--1 InvestmentFlowBlock_total(storage_electricity_6)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_7_21)_:
-+1 flow(storage_electricity_7_21)
--1 InvestmentFlowBlock_total(storage_electricity_7)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_7_22)_:
-+1 flow(storage_electricity_7_22)
--1 InvestmentFlowBlock_total(storage_electricity_7)
-<= 0
-
-c_u_InvestmentFlowBlock_max(storage_electricity_7_23)_:
-+1 flow(storage_electricity_7_23)
--1 InvestmentFlowBlock_total(storage_electricity_7)
-<= 0
+c_e_InvestmentFlowBlock_old_rule(storage_electricity_7)_:
++1 InvestmentFlowBlock_old(storage_electricity_7)
+-1 InvestmentFlowBlock_old_end(storage_electricity_7)
+-1 InvestmentFlowBlock_old_exo(storage_electricity_7)
+= 0
 
 c_u_InvestmentFlowBlock_max(electricity_storage_0_0)_:
 +1 flow(electricity_storage_0_0)
@@ -1742,6 +1622,126 @@ c_u_InvestmentFlowBlock_max(electricity_storage_7_22)_:
 c_u_InvestmentFlowBlock_max(electricity_storage_7_23)_:
 +1 flow(electricity_storage_7_23)
 -1 InvestmentFlowBlock_total(electricity_storage_7)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_0_0)_:
++1 flow(storage_electricity_0_0)
+-1 InvestmentFlowBlock_total(storage_electricity_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_0_1)_:
++1 flow(storage_electricity_0_1)
+-1 InvestmentFlowBlock_total(storage_electricity_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_0_2)_:
++1 flow(storage_electricity_0_2)
+-1 InvestmentFlowBlock_total(storage_electricity_0)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_1_3)_:
++1 flow(storage_electricity_1_3)
+-1 InvestmentFlowBlock_total(storage_electricity_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_1_4)_:
++1 flow(storage_electricity_1_4)
+-1 InvestmentFlowBlock_total(storage_electricity_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_1_5)_:
++1 flow(storage_electricity_1_5)
+-1 InvestmentFlowBlock_total(storage_electricity_1)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_2_6)_:
++1 flow(storage_electricity_2_6)
+-1 InvestmentFlowBlock_total(storage_electricity_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_2_7)_:
++1 flow(storage_electricity_2_7)
+-1 InvestmentFlowBlock_total(storage_electricity_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_2_8)_:
++1 flow(storage_electricity_2_8)
+-1 InvestmentFlowBlock_total(storage_electricity_2)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_3_9)_:
++1 flow(storage_electricity_3_9)
+-1 InvestmentFlowBlock_total(storage_electricity_3)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_3_10)_:
++1 flow(storage_electricity_3_10)
+-1 InvestmentFlowBlock_total(storage_electricity_3)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_3_11)_:
++1 flow(storage_electricity_3_11)
+-1 InvestmentFlowBlock_total(storage_electricity_3)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_4_12)_:
++1 flow(storage_electricity_4_12)
+-1 InvestmentFlowBlock_total(storage_electricity_4)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_4_13)_:
++1 flow(storage_electricity_4_13)
+-1 InvestmentFlowBlock_total(storage_electricity_4)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_4_14)_:
++1 flow(storage_electricity_4_14)
+-1 InvestmentFlowBlock_total(storage_electricity_4)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_5_15)_:
++1 flow(storage_electricity_5_15)
+-1 InvestmentFlowBlock_total(storage_electricity_5)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_5_16)_:
++1 flow(storage_electricity_5_16)
+-1 InvestmentFlowBlock_total(storage_electricity_5)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_5_17)_:
++1 flow(storage_electricity_5_17)
+-1 InvestmentFlowBlock_total(storage_electricity_5)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_6_18)_:
++1 flow(storage_electricity_6_18)
+-1 InvestmentFlowBlock_total(storage_electricity_6)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_6_19)_:
++1 flow(storage_electricity_6_19)
+-1 InvestmentFlowBlock_total(storage_electricity_6)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_6_20)_:
++1 flow(storage_electricity_6_20)
+-1 InvestmentFlowBlock_total(storage_electricity_6)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_7_21)_:
++1 flow(storage_electricity_7_21)
+-1 InvestmentFlowBlock_total(storage_electricity_7)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_7_22)_:
++1 flow(storage_electricity_7_22)
+-1 InvestmentFlowBlock_total(storage_electricity_7)
+<= 0
+
+c_u_InvestmentFlowBlock_max(storage_electricity_7_23)_:
++1 flow(storage_electricity_7_23)
+-1 InvestmentFlowBlock_total(storage_electricity_7)
 <= 0
 
 c_e_GenericInvestmentStorageBlock_total_storage_rule(storage_0)_:
@@ -2083,43 +2083,43 @@ c_e_GenericInvestmentStorageBlock_balance(storage_7_23)_:
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_0)_:
-+1 InvestmentFlowBlock_total(storage_electricity_0)
 -1 InvestmentFlowBlock_total(electricity_storage_0)
++1 InvestmentFlowBlock_total(storage_electricity_0)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_1)_:
-+1 InvestmentFlowBlock_total(storage_electricity_1)
 -1 InvestmentFlowBlock_total(electricity_storage_1)
++1 InvestmentFlowBlock_total(storage_electricity_1)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_2)_:
-+1 InvestmentFlowBlock_total(storage_electricity_2)
 -1 InvestmentFlowBlock_total(electricity_storage_2)
++1 InvestmentFlowBlock_total(storage_electricity_2)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_3)_:
-+1 InvestmentFlowBlock_total(storage_electricity_3)
 -1 InvestmentFlowBlock_total(electricity_storage_3)
++1 InvestmentFlowBlock_total(storage_electricity_3)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_4)_:
-+1 InvestmentFlowBlock_total(storage_electricity_4)
 -1 InvestmentFlowBlock_total(electricity_storage_4)
++1 InvestmentFlowBlock_total(storage_electricity_4)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_5)_:
-+1 InvestmentFlowBlock_total(storage_electricity_5)
 -1 InvestmentFlowBlock_total(electricity_storage_5)
++1 InvestmentFlowBlock_total(storage_electricity_5)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_6)_:
-+1 InvestmentFlowBlock_total(storage_electricity_6)
 -1 InvestmentFlowBlock_total(electricity_storage_6)
++1 InvestmentFlowBlock_total(storage_electricity_6)
 = 0
 
 c_e_GenericInvestmentStorageBlock_power_coupled(storage_7)_:
-+1 InvestmentFlowBlock_total(storage_electricity_7)
 -1 InvestmentFlowBlock_total(electricity_storage_7)
++1 InvestmentFlowBlock_total(storage_electricity_7)
 = 0
 
 c_e_GenericInvestmentStorageBlock_storage_capacity_outflow(storage_0)_:
@@ -6718,14 +6718,6 @@ c_l_SinkDSMOemofInvestmentBlock_overall_minimum(demand_dsm_oemof)_:
 
 bounds
    1 <= ONE_VAR_CONSTANT <= 1
-   0 <= InvestmentFlowBlock_invest(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_3) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_4) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_5) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_6) <= +inf
-   0 <= InvestmentFlowBlock_invest(storage_electricity_7) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_2) <= +inf
@@ -6734,6 +6726,14 @@ bounds
    0 <= InvestmentFlowBlock_invest(electricity_storage_5) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_6) <= +inf
    0 <= InvestmentFlowBlock_invest(electricity_storage_7) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_3) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_4) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_5) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_6) <= +inf
+   0 <= InvestmentFlowBlock_invest(storage_electricity_7) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_invest(storage_2) <= +inf
@@ -7798,21 +7798,6 @@ bounds
    0 <= flow(electricity_demand_dsm_diw_7_23) <= +inf
    0 <= flow(electricity_demand_dsm_dlr_7_23) <= +inf
    0 <= flow(electricity_demand_dsm_oemof_7_23) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_3) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_3) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_4) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_4) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_5) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_5) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_6) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_6) <= +inf
-   0 <= InvestmentFlowBlock_total(storage_electricity_7) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_7) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old(electricity_storage_1) <= +inf
@@ -7828,14 +7813,21 @@ bounds
    0 <= InvestmentFlowBlock_old(electricity_storage_6) <= +inf
    0 <= InvestmentFlowBlock_total(electricity_storage_7) <= +inf
    0 <= InvestmentFlowBlock_old(electricity_storage_7) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_3) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_4) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_5) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_6) <= +inf
-   0 <= InvestmentFlowBlock_old_end(storage_electricity_7) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_3) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_3) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_4) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_4) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_5) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_5) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_6) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_6) <= +inf
+   0 <= InvestmentFlowBlock_total(storage_electricity_7) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_7) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricity_storage_2) <= +inf
@@ -7844,14 +7836,14 @@ bounds
    0 <= InvestmentFlowBlock_old_end(electricity_storage_5) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricity_storage_6) <= +inf
    0 <= InvestmentFlowBlock_old_end(electricity_storage_7) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_0) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_1) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_2) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_3) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_4) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_5) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_6) <= +inf
-   0 <= InvestmentFlowBlock_old_exo(storage_electricity_7) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_3) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_4) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_5) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_6) <= +inf
+   0 <= InvestmentFlowBlock_old_end(storage_electricity_7) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_2) <= +inf
@@ -7860,8 +7852,16 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_5) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_6) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricity_storage_7) <= +inf
-   0 <= InvestmentFlowBlock_old(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_0) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_1) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_2) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_3) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_4) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_5) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_6) <= +inf
+   0 <= InvestmentFlowBlock_old_exo(storage_electricity_7) <= +inf
    0 <= InvestmentFlowBlock_old(electricity_storage_0) <= +inf
+   0 <= InvestmentFlowBlock_old(storage_electricity_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_0) <= +inf
    0 <= GenericInvestmentStorageBlock_total(storage_1) <= +inf
    0 <= GenericInvestmentStorageBlock_old(storage_1) <= +inf

--- a/tests/lp_files/storage_invest_multi_period.lp
+++ b/tests/lp_files/storage_invest_multi_period.lp
@@ -3,9 +3,9 @@
 min 
 objective:
 +250.0 ONE_VAR_CONSTANT
-+29.99406858132935 GenericInvestmentStorageBlock_invest(storage1_0)
-+19.60706904757886 GenericInvestmentStorageBlock_invest(storage1_1)
-+9.614085282931445 GenericInvestmentStorageBlock_invest(storage1_2)
++29.994068581329355 GenericInvestmentStorageBlock_invest(storage1_0)
++19.797418159157367 GenericInvestmentStorageBlock_invest(storage1_1)
++9.8007020589888 GenericInvestmentStorageBlock_invest(storage1_2)
 
 s.t.
 

--- a/tests/multi_period_constraint_tests.py
+++ b/tests/multi_period_constraint_tests.py
@@ -783,6 +783,7 @@ class TestsMultiPeriodConstraint:
                         maximum=1000,
                         ep_costs=20,
                         lifetime=20,
+                        fixed_costs=10,
                     ),
                 ),
                 bth: solph.flows.Flow(variable_costs=20),


### PR DESCRIPTION
close #1019

Remove duplicated discounting for fixed costs.

The discounting is already taken care of as the discount starts with the temporal distance of optimization start and investment period.

