### PR TITLE
Multiple Outputs for OffsetConverter

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -748,6 +748,7 @@ which results in a nonlinear relation:
    :align: center
 
 The parameters :math:`C_{0}` and :math:`C_{1}` can be given by scalars or by series in order to define a different efficiency equation for every timestep.
+It is also possible to define multiple outputs.
 
 .. note:: See the :py:class:`~oemof.solph.components._offset_converter.OffsetConverter` class for all parameters and the mathematical background.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -682,40 +682,42 @@ The `Link` allows to model connections between two busses, e.g. modeling the tra
 OffsetConverter (component)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The `OffsetConverter` object makes it possible to create a Converter with different efficiencies in part load condition.
-For this object it is necessary to define the inflow as a nonconvex flow and to set a minimum load.
+The `OffsetConverter` object makes it possible to create a Converter with efficiencies depending on the part load condition.
+For this object it is necessary to define the outflow as a nonconvex flow and to set a minimum load.
 The following example illustrates how to define an OffsetConverter for given information for the output:
 
 .. code-block:: python
 
-    eta_min = 0.5       # efficiency at minimal operation point
-    eta_max = 0.8       # efficiency at nominal operation point
-    P_out_min = 20      # absolute minimal output power
-    P_out_max = 100     # absolute nominal output power
-
-    # calculate limits of input power flow
-    P_in_min = P_out_min / eta_min
-    P_in_max = P_out_max / eta_max
+    eta_min = 0.5                # efficiency at minimal operation point
+    eta_max = 0.8                # efficiency at nominal operation point
+    P_out_min = 20               # absolute minimal output power
+    P_out_max = 100              # absolute nominal output power
+    l_max = P_out_max/P_out_max  # upper part load limit
+    l_min = P_out_min/P_out_max  # lower part load limit
 
     # calculate coefficients of input-output line equation
-    c1 = (P_out_max-P_out_min)/(P_in_max-P_in_min)
-    c0 = P_out_max - c1*P_in_max
+    c1 = (l_max-l_min)/(l_max/eta_max - l_min/eta_min)
+    c0 = l_min * (1-c1/eta_min)
 
     # define OffsetConverter
     solph.components.OffsetConverter(
         label='boiler',
-        inputs={bfuel: solph.flows.Flow(
-            nominal_value=P_in_max,
-            max=1,
-            min=P_in_min/P_in_max,
-            nonconvex=solph.NonConvex())},
-        outputs={bth: solph.flows.Flow()},
-        coefficients = [c0, c1])
+        inputs={bfuel: solph.flows.Flow()},
+        outputs={
+            bth: solph.flows.Flow(
+                nominal_value=P_out_max,
+                max=l_max,
+                min=l_min,
+                nonconvex=solph.NonConvex()
+            ),
+        },
+        coefficients = {bth: (c0, c1)},
+    )
 
 This example represents a boiler, which is supplied by fuel and generates heat.
 It is assumed that the nominal thermal power of the boiler (output power) is 100 (kW) and the efficiency at nominal power is 80 %.
 The boiler cannot operate under 20 % of nominal power, in this case 20 (kW) and the efficiency at that part load is 50 %.
-Note that the nonconvex flow has to be defined for the input flow.
+Note that the nonconvex flow has to be defined for the output flow.
 By using the OffsetConverter a linear relation of in- and output power with a power dependent efficiency is generated.
 The following figures illustrate the relations:
 

--- a/docs/whatsnew/v0-5-3.rst
+++ b/docs/whatsnew/v0-5-3.rst
@@ -4,8 +4,13 @@ v0.5.3
 API changes
 ###########
 
+* `coefficient` of `OffsetConverter` expects a dictionary similar to 
+  `Converter`s `conversion_factors`
+
 New features
 ############
+
+* `OffsetConverter` can now handle multiple outputs
 
 Documentation
 #############
@@ -16,8 +21,12 @@ Bug fixes
 Other changes
 #############
 
+* Unified (usage) documentation for `OffsetConverter`
+
 Known issues
 ############
 
 Contributors
 ############
+
+* Lennart Schürmann

--- a/examples/offset_converter_example/offset_diesel_genset_nonconvex_investment.py
+++ b/examples/offset_converter_example/offset_diesel_genset_nonconvex_investment.py
@@ -44,11 +44,14 @@ This example requires the version v0.5.x of oemof. Install by:
 __copyright__ = "oemof developer group"
 __license__ = "MIT"
 
-import numpy as np
 import os
-import pandas as pd
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
+
+import numpy as np
+import pandas as pd
+
 from oemof import solph
 
 try:
@@ -155,10 +158,10 @@ def offset_converter_example():
 
     # Calculate the two polynomial coefficients, i.e. the y-intersection and the
     # slope of the linear equation.
-    c1 = (max_load / max_efficiency - min_load / min_efficiency) / (
-        max_load - min_load
+    c1 = (max_load - min_load) / (
+        max_load / max_efficiency - min_load / min_efficiency
     )
-    c0 = min_load * (1 / min_efficiency - c1)
+    c0 = min_load * (1 - c1 / min_efficiency)
 
     epc_diesel_genset = 84.80  # currency/kW/year
     variable_cost_diesel_genset = 0.045  # currency/kWh
@@ -277,7 +280,7 @@ def offset_converter_example():
     # The higher the MipGap or ratioGap, the faster the solver would converge,
     # but the less accurate the results would be.
     solver_option = {"gurobi": {"MipGap": "0.02"}, "cbc": {"ratioGap": "0.02"}}
-    solver = "cbc"
+    solver = "gurobi"
 
     model = solph.Model(energy_system)
     model.solve(

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -55,13 +55,13 @@ class OffsetConverter(Node):
 
     .. math::
 
-        C_1 = (l_{max}-l_{min})/(l_{max}/\eta_{max}-l_{min}/\eta_{min})
+        C_1 = (l_{max}-l_{min})/(l_{max}/\\eta_{max}-l_{min}/\\eta_{min})
 
-        C_0 = l_{min} \cdot (1-C_1/\eta_{min})
+        C_0 = l_{min} \\cdot (1-C_1/\\eta_{min})
 
     Where :math:`l_{max}` and :math:`l_{min}` are the maximum and minimum
-    partload share (e.g. 1.0 and 0.3) and :math:`\eta_{max}` and
-    :math:`\eta_{min}` are the efficiencies/conversion factors at these
+    partload share (e.g. 1.0 and 0.3) and :math:`\\eta_{max}` and
+    :math:`\\eta_{min}` are the efficiencies/conversion factors at these
     partloads.
 
     The sets, variables, constraints and objective parts are created

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -112,15 +112,16 @@ class OffsetConverter(Node):
             if isinstance(coefficients, tuple):
                 # TODO: add the correct version in the message
                 msg = (
-                    "Passing a tuple to the keyword `coefficients` will be deprecated"
-                    " in a later version. Please use a dict to specify the"
-                    " corresponding output flow. The first output flow will be assumed"
-                    " as target by default."
+                    "Passing a tuple to the keyword `coefficients` will be"
+                    " deprecated in a later version. Please use a dict to"
+                    " specify the corresponding output flow. The first output"
+                    " flow will be assumed as target by default."
                 )
                 warn(msg, DeprecationWarning)
                 if len(coefficients) != 2:
                     raise ValueError(
-                        "Two coefficients or coefficient series have to be given."
+                        "Two coefficients or coefficient series have to be"
+                        " given."
                     )
                 self.coefficients.update(
                     {
@@ -133,14 +134,16 @@ class OffsetConverter(Node):
                 for k, v in coefficients.items():
                     if len(v) != 2:
                         raise ValueError(
-                            "Two coefficients or coefficient series have to be given."
+                            "Two coefficients or coefficient series have to be"
+                            " given."
                         )
                     self.coefficients.update(
                         {k: (sequence(v[0]), sequence(v[1]))}
                     )
             else:
                 raise TypeError(
-                    "`coefficiencts` needs to be either dict or tuple (deprecated)."
+                    "`coefficiencts` needs to be either dict or tuple"
+                    " (deprecated)."
                 )
 
         # `OffsetConverter` always needs the `NonConvex` attribute, but the

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -45,7 +45,7 @@ class OffsetConverter(Node):
         output flow (this is for internal purposes).
 
         :math:`C_1 = (l_{max}-l_{min})/(l_{max}/eta_{max}-l_{min}/eta_{min})`
-        :math:`C_0 = l_{min} \cdot (1-C_1/eta_{min})`
+        :math:`C_0 = l_{min} * (1-C_1/eta_{min})`
 
         The symbols used are defined as follows(index (t) was previously omitted
         for brevity):

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -116,7 +116,7 @@ class OffsetConverter(Node):
                 # TODO: add the correct version in the message
                 msg = (
                     "Passing a tuple to the keyword `coefficients` will be deprecated"
-                    " starting from vX.X.X. Please use a dict to specify the"
+                    " in a later version. Please use a dict to specify the"
                     " corresponding output flow. The first output flow will be assumed"
                     " as target by default."
                 )

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -44,29 +44,26 @@ class OffsetConverter(Node):
         :math:`C_0(t)` is the y-intercept devided by the `nominal_value` of the
         output flow (this is for internal purposes).
 
-        :math:`C_1 = (l_{max}-l_{min})/(l_{max}/eta_{max}-l_{min}/eta_{min})`
-        :math:`C_0 = l_{min} * (1-C_1/eta_{min})`
-
-        The symbols used are defined as follows(index (t) was previously omitted
-        for brevity):
-
-        +----------------------+--------------------------------------------------+
-        | symbol               | explanation                                      |
-        +======================+==================================================+
-        | :math:`l_{max}(t)`   | Maximum partload (value passed to `max`)         |
-        +----------------------+--------------------------------------------------+
-        | :math:`l_{min}(t)`   | Minimum partload (value passed to `min`)         |
-        +----------------------+--------------------------------------------------+
-        | :math:`eta_{max}(t)` | Efficiency/conversion factor at :math:`l_{max}(t)|
-        +----------------------+--------------------------------------------------+
-        | :math:`eta_{min}(t)` | Efficiency/conversion factor at :math:`l_{min}(t)|
-        +----------------------+--------------------------------------------------+
-
         The tuple values can either be a scalar or a sequence with length
         of time horizon for simulation.
 
     Notes
     -----
+    **C_1 and C_0 can be calculated as follows:**
+
+    .. _OffsetConverterCoefficients-equations:
+
+    .. math::
+
+        C_1 = (l_{max}-l_{min})/(l_{max}/\eta_{max}-l_{min}/\eta_{min})
+
+        C_0 = l_{min} \cdot (1-C_1/\eta_{min})
+
+    Where :math:`l_{max}` and :math:`l_{min}` are the maximum and minimum
+    partload share (e.g. 1.0 and 0.3) and :math:`\eta_{max}` and
+    :math:`\eta_{min}` are the efficiencies/conversion factors at these
+    partloads.
+
     The sets, variables, constraints and objective parts are created
      * :py:class:`~oemof.solph.components._offset_converter.OffsetConverterBlock`
 

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -1368,7 +1368,7 @@ class TestsConstraint:
                     min=0.2,
                 )
             },
-            coefficients=[2.5, 0.5],
+            coefficients={b_el: (2.5, 0.5)},
         )
         self.energysystem.add(b_diesel, b_el, diesel_genset)
 
@@ -1393,7 +1393,7 @@ class TestsConstraint:
                     ),
                 )
             },
-            coefficients=[2.5, 0.5],
+            coefficients={b_el: (2.5, 0.5)},
         )
         self.energysystem.add(b_diesel, b_el, diesel_genset)
 

--- a/tests/multi_period_constraint_tests.py
+++ b/tests/multi_period_constraint_tests.py
@@ -1529,7 +1529,7 @@ class TestsMultiPeriodConstraint:
                     nominal_value=100, min=0.32, nonconvex=solph.NonConvex()
                 )
             },
-            coefficients=[-17, 0.9],
+            coefficients={bth: (-17, 0.9)},
         )
         self.energysystem.add(bgas, bth, otrf)
         self.compare_lp_files("offsetconverter_multi_period.lp")

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -224,7 +224,7 @@ def test_offsetconverter_without_nonconvex():
             label="diesel_genset",
             inputs={b_el: Flow()},
             outputs={b_el: Flow()},
-            coefficients=(2.5, 0.5),
+            coefficients={b_el: (2.5, 0.5)},
         )
 
 
@@ -239,7 +239,7 @@ def test_offsetconverter_nonconvex_on_inputs():
         components.OffsetConverter(
             inputs={b_diesel: Flow(nonconvex=NonConvex())},
             outputs={b_diesel: Flow(nonconvex=NonConvex())},
-            coefficients=(2.5, 0.5),
+            coefficients={b_diesel: (2.5, 0.5)},
         )
 
 
@@ -258,7 +258,7 @@ def test_offsetconverter_investment_on_inputs():
                     nonconvex=NonConvex(), nominal_value=Investment(maximum=1)
                 )
             },
-            coefficients=(2.5, 0.5),
+            coefficients={b_diesel: (2.5, 0.5)},
         )
 
 
@@ -272,7 +272,7 @@ def test_offsetconverter_not_enough_coefficients():
             label="of1",
             inputs={bus: Flow()},
             outputs={bus: Flow(nonconvex=NonConvex())},
-            coefficients=([1, 4, 7]),
+            coefficients={bus: ([1, 4, 7])},
         )
 
 
@@ -286,16 +286,15 @@ def test_offsetconverter_too_many_coefficients():
             label="of2",
             inputs={bus: Flow()},
             outputs={bus: Flow(nonconvex=NonConvex())},
-            coefficients=(1, 4, 7),
+            coefficients={bus: (1, 4, 7)},
         )
 
 
-def test_offsetconverter__too_many_input_flows():
+def test_offsetconverter_too_many_input_flows():
     """Too many Input Flows defined."""
     with pytest.raises(
         ValueError,
-        match="Component `OffsetConverter` must not have more than 1 input "
-        + "and 1 output!",
+        match="Component `OffsetConverter` must not have more than 1 input!",
     ):
         b_gas = Bus(label="bus_gas")
         b_coal = Bus(label="bus_coal")
@@ -305,28 +304,6 @@ def test_offsetconverter__too_many_input_flows():
                 b_coal: Flow(),
             },
             outputs={b_coal: Flow(nonconvex=NonConvex())},
-            coefficients=(20, 0.5),
-        )
-
-
-def test_offsetconverter_too_many_output_flows():
-    """Too many Output Flows defined."""
-    with pytest.raises(
-        ValueError,
-        match="Component `OffsetConverter` must not have more than 1 input "
-        + "and 1 output!",
-    ):
-        b_el = Bus(label="bus_electricity")
-        b_th = Bus(label="bus_thermal")
-
-        components.OffsetConverter(
-            inputs={
-                b_el: Flow(),
-            },
-            outputs={
-                b_el: Flow(nonconvex=NonConvex()),
-                b_th: Flow(nonconvex=NonConvex()),
-            },
             coefficients=(20, 0.5),
         )
 


### PR DESCRIPTION
This PR enables the OffsetConverter to output two (or more) flows with part-load depending efficiencies.
1. `outputs` are allowed to contain multiple busses.
2. `coefficients` expects a dictionary, where the keys are the output busses and the values are the tuples containing the necessary parameters. I took the liberty to implement a deprecation warning for the old behaviour (passing a tuple without specifying the output bus it corresponds to). This way, the OffsetConverter is more in line with the regular Converter and there is less room for confusion. But this is totally up for debate!
3. The issues discussed in https://github.com/oemof/oemof-solph/issues/1010 are fixed (misleading docu, usage guide and erroneous example).