### PR TITLE
Feature/integrate tsam no multiple timegrid storage

### DIFF
--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -120,7 +120,9 @@ class GenericStorage(Node):
         Determine the lifetime of an outflow; only applicable for multi-period
         models which can invest in storage capacity and have an
         invest_relation_output_capacity defined
-
+    multiple_tsam_timegrid : boolean
+        Relevant in tsam mode.
+        If true, inter and intra storage content is considers.
     Notes
     -----
     The following sets, variables, constraints and objective parts are created


### PR DESCRIPTION

Added possibility to have diverse storage with and without inter_storage_content in tsam mode.

For this purpose, multiple_time_grid has been added to generic_storage. The naming can be improved in the future.
