### PR TITLE
Explicitely pass `custom_properties` to `Node` class

### DIFF
--- a/docs/whatsnew/v0-5-3.rst
+++ b/docs/whatsnew/v0-5-3.rst
@@ -13,6 +13,9 @@ Documentation
 Bug fixes
 #########
 
+* Fix custom attributes of Sink, Source, GenericCHP and Converter components
+  not being properly passed to base Node class
+
 Other changes
 #############
 
@@ -21,3 +24,5 @@ Known issues
 
 Contributors
 ############
+
+* Richard Keil

--- a/src/oemof/solph/components/_generic_chp.py
+++ b/src/oemof/solph/components/_generic_chp.py
@@ -131,7 +131,7 @@ class GenericCHP(Node):
     ):
         if custom_attributes is None:
             custom_attributes = {}
-        super().__init__(label, **custom_attributes)
+        super().__init__(label, custom_properties=custom_attributes)
 
         self.fuel_input = fuel_input
         self.electrical_output = electrical_output

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -77,7 +77,7 @@ class OffsetConverter(Node):
             inputs=inputs,
             outputs=outputs,
             label=label,
-            **custom_attributes,
+            custom_properties=custom_attributes,
         )
 
         if coefficients is not None:

--- a/src/oemof/solph/components/_sink.py
+++ b/src/oemof/solph/components/_sink.py
@@ -63,7 +63,11 @@ class Sink(Node):
                 debugging.SuspiciousUsageWarning,
             )
 
-        super().__init__(label=label, inputs=inputs, **custom_attributes)
+        super().__init__(
+            label=label,
+            inputs=inputs,
+            custom_properties=custom_attributes
+        )
 
     def constraint_group(self):
         pass

--- a/src/oemof/solph/components/_source.py
+++ b/src/oemof/solph/components/_source.py
@@ -73,7 +73,11 @@ class Source(Node):
                 debugging.SuspiciousUsageWarning,
             )
 
-        super().__init__(label=label, outputs=outputs, **custom_attributes)
+        super().__init__(
+            label=label,
+            outputs=outputs,
+            custom_properties=custom_attributes
+        )
 
     def constraint_group(self):
         pass


### PR DESCRIPTION
This fixes #1059 by explicitly passing `custom_attributes` to the base class instead of unpacking them.