### PR TITLE
Introduce variable for storage losses

### DIFF
--- a/examples/storage_balanced_unbalanced/storage.py
+++ b/examples/storage_balanced_unbalanced/storage.py
@@ -67,7 +67,7 @@ def storage_example():
 
     # create an energy system
     idx = pd.date_range("1/1/2017", periods=len(timeseries), freq="h")
-    es = solph.EnergySystem(timeindex=idx)
+    es = solph.EnergySystem(timeindex=idx, infer_last_interval=True)
 
     for data_set in DATA:
         name = data_set["name"]

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -360,7 +360,7 @@ class GenericStorageBlock(ScalarBlock):
 
     Storage losses :attr:`om.Storage.losses[n, t]`
         .. math:: E_{loss}(t) = &E(t-1) \cdot
-            \beta(t)^{\tau(t)/(t_u)} \\
+            1 - (1 - \beta(t))^{\tau(t)/(t_u)} \\
             &- \gamma(t)\cdot E_{nom} \cdot {\tau(t)/(t_u)}\\
             &- \delta(t) \cdot {\tau(t)/(t_u)}
 
@@ -515,7 +515,7 @@ class GenericStorageBlock(ScalarBlock):
 
         def _storage_losses_rule(block, n, t):
             expr = block.storage_content[n, t] * (
-                n.loss_rate[t] ** m.timeincrement[t]
+                1 - (1 - n.loss_rate[t]) ** m.timeincrement[t]
             )
             expr += (
                 n.fixed_losses_relative[t]

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -358,11 +358,14 @@ class GenericStorageBlock(ScalarBlock):
         .. math::
             E(t_{last}) = E(-1)
 
-    Storage balance :attr:`om.Storage.balance[n, t]`
-        .. math:: E(t) = &E(t-1) \cdot
-            (1 - \beta(t)) ^{\tau(t)/(t_u)} \\
+    Storage losses :attr:`om.Storage.losses[n, t]`
+        .. math:: E_{loss}(t) = &E(t-1) \cdot
+            \beta(t)^{\tau(t)/(t_u)} \\
             &- \gamma(t)\cdot E_{nom} \cdot {\tau(t)/(t_u)}\\
-            &- \delta(t) \cdot {\tau(t)/(t_u)}\\
+            &- \delta(t) \cdot {\tau(t)/(t_u)}
+
+    Storage balance :attr:`om.Storage.balance[n, t]`
+        .. math:: E(t) = &E(t-1) - E_{loss}(t)
             &- \frac{\dot{E}_o(p, t)}{\eta_o(t)} \cdot \tau(t)
             + \dot{E}_i(p, t) \cdot \eta_i(t) \cdot \tau(t)
 
@@ -1025,6 +1028,8 @@ class GenericInvestmentStorageBlock(ScalarBlock):
         of the storage"
         ":math:`E(t)`", ":attr:`storage_content[n, t]`", "Current storage
         content (current absolute stored energy)"
+        ":math:`E_{loss}(t)`", ":attr:`storage_losses[n, t]`", "Current storage
+        losses (absolute losses per time step)"
         ":math:`E_{invest}(p)`", ":attr:`invest[n, p]`", "Invested (nominal)
         capacity of the storage"
         ":math:`E_{old}(p)`", ":attr:`old[n, p]`", "

--- a/tests/lp_files/nonequidistant_timeindex.lp
+++ b/tests/lp_files/nonequidistant_timeindex.lp
@@ -165,27 +165,27 @@ c_e_GenericStorageBlock_losses(storage_2)_:
 
 c_e_GenericStorageBlock_losses(storage_3)_:
 -1 GenericStorageBlock_storage_losses(storage_3)
-+0.010000000000000002 GenericStorageBlock_storage_content(storage_3)
++0.19 GenericStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericStorageBlock_losses(storage_4)_:
 -1 GenericStorageBlock_storage_losses(storage_4)
-+0.010000000000000002 GenericStorageBlock_storage_content(storage_4)
++0.19 GenericStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericStorageBlock_losses(storage_5)_:
 -1 GenericStorageBlock_storage_losses(storage_5)
-+0.31622776601683794 GenericStorageBlock_storage_content(storage_5)
++0.05131670194948623 GenericStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericStorageBlock_losses(storage_6)_:
 -1 GenericStorageBlock_storage_losses(storage_6)
-+0.31622776601683794 GenericStorageBlock_storage_content(storage_6)
++0.05131670194948623 GenericStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericStorageBlock_losses(storage_7)_:
 -1 GenericStorageBlock_storage_losses(storage_7)
-+0.31622776601683794 GenericStorageBlock_storage_content(storage_7)
++0.05131670194948623 GenericStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_0)_:

--- a/tests/lp_files/nonequidistant_timeindex.lp
+++ b/tests/lp_files/nonequidistant_timeindex.lp
@@ -149,59 +149,106 @@ c_e_ConverterBlock_relation(boiler_gas_heat_7)_:
 -1 flow(boiler_heat_7)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_0)_:
+-1 GenericStorageBlock_storage_losses(storage_0)
+= -30.0
+
+c_e_GenericStorageBlock_losses(storage_1)_:
+-1 GenericStorageBlock_storage_losses(storage_1)
++0.1 GenericStorageBlock_storage_content(storage_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_2)_:
+-1 GenericStorageBlock_storage_losses(storage_2)
++0.1 GenericStorageBlock_storage_content(storage_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_3)_:
+-1 GenericStorageBlock_storage_losses(storage_3)
++0.010000000000000002 GenericStorageBlock_storage_content(storage_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_4)_:
+-1 GenericStorageBlock_storage_losses(storage_4)
++0.010000000000000002 GenericStorageBlock_storage_content(storage_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_5)_:
+-1 GenericStorageBlock_storage_losses(storage_5)
++0.31622776601683794 GenericStorageBlock_storage_content(storage_5)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_6)_:
+-1 GenericStorageBlock_storage_losses(storage_6)
++0.31622776601683794 GenericStorageBlock_storage_content(storage_6)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_7)_:
+-1 GenericStorageBlock_storage_losses(storage_7)
++0.31622776601683794 GenericStorageBlock_storage_content(storage_7)
+= 0
+
 c_e_GenericStorageBlock_balance(storage_0)_:
--1 flow(heat_storage_0)
-+1 flow(storage_heat_0)
-+1 GenericStorageBlock_storage_content(storage_1)
-= 270.0
++1 flow(heat_storage_0)
+-1 flow(storage_heat_0)
+-1 GenericStorageBlock_storage_losses(storage_0)
+-1 GenericStorageBlock_storage_content(storage_1)
+= -300
 
 c_e_GenericStorageBlock_balance(storage_1)_:
--1 flow(heat_storage_1)
-+1 flow(storage_heat_1)
--0.9 GenericStorageBlock_storage_content(storage_1)
-+1 GenericStorageBlock_storage_content(storage_2)
++1 flow(heat_storage_1)
+-1 flow(storage_heat_1)
+-1 GenericStorageBlock_storage_losses(storage_1)
++1 GenericStorageBlock_storage_content(storage_1)
+-1 GenericStorageBlock_storage_content(storage_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_2)_:
--1 flow(heat_storage_2)
-+1 flow(storage_heat_2)
--0.9 GenericStorageBlock_storage_content(storage_2)
-+1 GenericStorageBlock_storage_content(storage_3)
++1 flow(heat_storage_2)
+-1 flow(storage_heat_2)
+-1 GenericStorageBlock_storage_losses(storage_2)
++1 GenericStorageBlock_storage_content(storage_2)
+-1 GenericStorageBlock_storage_content(storage_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_3)_:
--2.0 flow(heat_storage_3)
-+2.0 flow(storage_heat_3)
--0.81 GenericStorageBlock_storage_content(storage_3)
-+1 GenericStorageBlock_storage_content(storage_4)
++2.0 flow(heat_storage_3)
+-2.0 flow(storage_heat_3)
+-1 GenericStorageBlock_storage_losses(storage_3)
++1 GenericStorageBlock_storage_content(storage_3)
+-1 GenericStorageBlock_storage_content(storage_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_4)_:
--2.0 flow(heat_storage_4)
-+2.0 flow(storage_heat_4)
--0.81 GenericStorageBlock_storage_content(storage_4)
-+1 GenericStorageBlock_storage_content(storage_5)
++2.0 flow(heat_storage_4)
+-2.0 flow(storage_heat_4)
+-1 GenericStorageBlock_storage_losses(storage_4)
++1 GenericStorageBlock_storage_content(storage_4)
+-1 GenericStorageBlock_storage_content(storage_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_5)_:
--0.5 flow(heat_storage_5)
-+0.5 flow(storage_heat_5)
--0.9486832980505138 GenericStorageBlock_storage_content(storage_5)
-+1 GenericStorageBlock_storage_content(storage_6)
++0.5 flow(heat_storage_5)
+-0.5 flow(storage_heat_5)
+-1 GenericStorageBlock_storage_losses(storage_5)
++1 GenericStorageBlock_storage_content(storage_5)
+-1 GenericStorageBlock_storage_content(storage_6)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_6)_:
--0.5 flow(heat_storage_6)
-+0.5 flow(storage_heat_6)
--0.9486832980505138 GenericStorageBlock_storage_content(storage_6)
-+1 GenericStorageBlock_storage_content(storage_7)
++0.5 flow(heat_storage_6)
+-0.5 flow(storage_heat_6)
+-1 GenericStorageBlock_storage_losses(storage_6)
++1 GenericStorageBlock_storage_content(storage_6)
+-1 GenericStorageBlock_storage_content(storage_7)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_7)_:
--0.5 flow(heat_storage_7)
-+0.5 flow(storage_heat_7)
--0.9486832980505138 GenericStorageBlock_storage_content(storage_7)
-+1 GenericStorageBlock_storage_content(storage_8)
++0.5 flow(heat_storage_7)
+-0.5 flow(storage_heat_7)
+-1 GenericStorageBlock_storage_losses(storage_7)
++1 GenericStorageBlock_storage_content(storage_7)
+-1 GenericStorageBlock_storage_content(storage_8)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage)_:
@@ -241,6 +288,14 @@ bounds
    0 <= flow(storage_heat_5) <= 100
    0 <= flow(storage_heat_6) <= 100
    0 <= flow(storage_heat_7) <= 100
+   -inf <= GenericStorageBlock_storage_losses(storage_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_5) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_6) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_7) <= +inf
    0 <= GenericStorageBlock_storage_content(storage_1) <= 300
    0 <= GenericStorageBlock_storage_content(storage_2) <= 300
    0 <= GenericStorageBlock_storage_content(storage_3) <= 300

--- a/tests/lp_files/shared_limit.lp
+++ b/tests/lp_files/shared_limit.lp
@@ -7,20 +7,20 @@ objective:
 s.t.
 
 c_e_limit_storage_constraint(0)_:
-+0.5 GenericStorageBlock_storage_content(storage1_0)
 +1.25 GenericStorageBlock_storage_content(storage2_0)
++0.5 GenericStorageBlock_storage_content(storage1_0)
 -1 limit_storage(0)
 = 0
 
 c_e_limit_storage_constraint(1)_:
-+0.5 GenericStorageBlock_storage_content(storage1_1)
 +1.25 GenericStorageBlock_storage_content(storage2_1)
++0.5 GenericStorageBlock_storage_content(storage1_1)
 -1 limit_storage(1)
 = 0
 
 c_e_limit_storage_constraint(2)_:
-+0.5 GenericStorageBlock_storage_content(storage1_2)
 +1.25 GenericStorageBlock_storage_content(storage2_2)
++0.5 GenericStorageBlock_storage_content(storage1_2)
 -1 limit_storage(2)
 = 0
 
@@ -45,51 +45,76 @@ c_e_BusBlock_balance(bus_2)_:
 +1 flow(storage2_bus_2)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_0)_:
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_1)
--1 flow(bus_storage1_0)
-+1 flow(storage1_bus_0)
+c_e_GenericStorageBlock_losses(storage2_0)_:
+-1 GenericStorageBlock_storage_losses(storage2_0)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_1)_:
--1 GenericStorageBlock_storage_content(storage1_1)
-+1 GenericStorageBlock_storage_content(storage1_2)
--1 flow(bus_storage1_1)
-+1 flow(storage1_bus_1)
+c_e_GenericStorageBlock_losses(storage2_1)_:
+-1 GenericStorageBlock_storage_losses(storage2_1)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_2)_:
--1 GenericStorageBlock_storage_content(storage1_2)
-+1 GenericStorageBlock_storage_content(storage1_3)
--1 flow(bus_storage1_2)
-+1 flow(storage1_bus_2)
+c_e_GenericStorageBlock_losses(storage2_2)_:
+-1 GenericStorageBlock_storage_losses(storage2_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_0)_:
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_1)_:
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_2)_:
+-1 GenericStorageBlock_storage_losses(storage1_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_0)_:
--1 GenericStorageBlock_storage_content(storage2_0)
-+1 GenericStorageBlock_storage_content(storage2_1)
--1 flow(bus_storage2_0)
-+1 flow(storage2_bus_0)
++1 GenericStorageBlock_storage_content(storage2_0)
+-1 GenericStorageBlock_storage_content(storage2_1)
++1 flow(bus_storage2_0)
+-1 flow(storage2_bus_0)
+-1 GenericStorageBlock_storage_losses(storage2_0)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_1)_:
--1 GenericStorageBlock_storage_content(storage2_1)
-+1 GenericStorageBlock_storage_content(storage2_2)
--1 flow(bus_storage2_1)
-+1 flow(storage2_bus_1)
++1 GenericStorageBlock_storage_content(storage2_1)
+-1 GenericStorageBlock_storage_content(storage2_2)
++1 flow(bus_storage2_1)
+-1 flow(storage2_bus_1)
+-1 GenericStorageBlock_storage_losses(storage2_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_2)_:
--1 GenericStorageBlock_storage_content(storage2_2)
-+1 GenericStorageBlock_storage_content(storage2_3)
--1 flow(bus_storage2_2)
-+1 flow(storage2_bus_2)
++1 GenericStorageBlock_storage_content(storage2_2)
+-1 GenericStorageBlock_storage_content(storage2_3)
++1 flow(bus_storage2_2)
+-1 flow(storage2_bus_2)
+-1 GenericStorageBlock_storage_losses(storage2_2)
 = 0
 
-c_e_GenericStorageBlock_balanced_cstr(storage1)_:
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_3)
+c_e_GenericStorageBlock_balance(storage1_0)_:
++1 GenericStorageBlock_storage_content(storage1_0)
+-1 GenericStorageBlock_storage_content(storage1_1)
++1 flow(bus_storage1_0)
+-1 flow(storage1_bus_0)
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_1)_:
++1 GenericStorageBlock_storage_content(storage1_1)
+-1 GenericStorageBlock_storage_content(storage1_2)
++1 flow(bus_storage1_1)
+-1 flow(storage1_bus_1)
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_2)_:
++1 GenericStorageBlock_storage_content(storage1_2)
+-1 GenericStorageBlock_storage_content(storage1_3)
++1 flow(bus_storage1_2)
+-1 flow(storage1_bus_2)
+-1 GenericStorageBlock_storage_losses(storage1_2)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage2)_:
@@ -97,16 +122,21 @@ c_e_GenericStorageBlock_balanced_cstr(storage2)_:
 +1 GenericStorageBlock_storage_content(storage2_3)
 = 0
 
+c_e_GenericStorageBlock_balanced_cstr(storage1)_:
+-1 GenericStorageBlock_storage_content(storage1_0)
++1 GenericStorageBlock_storage_content(storage1_3)
+= 0
+
 bounds
    1 <= ONE_VAR_CONSTANT <= 1
-   0 <= GenericStorageBlock_storage_content(storage1_0) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_1) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_2) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_3) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_0) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_1) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_2) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_3) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_0) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_1) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_2) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_3) <= 5
    0 <= limit_storage(0) <= 7
    0 <= limit_storage(1) <= 7
    0 <= limit_storage(2) <= 7
@@ -122,4 +152,10 @@ bounds
    0 <= flow(storage2_bus_0) <= +inf
    0 <= flow(storage2_bus_1) <= +inf
    0 <= flow(storage2_bus_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_2) <= +inf
 end

--- a/tests/lp_files/shared_limit_multi_period.lp
+++ b/tests/lp_files/shared_limit_multi_period.lp
@@ -7,38 +7,38 @@ objective:
 s.t.
 
 c_e_limit_storage_constraint(0)_:
-+0.5 GenericStorageBlock_storage_content(storage1_0)
 +1.25 GenericStorageBlock_storage_content(storage2_0)
++0.5 GenericStorageBlock_storage_content(storage1_0)
 -1 limit_storage(0)
 = 0
 
 c_e_limit_storage_constraint(1)_:
-+0.5 GenericStorageBlock_storage_content(storage1_1)
 +1.25 GenericStorageBlock_storage_content(storage2_1)
++0.5 GenericStorageBlock_storage_content(storage1_1)
 -1 limit_storage(1)
 = 0
 
 c_e_limit_storage_constraint(2)_:
-+0.5 GenericStorageBlock_storage_content(storage1_2)
 +1.25 GenericStorageBlock_storage_content(storage2_2)
++0.5 GenericStorageBlock_storage_content(storage1_2)
 -1 limit_storage(2)
 = 0
 
 c_e_limit_storage_constraint(3)_:
-+0.5 GenericStorageBlock_storage_content(storage1_3)
 +1.25 GenericStorageBlock_storage_content(storage2_3)
++0.5 GenericStorageBlock_storage_content(storage1_3)
 -1 limit_storage(3)
 = 0
 
 c_e_limit_storage_constraint(4)_:
-+0.5 GenericStorageBlock_storage_content(storage1_4)
 +1.25 GenericStorageBlock_storage_content(storage2_4)
++0.5 GenericStorageBlock_storage_content(storage1_4)
 -1 limit_storage(4)
 = 0
 
 c_e_limit_storage_constraint(5)_:
-+0.5 GenericStorageBlock_storage_content(storage1_5)
 +1.25 GenericStorageBlock_storage_content(storage2_5)
++0.5 GenericStorageBlock_storage_content(storage1_5)
 -1 limit_storage(5)
 = 0
 
@@ -84,93 +84,148 @@ c_e_BusBlock_balance(bus_5)_:
 +1 flow(storage2_bus_5)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_0)_:
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_1)
--1 flow(bus_storage1_0)
-+1 flow(storage1_bus_0)
+c_e_GenericStorageBlock_losses(storage2_0)_:
+-1 GenericStorageBlock_storage_losses(storage2_0)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_1)_:
--1 GenericStorageBlock_storage_content(storage1_1)
-+1 GenericStorageBlock_storage_content(storage1_2)
--1 flow(bus_storage1_1)
-+1 flow(storage1_bus_1)
+c_e_GenericStorageBlock_losses(storage2_1)_:
+-1 GenericStorageBlock_storage_losses(storage2_1)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_2)_:
--1 GenericStorageBlock_storage_content(storage1_2)
-+1 GenericStorageBlock_storage_content(storage1_3)
--1 flow(bus_storage1_2)
-+1 flow(storage1_bus_2)
+c_e_GenericStorageBlock_losses(storage2_2)_:
+-1 GenericStorageBlock_storage_losses(storage2_2)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_3)_:
--1 GenericStorageBlock_storage_content(storage1_3)
-+1 GenericStorageBlock_storage_content(storage1_4)
--1 flow(bus_storage1_3)
-+1 flow(storage1_bus_3)
+c_e_GenericStorageBlock_losses(storage2_3)_:
+-1 GenericStorageBlock_storage_losses(storage2_3)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_4)_:
--1 GenericStorageBlock_storage_content(storage1_4)
-+1 GenericStorageBlock_storage_content(storage1_5)
--1 flow(bus_storage1_4)
-+1 flow(storage1_bus_4)
+c_e_GenericStorageBlock_losses(storage2_4)_:
+-1 GenericStorageBlock_storage_losses(storage2_4)
 = 0
 
-c_e_GenericStorageBlock_balance(storage1_5)_:
--1 GenericStorageBlock_storage_content(storage1_5)
-+1 GenericStorageBlock_storage_content(storage1_6)
--1 flow(bus_storage1_5)
-+1 flow(storage1_bus_5)
+c_e_GenericStorageBlock_losses(storage2_5)_:
+-1 GenericStorageBlock_storage_losses(storage2_5)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_0)_:
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_1)_:
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_2)_:
+-1 GenericStorageBlock_storage_losses(storage1_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_3)_:
+-1 GenericStorageBlock_storage_losses(storage1_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_4)_:
+-1 GenericStorageBlock_storage_losses(storage1_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_5)_:
+-1 GenericStorageBlock_storage_losses(storage1_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_0)_:
--1 GenericStorageBlock_storage_content(storage2_0)
-+1 GenericStorageBlock_storage_content(storage2_1)
--1 flow(bus_storage2_0)
-+1 flow(storage2_bus_0)
++1 GenericStorageBlock_storage_content(storage2_0)
+-1 GenericStorageBlock_storage_content(storage2_1)
++1 flow(bus_storage2_0)
+-1 flow(storage2_bus_0)
+-1 GenericStorageBlock_storage_losses(storage2_0)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_1)_:
--1 GenericStorageBlock_storage_content(storage2_1)
-+1 GenericStorageBlock_storage_content(storage2_2)
--1 flow(bus_storage2_1)
-+1 flow(storage2_bus_1)
++1 GenericStorageBlock_storage_content(storage2_1)
+-1 GenericStorageBlock_storage_content(storage2_2)
++1 flow(bus_storage2_1)
+-1 flow(storage2_bus_1)
+-1 GenericStorageBlock_storage_losses(storage2_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_2)_:
--1 GenericStorageBlock_storage_content(storage2_2)
-+1 GenericStorageBlock_storage_content(storage2_3)
--1 flow(bus_storage2_2)
-+1 flow(storage2_bus_2)
++1 GenericStorageBlock_storage_content(storage2_2)
+-1 GenericStorageBlock_storage_content(storage2_3)
++1 flow(bus_storage2_2)
+-1 flow(storage2_bus_2)
+-1 GenericStorageBlock_storage_losses(storage2_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_3)_:
--1 GenericStorageBlock_storage_content(storage2_3)
-+1 GenericStorageBlock_storage_content(storage2_4)
--1 flow(bus_storage2_3)
-+1 flow(storage2_bus_3)
++1 GenericStorageBlock_storage_content(storage2_3)
+-1 GenericStorageBlock_storage_content(storage2_4)
++1 flow(bus_storage2_3)
+-1 flow(storage2_bus_3)
+-1 GenericStorageBlock_storage_losses(storage2_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_4)_:
--1 GenericStorageBlock_storage_content(storage2_4)
-+1 GenericStorageBlock_storage_content(storage2_5)
--1 flow(bus_storage2_4)
-+1 flow(storage2_bus_4)
++1 GenericStorageBlock_storage_content(storage2_4)
+-1 GenericStorageBlock_storage_content(storage2_5)
++1 flow(bus_storage2_4)
+-1 flow(storage2_bus_4)
+-1 GenericStorageBlock_storage_losses(storage2_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage2_5)_:
--1 GenericStorageBlock_storage_content(storage2_5)
-+1 GenericStorageBlock_storage_content(storage2_6)
--1 flow(bus_storage2_5)
-+1 flow(storage2_bus_5)
++1 GenericStorageBlock_storage_content(storage2_5)
+-1 GenericStorageBlock_storage_content(storage2_6)
++1 flow(bus_storage2_5)
+-1 flow(storage2_bus_5)
+-1 GenericStorageBlock_storage_losses(storage2_5)
 = 0
 
-c_e_GenericStorageBlock_balanced_cstr(storage1)_:
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_6)
+c_e_GenericStorageBlock_balance(storage1_0)_:
++1 GenericStorageBlock_storage_content(storage1_0)
+-1 GenericStorageBlock_storage_content(storage1_1)
++1 flow(bus_storage1_0)
+-1 flow(storage1_bus_0)
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_1)_:
++1 GenericStorageBlock_storage_content(storage1_1)
+-1 GenericStorageBlock_storage_content(storage1_2)
++1 flow(bus_storage1_1)
+-1 flow(storage1_bus_1)
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_2)_:
++1 GenericStorageBlock_storage_content(storage1_2)
+-1 GenericStorageBlock_storage_content(storage1_3)
++1 flow(bus_storage1_2)
+-1 flow(storage1_bus_2)
+-1 GenericStorageBlock_storage_losses(storage1_2)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_3)_:
++1 GenericStorageBlock_storage_content(storage1_3)
+-1 GenericStorageBlock_storage_content(storage1_4)
++1 flow(bus_storage1_3)
+-1 flow(storage1_bus_3)
+-1 GenericStorageBlock_storage_losses(storage1_3)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_4)_:
++1 GenericStorageBlock_storage_content(storage1_4)
+-1 GenericStorageBlock_storage_content(storage1_5)
++1 flow(bus_storage1_4)
+-1 flow(storage1_bus_4)
+-1 GenericStorageBlock_storage_losses(storage1_4)
+= 0
+
+c_e_GenericStorageBlock_balance(storage1_5)_:
++1 GenericStorageBlock_storage_content(storage1_5)
+-1 GenericStorageBlock_storage_content(storage1_6)
++1 flow(bus_storage1_5)
+-1 flow(storage1_bus_5)
+-1 GenericStorageBlock_storage_losses(storage1_5)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage2)_:
@@ -178,15 +233,13 @@ c_e_GenericStorageBlock_balanced_cstr(storage2)_:
 +1 GenericStorageBlock_storage_content(storage2_6)
 = 0
 
+c_e_GenericStorageBlock_balanced_cstr(storage1)_:
+-1 GenericStorageBlock_storage_content(storage1_0)
++1 GenericStorageBlock_storage_content(storage1_6)
+= 0
+
 bounds
    1 <= ONE_VAR_CONSTANT <= 1
-   0 <= GenericStorageBlock_storage_content(storage1_0) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_1) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_2) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_3) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_4) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_5) <= 5
-   0 <= GenericStorageBlock_storage_content(storage1_6) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_0) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_1) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_2) <= 5
@@ -194,6 +247,13 @@ bounds
    0 <= GenericStorageBlock_storage_content(storage2_4) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_5) <= 5
    0 <= GenericStorageBlock_storage_content(storage2_6) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_0) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_1) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_2) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_3) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_4) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_5) <= 5
+   0 <= GenericStorageBlock_storage_content(storage1_6) <= 5
    0 <= limit_storage(0) <= 7
    0 <= limit_storage(1) <= 7
    0 <= limit_storage(2) <= 7
@@ -224,4 +284,16 @@ bounds
    0 <= flow(storage2_bus_3) <= +inf
    0 <= flow(storage2_bus_4) <= +inf
    0 <= flow(storage2_bus_5) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage2_5) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_5) <= +inf
 end

--- a/tests/lp_files/storage.lp
+++ b/tests/lp_files/storage.lp
@@ -30,24 +30,41 @@ c_e_BusBlock_balance(electricityBus_2)_:
 +1 flow(storage_no_invest_electricityBus_2)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_no_invest_0)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+= -5200.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_1)_:
++0.13 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_2)_:
++0.13 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
+= 0
+
 c_e_GenericStorageBlock_balance(storage_no_invest_0)_:
--0.97 flow(electricityBus_storage_no_invest_0)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_0)
-+1 GenericStorageBlock_storage_content(storage_no_invest_1)
-= 34800.0
++0.97 flow(electricityBus_storage_no_invest_0)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_0)
+-1 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+= -40000.0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_1)_:
--0.97 flow(electricityBus_storage_no_invest_1)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_1)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_1)
-+1 GenericStorageBlock_storage_content(storage_no_invest_2)
++0.97 flow(electricityBus_storage_no_invest_1)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_1)
++1 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_2)_:
--0.97 flow(electricityBus_storage_no_invest_2)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_2)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_2)
-+1 GenericStorageBlock_storage_content(storage_no_invest_3)
++0.97 flow(electricityBus_storage_no_invest_2)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_2)
++1 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_content(storage_no_invest_3)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
@@ -65,4 +82,7 @@ bounds
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_1) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_2) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_3) <= 100000.0
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_2) <= +inf
 end

--- a/tests/lp_files/storage_fixed_losses.lp
+++ b/tests/lp_files/storage_fixed_losses.lp
@@ -26,25 +26,42 @@ c_e_BusBlock_balance(electricityBus_2)_:
 +1 flow(storage_no_invest_electricityBus_2)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_no_invest_0)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+= -6203.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_1)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_1)
+= -1003.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_2)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_2)
+= -1003.0
+
 c_e_GenericStorageBlock_balance(storage_no_invest_0)_:
--0.97 flow(electricityBus_storage_no_invest_0)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_0)
-+1 GenericStorageBlock_storage_content(storage_no_invest_1)
-= 33797.0
++0.97 flow(electricityBus_storage_no_invest_0)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+-1 GenericStorageBlock_storage_content(storage_no_invest_1)
+= -40000.0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_1)_:
--0.97 flow(electricityBus_storage_no_invest_1)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_1)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_1)
-+1 GenericStorageBlock_storage_content(storage_no_invest_2)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_1)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++1 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_content(storage_no_invest_2)
+= 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_2)_:
--0.97 flow(electricityBus_storage_no_invest_2)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_2)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_2)
-+1 GenericStorageBlock_storage_content(storage_no_invest_3)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_2)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++1 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_content(storage_no_invest_3)
+= 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
 +1 GenericStorageBlock_storage_content(storage_no_invest_3)
@@ -57,6 +74,9 @@ bounds
    0 <= flow(storage_no_invest_electricityBus_0) <= 16667
    0 <= flow(storage_no_invest_electricityBus_1) <= 16667
    0 <= flow(storage_no_invest_electricityBus_2) <= 16667
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_2) <= +inf
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_1) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_2) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_3) <= 100000.0

--- a/tests/lp_files/storage_fixed_losses_multi_period.lp
+++ b/tests/lp_files/storage_fixed_losses_multi_period.lp
@@ -47,46 +47,81 @@ c_e_BusBlock_balance(electricityBus_5)_:
 +1 flow(storage_no_invest_electricityBus_5)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_no_invest_0)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+= -6203.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_1)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_1)
+= -1003.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_2)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_2)
+= -1003.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_3)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_3)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_3)
+= -1003.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_4)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_4)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_4)
+= -1003.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_5)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_5)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_5)
+= -1003.0
+
 c_e_GenericStorageBlock_balance(storage_no_invest_0)_:
--0.97 flow(electricityBus_storage_no_invest_0)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_0)
-+1 GenericStorageBlock_storage_content(storage_no_invest_1)
-= 33797.0
++0.97 flow(electricityBus_storage_no_invest_0)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+-1 GenericStorageBlock_storage_content(storage_no_invest_1)
+= -40000.0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_1)_:
--0.97 flow(electricityBus_storage_no_invest_1)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_1)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_1)
-+1 GenericStorageBlock_storage_content(storage_no_invest_2)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_1)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++1 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_content(storage_no_invest_2)
+= 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_2)_:
--0.97 flow(electricityBus_storage_no_invest_2)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_2)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_2)
-+1 GenericStorageBlock_storage_content(storage_no_invest_3)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_2)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++1 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_content(storage_no_invest_3)
+= 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_3)_:
--0.97 flow(electricityBus_storage_no_invest_3)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_3)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_3)
-+1 GenericStorageBlock_storage_content(storage_no_invest_4)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_3)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_3)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_3)
++1 GenericStorageBlock_storage_content(storage_no_invest_3)
+-1 GenericStorageBlock_storage_content(storage_no_invest_4)
+= 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_4)_:
--0.97 flow(electricityBus_storage_no_invest_4)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_4)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_4)
-+1 GenericStorageBlock_storage_content(storage_no_invest_5)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_4)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_4)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_4)
++1 GenericStorageBlock_storage_content(storage_no_invest_4)
+-1 GenericStorageBlock_storage_content(storage_no_invest_5)
+= 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_5)_:
--0.97 flow(electricityBus_storage_no_invest_5)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_5)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_5)
-+1 GenericStorageBlock_storage_content(storage_no_invest_6)
-= -1003.0
++0.97 flow(electricityBus_storage_no_invest_5)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_5)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_5)
++1 GenericStorageBlock_storage_content(storage_no_invest_5)
+-1 GenericStorageBlock_storage_content(storage_no_invest_6)
+= 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
 +1 GenericStorageBlock_storage_content(storage_no_invest_6)
@@ -105,6 +140,12 @@ bounds
    0 <= flow(storage_no_invest_electricityBus_3) <= 16667
    0 <= flow(storage_no_invest_electricityBus_4) <= 16667
    0 <= flow(storage_no_invest_electricityBus_5) <= 16667
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_5) <= +inf
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_1) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_2) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_3) <= 100000.0

--- a/tests/lp_files/storage_invest_3.lp
+++ b/tests/lp_files/storage_invest_3.lp
@@ -62,25 +62,40 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage3_0_2)_:
 -1 InvestmentFlowBlock_total(electricityBus_storage3_0)
 <= 0
 
+c_e_GenericStorageBlock_losses(storage3_0)_:
+-1 GenericStorageBlock_storage_losses(storage3_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_1)_:
+-1 GenericStorageBlock_storage_losses(storage3_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_2)_:
+-1 GenericStorageBlock_storage_losses(storage3_2)
+= 0
+
 c_e_GenericStorageBlock_balance(storage3_0)_:
--1 flow(electricityBus_storage3_0)
-+1 flow(storage3_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage3_0)
-+1 GenericStorageBlock_storage_content(storage3_1)
++1 flow(electricityBus_storage3_0)
+-1 flow(storage3_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage3_0)
++1 GenericStorageBlock_storage_content(storage3_0)
+-1 GenericStorageBlock_storage_content(storage3_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_1)_:
--1 flow(electricityBus_storage3_1)
-+1 flow(storage3_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage3_1)
-+1 GenericStorageBlock_storage_content(storage3_2)
++1 flow(electricityBus_storage3_1)
+-1 flow(storage3_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage3_1)
++1 GenericStorageBlock_storage_content(storage3_1)
+-1 GenericStorageBlock_storage_content(storage3_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_2)_:
--1 flow(electricityBus_storage3_2)
-+1 flow(storage3_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage3_2)
-+1 GenericStorageBlock_storage_content(storage3_3)
++1 flow(electricityBus_storage3_2)
+-1 flow(storage3_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage3_2)
++1 GenericStorageBlock_storage_content(storage3_2)
+-1 GenericStorageBlock_storage_content(storage3_3)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage3)_:
@@ -99,6 +114,9 @@ bounds
    0 <= flow(storage3_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage3_electricityBus_0) <= +inf
    0 <= InvestmentFlowBlock_total(electricityBus_storage3_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_2) <= +inf
    0 <= GenericStorageBlock_storage_content(storage3_0) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_1) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_2) <= 5000

--- a/tests/lp_files/storage_invest_3_multi_period.lp
+++ b/tests/lp_files/storage_invest_3_multi_period.lp
@@ -224,46 +224,76 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage3_2_5)_:
 -1 InvestmentFlowBlock_total(electricityBus_storage3_2)
 <= 0
 
+c_e_GenericStorageBlock_losses(storage3_0)_:
+-1 GenericStorageBlock_storage_losses(storage3_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_1)_:
+-1 GenericStorageBlock_storage_losses(storage3_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_2)_:
+-1 GenericStorageBlock_storage_losses(storage3_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_3)_:
+-1 GenericStorageBlock_storage_losses(storage3_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_4)_:
+-1 GenericStorageBlock_storage_losses(storage3_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage3_5)_:
+-1 GenericStorageBlock_storage_losses(storage3_5)
+= 0
+
 c_e_GenericStorageBlock_balance(storage3_0)_:
--1 flow(electricityBus_storage3_0)
-+1 flow(storage3_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage3_0)
-+1 GenericStorageBlock_storage_content(storage3_1)
++1 flow(electricityBus_storage3_0)
+-1 flow(storage3_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage3_0)
++1 GenericStorageBlock_storage_content(storage3_0)
+-1 GenericStorageBlock_storage_content(storage3_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_1)_:
--1 flow(electricityBus_storage3_1)
-+1 flow(storage3_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage3_1)
-+1 GenericStorageBlock_storage_content(storage3_2)
++1 flow(electricityBus_storage3_1)
+-1 flow(storage3_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage3_1)
++1 GenericStorageBlock_storage_content(storage3_1)
+-1 GenericStorageBlock_storage_content(storage3_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_2)_:
--1 flow(electricityBus_storage3_2)
-+1 flow(storage3_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage3_2)
-+1 GenericStorageBlock_storage_content(storage3_3)
++1 flow(electricityBus_storage3_2)
+-1 flow(storage3_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage3_2)
++1 GenericStorageBlock_storage_content(storage3_2)
+-1 GenericStorageBlock_storage_content(storage3_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_3)_:
--1 flow(electricityBus_storage3_3)
-+1 flow(storage3_electricityBus_3)
--1 GenericStorageBlock_storage_content(storage3_3)
-+1 GenericStorageBlock_storage_content(storage3_4)
++1 flow(electricityBus_storage3_3)
+-1 flow(storage3_electricityBus_3)
+-1 GenericStorageBlock_storage_losses(storage3_3)
++1 GenericStorageBlock_storage_content(storage3_3)
+-1 GenericStorageBlock_storage_content(storage3_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_4)_:
--1 flow(electricityBus_storage3_4)
-+1 flow(storage3_electricityBus_4)
--1 GenericStorageBlock_storage_content(storage3_4)
-+1 GenericStorageBlock_storage_content(storage3_5)
++1 flow(electricityBus_storage3_4)
+-1 flow(storage3_electricityBus_4)
+-1 GenericStorageBlock_storage_losses(storage3_4)
++1 GenericStorageBlock_storage_content(storage3_4)
+-1 GenericStorageBlock_storage_content(storage3_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage3_5)_:
--1 flow(electricityBus_storage3_5)
-+1 flow(storage3_electricityBus_5)
--1 GenericStorageBlock_storage_content(storage3_5)
-+1 GenericStorageBlock_storage_content(storage3_6)
++1 flow(electricityBus_storage3_5)
+-1 flow(storage3_electricityBus_5)
+-1 GenericStorageBlock_storage_losses(storage3_5)
++1 GenericStorageBlock_storage_content(storage3_5)
+-1 GenericStorageBlock_storage_content(storage3_6)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage3)_:
@@ -314,6 +344,12 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage3_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage3_5) <= +inf
    0 <= GenericStorageBlock_storage_content(storage3_0) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_1) <= 5000
    0 <= GenericStorageBlock_storage_content(storage3_2) <= 5000

--- a/tests/lp_files/storage_invest_5.lp
+++ b/tests/lp_files/storage_invest_5.lp
@@ -61,25 +61,40 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage5_0_2)_:
 -1 InvestmentFlowBlock_total(electricityBus_storage5_0)
 <= 0
 
+c_e_GenericStorageBlock_losses(storage5_0)_:
+-1 GenericStorageBlock_storage_losses(storage5_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_1)_:
+-1 GenericStorageBlock_storage_losses(storage5_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_2)_:
+-1 GenericStorageBlock_storage_losses(storage5_2)
+= 0
+
 c_e_GenericStorageBlock_balance(storage5_0)_:
--1 flow(electricityBus_storage5_0)
-+1 flow(storage5_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage5_0)
-+1 GenericStorageBlock_storage_content(storage5_1)
++1 flow(electricityBus_storage5_0)
+-1 flow(storage5_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage5_0)
++1 GenericStorageBlock_storage_content(storage5_0)
+-1 GenericStorageBlock_storage_content(storage5_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_1)_:
--1 flow(electricityBus_storage5_1)
-+1 flow(storage5_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage5_1)
-+1 GenericStorageBlock_storage_content(storage5_2)
++1 flow(electricityBus_storage5_1)
+-1 flow(storage5_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage5_1)
++1 GenericStorageBlock_storage_content(storage5_1)
+-1 GenericStorageBlock_storage_content(storage5_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_2)_:
--1 flow(electricityBus_storage5_2)
-+1 flow(storage5_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage5_2)
-+1 GenericStorageBlock_storage_content(storage5_3)
++1 flow(electricityBus_storage5_2)
+-1 flow(storage5_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage5_2)
++1 GenericStorageBlock_storage_content(storage5_2)
+-1 GenericStorageBlock_storage_content(storage5_3)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage5)_:
@@ -103,6 +118,9 @@ bounds
    0 <= flow(storage5_electricityBus_2) <= +inf
    0 <= InvestmentFlowBlock_total(storage5_electricityBus_0) <= +inf
    0 <= InvestmentFlowBlock_total(electricityBus_storage5_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_2) <= +inf
    0 <= GenericStorageBlock_storage_content(storage5_0) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_1) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_2) <= 10000

--- a/tests/lp_files/storage_invest_5_multi_period.lp
+++ b/tests/lp_files/storage_invest_5_multi_period.lp
@@ -220,46 +220,76 @@ c_u_InvestmentFlowBlock_max(electricityBus_storage5_2_5)_:
 -1 InvestmentFlowBlock_total(electricityBus_storage5_2)
 <= 0
 
+c_e_GenericStorageBlock_losses(storage5_0)_:
+-1 GenericStorageBlock_storage_losses(storage5_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_1)_:
+-1 GenericStorageBlock_storage_losses(storage5_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_2)_:
+-1 GenericStorageBlock_storage_losses(storage5_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_3)_:
+-1 GenericStorageBlock_storage_losses(storage5_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_4)_:
+-1 GenericStorageBlock_storage_losses(storage5_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage5_5)_:
+-1 GenericStorageBlock_storage_losses(storage5_5)
+= 0
+
 c_e_GenericStorageBlock_balance(storage5_0)_:
--1 flow(electricityBus_storage5_0)
-+1 flow(storage5_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage5_0)
-+1 GenericStorageBlock_storage_content(storage5_1)
++1 flow(electricityBus_storage5_0)
+-1 flow(storage5_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage5_0)
++1 GenericStorageBlock_storage_content(storage5_0)
+-1 GenericStorageBlock_storage_content(storage5_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_1)_:
--1 flow(electricityBus_storage5_1)
-+1 flow(storage5_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage5_1)
-+1 GenericStorageBlock_storage_content(storage5_2)
++1 flow(electricityBus_storage5_1)
+-1 flow(storage5_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage5_1)
++1 GenericStorageBlock_storage_content(storage5_1)
+-1 GenericStorageBlock_storage_content(storage5_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_2)_:
--1 flow(electricityBus_storage5_2)
-+1 flow(storage5_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage5_2)
-+1 GenericStorageBlock_storage_content(storage5_3)
++1 flow(electricityBus_storage5_2)
+-1 flow(storage5_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage5_2)
++1 GenericStorageBlock_storage_content(storage5_2)
+-1 GenericStorageBlock_storage_content(storage5_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_3)_:
--1 flow(electricityBus_storage5_3)
-+1 flow(storage5_electricityBus_3)
--1 GenericStorageBlock_storage_content(storage5_3)
-+1 GenericStorageBlock_storage_content(storage5_4)
++1 flow(electricityBus_storage5_3)
+-1 flow(storage5_electricityBus_3)
+-1 GenericStorageBlock_storage_losses(storage5_3)
++1 GenericStorageBlock_storage_content(storage5_3)
+-1 GenericStorageBlock_storage_content(storage5_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_4)_:
--1 flow(electricityBus_storage5_4)
-+1 flow(storage5_electricityBus_4)
--1 GenericStorageBlock_storage_content(storage5_4)
-+1 GenericStorageBlock_storage_content(storage5_5)
++1 flow(electricityBus_storage5_4)
+-1 flow(storage5_electricityBus_4)
+-1 GenericStorageBlock_storage_losses(storage5_4)
++1 GenericStorageBlock_storage_content(storage5_4)
+-1 GenericStorageBlock_storage_content(storage5_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage5_5)_:
--1 flow(electricityBus_storage5_5)
-+1 flow(storage5_electricityBus_5)
--1 GenericStorageBlock_storage_content(storage5_5)
-+1 GenericStorageBlock_storage_content(storage5_6)
++1 flow(electricityBus_storage5_5)
+-1 flow(storage5_electricityBus_5)
+-1 GenericStorageBlock_storage_losses(storage5_5)
++1 GenericStorageBlock_storage_content(storage5_5)
+-1 GenericStorageBlock_storage_content(storage5_6)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage5)_:
@@ -325,6 +355,12 @@ bounds
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_0) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_1) <= +inf
    0 <= InvestmentFlowBlock_old_exo(electricityBus_storage5_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage5_5) <= +inf
    0 <= GenericStorageBlock_storage_content(storage5_0) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_1) <= 10000
    0 <= GenericStorageBlock_storage_content(storage5_2) <= 10000

--- a/tests/lp_files/storage_level_constraint.lp
+++ b/tests/lp_files/storage_level_constraint.lp
@@ -88,17 +88,28 @@ c_e_BusBlock_balance(multiplexer_1)_:
 +1 flow(in_1_multiplexer_1)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_0)_:
+-1 GenericStorageBlock_storage_losses(storage_0)
+= -1.0
+
+c_e_GenericStorageBlock_losses(storage_1)_:
++0.25 GenericStorageBlock_storage_content(storage_1)
+-1 GenericStorageBlock_storage_losses(storage_1)
+= 0
+
 c_e_GenericStorageBlock_balance(storage_0)_:
--1 flow(multiplexer_storage_0)
-+1 flow(storage_multiplexer_0)
-+1 GenericStorageBlock_storage_content(storage_1)
-= 3.0
++1 flow(multiplexer_storage_0)
+-1 flow(storage_multiplexer_0)
+-1 GenericStorageBlock_storage_content(storage_1)
+-1 GenericStorageBlock_storage_losses(storage_0)
+= -4
 
 c_e_GenericStorageBlock_balance(storage_1)_:
--1 flow(multiplexer_storage_1)
-+1 flow(storage_multiplexer_1)
--0.75 GenericStorageBlock_storage_content(storage_1)
-+1 GenericStorageBlock_storage_content(storage_2)
++1 flow(multiplexer_storage_1)
+-1 flow(storage_multiplexer_1)
++1 GenericStorageBlock_storage_content(storage_1)
+-1 GenericStorageBlock_storage_content(storage_2)
+-1 GenericStorageBlock_storage_losses(storage_1)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage)_:
@@ -126,6 +137,8 @@ bounds
    0 <= GenericStorageBlock_storage_content(storage_2) <= 4
    0 <= multiplexer_active_input(in_1_0) <= 1
    0 <= multiplexer_active_input(in_1_1) <= 1
+   -inf <= GenericStorageBlock_storage_losses(storage_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_1) <= +inf
 binary
   multiplexer_active_output(out_0_0)
   multiplexer_active_output(out_0_1)

--- a/tests/lp_files/storage_multi_period.lp
+++ b/tests/lp_files/storage_multi_period.lp
@@ -47,45 +47,80 @@ c_e_BusBlock_balance(electricityBus_5)_:
 +1 flow(storage_no_invest_electricityBus_5)
 = 0
 
+c_e_GenericStorageBlock_losses(storage_no_invest_0)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+= -5200.0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_1)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_2)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_3)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_3)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_4)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_4)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage_no_invest_5)_:
+-1 GenericStorageBlock_storage_losses(storage_no_invest_5)
++0.13 GenericStorageBlock_storage_content(storage_no_invest_5)
+= 0
+
 c_e_GenericStorageBlock_balance(storage_no_invest_0)_:
--0.97 flow(electricityBus_storage_no_invest_0)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_0)
-+1 GenericStorageBlock_storage_content(storage_no_invest_1)
-= 34800.0
++0.97 flow(electricityBus_storage_no_invest_0)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_0)
+-1 GenericStorageBlock_storage_content(storage_no_invest_1)
+= -40000.0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_1)_:
--0.97 flow(electricityBus_storage_no_invest_1)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_1)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_1)
-+1 GenericStorageBlock_storage_content(storage_no_invest_2)
++0.97 flow(electricityBus_storage_no_invest_1)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_1)
++1 GenericStorageBlock_storage_content(storage_no_invest_1)
+-1 GenericStorageBlock_storage_content(storage_no_invest_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_2)_:
--0.97 flow(electricityBus_storage_no_invest_2)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_2)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_2)
-+1 GenericStorageBlock_storage_content(storage_no_invest_3)
++0.97 flow(electricityBus_storage_no_invest_2)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_2)
++1 GenericStorageBlock_storage_content(storage_no_invest_2)
+-1 GenericStorageBlock_storage_content(storage_no_invest_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_3)_:
--0.97 flow(electricityBus_storage_no_invest_3)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_3)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_3)
-+1 GenericStorageBlock_storage_content(storage_no_invest_4)
++0.97 flow(electricityBus_storage_no_invest_3)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_3)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_3)
++1 GenericStorageBlock_storage_content(storage_no_invest_3)
+-1 GenericStorageBlock_storage_content(storage_no_invest_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_4)_:
--0.97 flow(electricityBus_storage_no_invest_4)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_4)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_4)
-+1 GenericStorageBlock_storage_content(storage_no_invest_5)
++0.97 flow(electricityBus_storage_no_invest_4)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_4)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_4)
++1 GenericStorageBlock_storage_content(storage_no_invest_4)
+-1 GenericStorageBlock_storage_content(storage_no_invest_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage_no_invest_5)_:
--0.97 flow(electricityBus_storage_no_invest_5)
-+1.1627906976744187 flow(storage_no_invest_electricityBus_5)
--0.87 GenericStorageBlock_storage_content(storage_no_invest_5)
-+1 GenericStorageBlock_storage_content(storage_no_invest_6)
++0.97 flow(electricityBus_storage_no_invest_5)
+-1.1627906976744187 flow(storage_no_invest_electricityBus_5)
+-1 GenericStorageBlock_storage_losses(storage_no_invest_5)
++1 GenericStorageBlock_storage_content(storage_no_invest_5)
+-1 GenericStorageBlock_storage_content(storage_no_invest_6)
 = 0
 
 c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
@@ -105,6 +140,12 @@ bounds
    0 <= flow(storage_no_invest_electricityBus_3) <= 16667
    0 <= flow(storage_no_invest_electricityBus_4) <= 16667
    0 <= flow(storage_no_invest_electricityBus_5) <= 16667
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage_no_invest_5) <= +inf
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_1) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_2) <= 100000.0
    0.0 <= GenericStorageBlock_storage_content(storage_no_invest_3) <= 100000.0

--- a/tests/lp_files/storage_unbalanced.lp
+++ b/tests/lp_files/storage_unbalanced.lp
@@ -21,25 +21,40 @@ c_e_BusBlock_balance(electricityBus_2)_:
 +1 flow(storage1_electricityBus_2)
 = 0
 
+c_e_GenericStorageBlock_losses(storage1_0)_:
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_1)_:
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_2)_:
+-1 GenericStorageBlock_storage_losses(storage1_2)
+= 0
+
 c_e_GenericStorageBlock_balance(storage1_0)_:
--1 flow(electricityBus_storage1_0)
-+1 flow(storage1_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_1)
++1 flow(electricityBus_storage1_0)
+-1 flow(storage1_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage1_0)
++1 GenericStorageBlock_storage_content(storage1_0)
+-1 GenericStorageBlock_storage_content(storage1_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_1)_:
--1 flow(electricityBus_storage1_1)
-+1 flow(storage1_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage1_1)
-+1 GenericStorageBlock_storage_content(storage1_2)
++1 flow(electricityBus_storage1_1)
+-1 flow(storage1_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage1_1)
++1 GenericStorageBlock_storage_content(storage1_1)
+-1 GenericStorageBlock_storage_content(storage1_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_2)_:
--1 flow(electricityBus_storage1_2)
-+1 flow(storage1_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage1_2)
-+1 GenericStorageBlock_storage_content(storage1_3)
++1 flow(electricityBus_storage1_2)
+-1 flow(storage1_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage1_2)
++1 GenericStorageBlock_storage_content(storage1_2)
+-1 GenericStorageBlock_storage_content(storage1_3)
 = 0
 
 bounds
@@ -50,6 +65,9 @@ bounds
    0 <= flow(storage1_electricityBus_0) <= +inf
    0 <= flow(storage1_electricityBus_1) <= +inf
    0 <= flow(storage1_electricityBus_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_2) <= +inf
    0 <= GenericStorageBlock_storage_content(storage1_0) <= 1111
    0 <= GenericStorageBlock_storage_content(storage1_1) <= 1111
    0 <= GenericStorageBlock_storage_content(storage1_2) <= 1111

--- a/tests/lp_files/storage_unbalanced_multi_period.lp
+++ b/tests/lp_files/storage_unbalanced_multi_period.lp
@@ -36,46 +36,76 @@ c_e_BusBlock_balance(electricityBus_5)_:
 +1 flow(storage1_electricityBus_5)
 = 0
 
+c_e_GenericStorageBlock_losses(storage1_0)_:
+-1 GenericStorageBlock_storage_losses(storage1_0)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_1)_:
+-1 GenericStorageBlock_storage_losses(storage1_1)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_2)_:
+-1 GenericStorageBlock_storage_losses(storage1_2)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_3)_:
+-1 GenericStorageBlock_storage_losses(storage1_3)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_4)_:
+-1 GenericStorageBlock_storage_losses(storage1_4)
+= 0
+
+c_e_GenericStorageBlock_losses(storage1_5)_:
+-1 GenericStorageBlock_storage_losses(storage1_5)
+= 0
+
 c_e_GenericStorageBlock_balance(storage1_0)_:
--1 flow(electricityBus_storage1_0)
-+1 flow(storage1_electricityBus_0)
--1 GenericStorageBlock_storage_content(storage1_0)
-+1 GenericStorageBlock_storage_content(storage1_1)
++1 flow(electricityBus_storage1_0)
+-1 flow(storage1_electricityBus_0)
+-1 GenericStorageBlock_storage_losses(storage1_0)
++1 GenericStorageBlock_storage_content(storage1_0)
+-1 GenericStorageBlock_storage_content(storage1_1)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_1)_:
--1 flow(electricityBus_storage1_1)
-+1 flow(storage1_electricityBus_1)
--1 GenericStorageBlock_storage_content(storage1_1)
-+1 GenericStorageBlock_storage_content(storage1_2)
++1 flow(electricityBus_storage1_1)
+-1 flow(storage1_electricityBus_1)
+-1 GenericStorageBlock_storage_losses(storage1_1)
++1 GenericStorageBlock_storage_content(storage1_1)
+-1 GenericStorageBlock_storage_content(storage1_2)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_2)_:
--1 flow(electricityBus_storage1_2)
-+1 flow(storage1_electricityBus_2)
--1 GenericStorageBlock_storage_content(storage1_2)
-+1 GenericStorageBlock_storage_content(storage1_3)
++1 flow(electricityBus_storage1_2)
+-1 flow(storage1_electricityBus_2)
+-1 GenericStorageBlock_storage_losses(storage1_2)
++1 GenericStorageBlock_storage_content(storage1_2)
+-1 GenericStorageBlock_storage_content(storage1_3)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_3)_:
--1 flow(electricityBus_storage1_3)
-+1 flow(storage1_electricityBus_3)
--1 GenericStorageBlock_storage_content(storage1_3)
-+1 GenericStorageBlock_storage_content(storage1_4)
++1 flow(electricityBus_storage1_3)
+-1 flow(storage1_electricityBus_3)
+-1 GenericStorageBlock_storage_losses(storage1_3)
++1 GenericStorageBlock_storage_content(storage1_3)
+-1 GenericStorageBlock_storage_content(storage1_4)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_4)_:
--1 flow(electricityBus_storage1_4)
-+1 flow(storage1_electricityBus_4)
--1 GenericStorageBlock_storage_content(storage1_4)
-+1 GenericStorageBlock_storage_content(storage1_5)
++1 flow(electricityBus_storage1_4)
+-1 flow(storage1_electricityBus_4)
+-1 GenericStorageBlock_storage_losses(storage1_4)
++1 GenericStorageBlock_storage_content(storage1_4)
+-1 GenericStorageBlock_storage_content(storage1_5)
 = 0
 
 c_e_GenericStorageBlock_balance(storage1_5)_:
--1 flow(electricityBus_storage1_5)
-+1 flow(storage1_electricityBus_5)
--1 GenericStorageBlock_storage_content(storage1_5)
-+1 GenericStorageBlock_storage_content(storage1_6)
++1 flow(electricityBus_storage1_5)
+-1 flow(storage1_electricityBus_5)
+-1 GenericStorageBlock_storage_losses(storage1_5)
++1 GenericStorageBlock_storage_content(storage1_5)
+-1 GenericStorageBlock_storage_content(storage1_6)
 = 0
 
 bounds
@@ -92,6 +122,12 @@ bounds
    0 <= flow(storage1_electricityBus_3) <= +inf
    0 <= flow(storage1_electricityBus_4) <= +inf
    0 <= flow(storage1_electricityBus_5) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_0) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_1) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_2) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_3) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_4) <= +inf
+   -inf <= GenericStorageBlock_storage_losses(storage1_5) <= +inf
    0 <= GenericStorageBlock_storage_content(storage1_0) <= 1111
    0 <= GenericStorageBlock_storage_content(storage1_1) <= 1111
    0 <= GenericStorageBlock_storage_content(storage1_2) <= 1111

--- a/tests/test_components/test_storage.py
+++ b/tests/test_components/test_storage.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+import numpy as np
+
+from oemof import solph
+
+
+def test_relative_losses():
+    cases = [
+        {"number": 500, "interval": 2},
+        {"number": 1000, "interval": 1},
+        {"number": 2000, "interval": 0.5},
+    ]
+
+    for case in cases:
+        es = solph.EnergySystem(
+            timeindex=solph.create_time_index(
+                year=2023, number=case["number"], interval=case["interval"]
+            ),
+            infer_last_interval=True,
+        )
+
+        bus = solph.Bus("slack_bus", balanced=False)
+        es.add(bus)
+
+        storage = solph.components.GenericStorage(
+            "storage",
+            inputs={bus: solph.Flow(variable_costs=1)},
+            outputs={bus: solph.Flow(variable_costs=1)},
+            nominal_storage_capacity=10,
+            initial_storage_level=1,
+            loss_rate=0.004125876075,  # half life of one week
+        )
+        es.add(storage)
+
+        model = solph.Model(es)
+        model.solve("cbc")
+
+        result = solph.processing.results(model)[(storage, None)]["sequences"][
+            "storage_content"
+        ]
+        case["result"] = np.array(result)
+
+    for i in range(500):
+        assert (
+            cases[0]["result"][i]
+            == pytest.approx(cases[1]["result"][2 * i])
+            == pytest.approx(cases[2]["result"][4 * i])
+        )

--- a/tests/test_components/test_storage.py
+++ b/tests/test_components/test_storage.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-import pytest
 import numpy as np
+import pytest
 
 from oemof import solph
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -16,6 +16,4 @@ def test_check_age_and_lifetime():
     """Check error being thrown if age > lifetime"""
     msg = "A unit's age must be smaller than its expected lifetime."
     with pytest.raises(AttributeError, match=msg):
-        solph.Flow(
-            nominal_value=solph.Investment(age=41, lifetime=40)
-        )
+        solph.Flow(nominal_value=solph.Investment(age=41, lifetime=40))

--- a/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
+++ b/tests/test_scripts/test_solph/test_storage_investment/test_storage_with_tuple_label.py
@@ -217,8 +217,8 @@ def test_tuples_as_labels_example(
     # Problem results
     assert int(meta["problem"]["Lower bound"]) == 37819254
     assert int(meta["problem"]["Upper bound"]) == 37819254
-    assert meta["problem"]["Number of variables"] == 280
-    assert meta["problem"]["Number of constraints"] == 162
+    assert meta["problem"]["Number of variables"] == 320
+    assert meta["problem"]["Number of constraints"] == 202
     assert meta["problem"]["Number of nonzeros"] == 116
     assert meta["problem"]["Number of objectives"] == 1
     assert str(meta["problem"]["Sense"]) == "minimize"


### PR DESCRIPTION
I think it makes a lot of sense, e.g. for adding custom constraints, to have an explicit variable for the losses of the storage. Note that the formula for the relative lasses is more complicated
```
losses(t) = energy(t) * (1-(1-b)**tau))
energy(t+1)= energy(t)-losses(t)
``` 
vs
```
energy(t+1) = energy(t) * (1-b)**tau
```
but I think the additional variable and constraint is useful and the 1-(1-b)**tau instead of (1-b)**tau changes a value in the lp file, so it will not significantly increase computational time.

PS: I existentially pushed this change to dev, so this PR reverts the revert.