### PR TITLE
Display inline math correctly and hint towards the usage of the inbuilt slope and offset calculation methods

### DIFF
--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -52,8 +52,8 @@ class OffsetConverter(Node):
         be a scalar or a sequence with length of time horizon for simulation.
     Notes
     -----
-    **:math:`m(t)` and :math:`y_\text{0,normed}(t)` can be calculated as **
-    **follows:**
+
+    :math:`m(t)` and :math:`y_\text{0,normed}(t)` can be calculated as follows:
 
     .. _OffsetConverterCoefficients-equations:
 
@@ -66,7 +66,18 @@ class OffsetConverter(Node):
     Where :math:`l_{max}` and :math:`l_{min}` are the maximum and minimum
     partload share (e.g. 1.0 and 0.5) with reference to the `NonConvex` flow
     and :math:`\eta_{max}` and :math:`\eta_{min}` are the respective
-    efficiencies/conversion factors at these partloads.
+    efficiencies/conversion factors at these partloads. Alternatively, you can
+    use the inbuilt methods:
+
+    - If the `NonConvex` flow is at an input of the component:
+      :py:meth:`oemof.solph.components._offset_converter.slope_offset_from_nonconvex_input`,
+    - If the `NonConvex` flow is at an output of the component:
+      :py:meth:`oemof.solph.components._offset_converter.slope_offset_from_nonconvex_output`
+
+    You can import these methods from the `oemof.solph.components` level:
+
+    >>> from oemof.solph.components import slope_offset_from_nonconvex_input
+    >>> from oemof.solph.components import slope_offset_from_nonconvex_output
 
     The sets, variables, constraints and objective parts are created
      * :py:class:`~oemof.solph.components._offset_converter.OffsetConverterBlock`
@@ -83,6 +94,17 @@ class OffsetConverter(Node):
     >>> eta_min = 0.3
     >>> slope = (l_max / eta_max - l_min / eta_min) / (l_max - l_min)
     >>> offset = 1 / eta_max - slope
+
+    Or use the provided method as explained in the previous section:
+
+    >>> _slope, _offset = slope_offset_from_nonconvex_output(
+    ...     l_max, l_min, eta_max, eta_min
+    ... )
+    >>> slope == _slope
+    True
+    >>> offset == _offset
+    True
+
     >>> ostf = solph.components.OffsetConverter(
     ...    label='ostf',
     ...    inputs={bel: solph.flows.Flow()},


### PR DESCRIPTION
Basically what the title says.

There was an issue, where the inline math inside the NOTE block did not render correctly. On top of that, the API documentation of the `OffsetConverter` now also hints towards the usage of the inbuilt methods to calculate slope and offset.