### PR TITLE
Fix/storage costs for initial level

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,7 @@ These are new features and improvements of note in each release
     :backlinks: top
 
 
+.. include::  whatsnew/v0-6-0.rst
 .. include::  whatsnew/v0-5-4.rst
 .. include::  whatsnew/v0-5-3.rst
 .. include::  whatsnew/v0-5-2.rst

--- a/docs/whatsnew/v0-6-0.rst
+++ b/docs/whatsnew/v0-6-0.rst
@@ -1,0 +1,38 @@
+v0.6.0
+------
+
+API changes
+###########
+
+* Costs for energy storage are now defined for N-1 points in time
+  (initial time step is neglected). This is because with a balanced
+  storage, content of the initial and the first time step (which is
+  effectively the same) had double weight before. Also, if the
+  initial storage level is defined, the costs just offset the
+  objective value without changing anything else.
+
+New features
+############
+
+
+Documentation
+#############
+
+Bug fixes
+#########
+
+
+Other changes
+#############
+
+
+Known issues
+############
+
+* Incompatible to numpy >= 2.0.0. This is because of Pyomo, but we have to
+  enforce a lower version in our package.
+
+Contributors
+############
+
+* Patrik Schönfeldt

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -110,7 +110,8 @@ class GenericStorage(Node):
         nominal_storage_capacity should not be set (or set to None) if an
         investment object is used.
     storage_costs : numeric (iterable or scalar), :math:`c_{storage}(t)`
-        Cost (per energy) for having energy in the storage.
+        Cost (per energy) for having energy in the storage, starting from
+        time point :math:`t_{1}`.
     lifetime_inflow : int, :math:`n_{in}`
         Determine the lifetime of an inflow; only applicable for multi-period
         models which can invest in storage capacity and have an
@@ -423,7 +424,7 @@ class GenericStorageBlock(ScalarBlock):
     * :attr: `storage_costs` not 0
 
         .. math::
-            \sum_{t \in \textrm{TIMESTEPS}} c_{storage}(t) \cdot E(t)
+            \sum_{t \in \textrm{TIMEPOINTS} > 0} c_{storage}(t) \cdot E(t)
 
 
     *Multi-period model*

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -616,12 +616,9 @@ class GenericStorageBlock(ScalarBlock):
 
         for n in self.STORAGES:
             if n.storage_costs[0] is not None:
-                storage_costs += (
-                    self.storage_content[n, 0] * n.storage_costs[0]
-                )
-                for t in m.TIMESTEPS:
+                for t in m.TIMEPOINTS:
                     storage_costs += (
-                        self.storage_content[n, t + 1] * n.storage_costs[t + 1]
+                        self.storage_content[n, t] * n.storage_costs[t]
                     )
 
         self.storage_costs = Expression(expr=storage_costs)

--- a/src/oemof/solph/components/_generic_storage.py
+++ b/src/oemof/solph/components/_generic_storage.py
@@ -616,9 +616,12 @@ class GenericStorageBlock(ScalarBlock):
 
         for n in self.STORAGES:
             if n.storage_costs[0] is not None:
-                for t in m.TIMEPOINTS:
+                # We actually want to iterate over all TIMEPOINTS except the
+                # 0th. As integers are used for the index, this is equicalent
+                # to iterating over the TIMESTEPS with one offset.
+                for t in m.TIMESTEPS:
                     storage_costs += (
-                        self.storage_content[n, t] * n.storage_costs[t]
+                        self.storage_content[n, t + 1] * n.storage_costs[t]
                     )
 
         self.storage_costs = Expression(expr=storage_costs)

--- a/tests/constraint_tests.py
+++ b/tests/constraint_tests.py
@@ -283,7 +283,7 @@ class TestsConstraint:
             },
             nominal_storage_capacity=1e5,
             loss_rate=0.13,
-            storage_costs=0.1,
+            storage_costs=[0.1, 0.2, 0.3, 0.4],
             inflow_conversion_factor=0.97,
             outflow_conversion_factor=0.86,
             initial_storage_level=0.4,

--- a/tests/lp_files/storage.lp
+++ b/tests/lp_files/storage.lp
@@ -2,7 +2,6 @@
 
 min 
 objective:
-+4000.0 ONE_VAR_CONSTANT
 +56 flow(electricityBus_storage_no_invest_0)
 +56 flow(electricityBus_storage_no_invest_1)
 +56 flow(electricityBus_storage_no_invest_2)
@@ -10,8 +9,8 @@ objective:
 +24 flow(storage_no_invest_electricityBus_1)
 +24 flow(storage_no_invest_electricityBus_2)
 +0.1 GenericStorageBlock_storage_content(storage_no_invest_1)
-+0.1 GenericStorageBlock_storage_content(storage_no_invest_2)
-+0.1 GenericStorageBlock_storage_content(storage_no_invest_3)
++0.2 GenericStorageBlock_storage_content(storage_no_invest_2)
++0.3 GenericStorageBlock_storage_content(storage_no_invest_3)
 
 s.t.
 
@@ -72,7 +71,6 @@ c_e_GenericStorageBlock_balanced_cstr(storage_no_invest)_:
 = 40000.0
 
 bounds
-   1 <= ONE_VAR_CONSTANT <= 1
    0 <= flow(electricityBus_storage_no_invest_0) <= 16667
    0 <= flow(electricityBus_storage_no_invest_1) <= 16667
    0 <= flow(electricityBus_storage_no_invest_2) <= 16667


### PR DESCRIPTION
* For optimisation using an assumed cyclic time, it does not make sense to consider both, the 0th and N+1st time point. This can be seen in particular as the storage is typically balanced, so it is really one value that gains twice the weight.
* If time is assumed linear (no balanced storage), there are N+1 points in time for N time steps. Thus, the implementation makes sense to me. However, typically the initial content is predefined, so it just gives an offset to the objective value.

Thus, I suggest to drop the costs for the 0th time step.

Targeted for the next "major" release, because it can change the behaviour in some cases.