### PR TITLE
Draft: Calculate Mipgap in the meta results

### DIFF
--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -481,6 +481,13 @@ def meta_results(om, undefined=False):
                     meta_res[k1][k2] = msg.format(
                         type(om.es.results[k1][0][k2])
                     )
+    try:
+        meta_res["problem"]["MIPGap"] = (
+            meta_res["problem"]["Upper bound"]
+            - meta_res["problem"]["Lower bound"]
+        ) / meta_res["problem"]["Lower bound"]
+    except KeyError:
+        pass
 
     return meta_res
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -87,6 +87,19 @@ class TestParameterResult:
         cls.mod = Model(cls.es)
         cls.mod.solve()
 
+    def test_mipgap(self):
+        """Test that one can access the MIPGap."""
+        meta = processing.meta_results(self.om)
+        assert "MIPGap" in meta["problem"], (
+            'No "MIPGap" in `meta_results`.'
+            " Maybe you're using solver other than cbc or gurobi?"
+        )
+        assert meta["problem"]["MIPGap"] == 0, (
+            "Incorrect MIPGap value."
+            "\nExpected: `0`"
+            f"\nGot: `{meta['problem']['MIPGap']}`"
+        )
+
     def test_flows_with_none_exclusion(self):
         b_el2 = self.es.groups["b_el2"]
         demand = self.es.groups["demand_el"]


### PR DESCRIPTION
in the processing.py the mipgap is calculated using the Upper and Lower bound returned by pyomo and written in the meta results dictionary.
A test  tests this functionality.
