### PR TITLE
Rename custom_attributes to custom_properties for Nodes

### DIFF
--- a/docs/whatsnew/v0-6-0.rst
+++ b/docs/whatsnew/v0-6-0.rst
@@ -10,6 +10,11 @@ API changes
   effectively the same) had double weight before. Also, if the
   initial storage level is defined, the costs just offset the
   objective value without changing anything else.
+* Rename custom_attributes to custom_properties for all Nodes.
+  Setting the oemof.network.Node.custom_properties
+  using an argument called "custom_attributes" was rather confusing.
+  Additionally, the class Bus already called the argument
+  "custom_properties".
 
 New features
 ############

--- a/src/oemof/solph/components/_converter.py
+++ b/src/oemof/solph/components/_converter.py
@@ -99,21 +99,20 @@ class Converter(Node):
         inputs=None,
         outputs=None,
         conversion_factors=None,
-        custom_attributes=None,
+        custom_properties=None,
     ):
         if inputs is None:
             inputs = {}
         if outputs is None:
             outputs = {}
-
-        if custom_attributes is None:
-            custom_attributes = {}
+        if custom_properties is None:
+            custom_properties = {}
 
         super().__init__(
             label=label,
             inputs=inputs,
             outputs=outputs,
-            custom_properties=custom_attributes,
+            custom_properties=custom_properties,
         )
         if not inputs:
             warn_if_missing_attribute(self, "inputs")

--- a/src/oemof/solph/components/_converter.py
+++ b/src/oemof/solph/components/_converter.py
@@ -152,7 +152,7 @@ class Transformer(Converter):
             inputs=inputs,
             outputs=outputs,
             conversion_factors=conversion_factors,
-            custom_attributes=custom_attributes,
+            custom_properties=custom_attributes,
         )
         warn(
             "solph.components.Transformer has been renamed to"

--- a/src/oemof/solph/components/_extraction_turbine_chp.py
+++ b/src/oemof/solph/components/_extraction_turbine_chp.py
@@ -77,14 +77,14 @@ class ExtractionTurbineCHP(Converter):
         inputs=None,
         outputs=None,
         conversion_factors=None,
-        custom_attributes=None,
+        custom_properties=None,
     ):
         super().__init__(
             label=label,
             inputs=inputs,
             outputs=outputs,
             conversion_factors=conversion_factors,
-            custom_attributes=custom_attributes,
+            custom_properties=custom_properties,
         )
         self.conversion_factor_full_condensation = {
             k: sequence(v)

--- a/src/oemof/solph/components/_generic_chp.py
+++ b/src/oemof/solph/components/_generic_chp.py
@@ -104,16 +104,16 @@ class GenericCHP(Node):
     >>> ccet = solph.components.GenericCHP(
     ...    label='combined_cycle_extraction_turbine',
     ...    fuel_input={bgas: solph.flows.Flow(
-    ...        custom_properties={"H_L_FG_share_max": [0.183]})},
+    ...        custom_attributes={"H_L_FG_share_max": [0.183]})},
     ...    electrical_output={bel: solph.flows.Flow(
-    ...        custom_properties={
+    ...        custom_attributes={
     ...            "P_max_woDH": [155.946],
     ...            "P_min_woDH": [68.787],
     ...            "Eta_el_max_woDH": [0.525],
     ...            "Eta_el_min_woDH": [0.444],
     ...        })},
     ...    heat_output={bth: solph.flows.Flow(
-    ...        custom_properties={"Q_CW_min": [10.552]})},
+    ...        custom_attributes={"Q_CW_min": [10.552]})},
     ...    beta=[0.122], back_pressure=False)
     >>> type(ccet)
     <class 'oemof.solph.components._generic_chp.GenericCHP'>

--- a/src/oemof/solph/components/_generic_chp.py
+++ b/src/oemof/solph/components/_generic_chp.py
@@ -104,16 +104,16 @@ class GenericCHP(Node):
     >>> ccet = solph.components.GenericCHP(
     ...    label='combined_cycle_extraction_turbine',
     ...    fuel_input={bgas: solph.flows.Flow(
-    ...        custom_attributes={"H_L_FG_share_max": [0.183]})},
+    ...        custom_properties={"H_L_FG_share_max": [0.183]})},
     ...    electrical_output={bel: solph.flows.Flow(
-    ...        custom_attributes={
+    ...        custom_properties={
     ...            "P_max_woDH": [155.946],
     ...            "P_min_woDH": [68.787],
     ...            "Eta_el_max_woDH": [0.525],
     ...            "Eta_el_min_woDH": [0.444],
     ...        })},
     ...    heat_output={bth: solph.flows.Flow(
-    ...        custom_attributes={"Q_CW_min": [10.552]})},
+    ...        custom_properties={"Q_CW_min": [10.552]})},
     ...    beta=[0.122], back_pressure=False)
     >>> type(ccet)
     <class 'oemof.solph.components._generic_chp.GenericCHP'>
@@ -127,11 +127,11 @@ class GenericCHP(Node):
         beta,
         back_pressure,
         label=None,
-        custom_attributes=None,
+        custom_properties=None,
     ):
-        if custom_attributes is None:
-            custom_attributes = {}
-        super().__init__(label, custom_properties=custom_attributes)
+        if custom_properties is None:
+            custom_properties = {}
+        super().__init__(label, custom_properties=custom_properties)
 
         self.fuel_input = fuel_input
         self.electrical_output = electrical_output

--- a/src/oemof/solph/components/_offset_converter.py
+++ b/src/oemof/solph/components/_offset_converter.py
@@ -139,16 +139,16 @@ class OffsetConverter(Node):
         conversion_factors=None,
         normed_offsets=None,
         coefficients=None,
-        custom_attributes=None,
+        custom_properties=None,
     ):
-        if custom_attributes is None:
-            custom_attributes = {}
+        if custom_properties is None:
+            custom_properties = {}
 
         super().__init__(
             inputs=inputs,
             outputs=outputs,
             label=label,
-            custom_properties=custom_attributes,
+            custom_properties=custom_properties,
         )
 
         # this part is used for the transition phase from the old
@@ -393,7 +393,7 @@ class OffsetTransformer(OffsetConverter):
             inputs=inputs,
             outputs=outputs,
             coefficients=coefficients,
-            custom_attributes=custom_attributes,
+            custom_properties=custom_attributes,
         )
         warn(
             "solph.components.OffsetTransformer has been renamed to"

--- a/src/oemof/solph/components/_sink.py
+++ b/src/oemof/solph/components/_sink.py
@@ -41,14 +41,14 @@ class Sink(Node):
 
     """
 
-    def __init__(self, label=None, *, inputs, custom_attributes=None):
+    def __init__(self, label=None, *, inputs, custom_properties=None):
         if inputs is None:
             inputs = {}
-        if custom_attributes is None:
-            custom_attributes = {}
+        if custom_properties is None:
+            custom_properties = {}
 
         super().__init__(
-            label=label, inputs=inputs, custom_properties=custom_attributes
+            label=label, inputs=inputs, custom_properties=custom_properties
         )
 
     def constraint_group(self):

--- a/src/oemof/solph/components/experimental/_sink_dsm.py
+++ b/src/oemof/solph/components/experimental/_sink_dsm.py
@@ -271,12 +271,12 @@ class SinkDSM(Sink):
         shift_eligibility=True,
         fixed_costs=0,
         investment=None,
-        custom_attributes=None,
+        custom_properties=None,
     ):
-        if custom_attributes is None:
-            custom_attributes = {}
+        if custom_properties is None:
+            custom_properties = {}
         super().__init__(
-            label=label, inputs=inputs, custom_attributes=custom_attributes
+            label=label, inputs=inputs, custom_properties=custom_properties
         )
 
         self.capacity_up = sequence(capacity_up)

--- a/tests/test_components/test_offset_converter.py
+++ b/tests/test_components/test_offset_converter.py
@@ -177,7 +177,7 @@ def test_custom_properties():
         outputs={bus2: solph.Flow()},
         conversion_factors={bus2: 2},
         normed_offsets={bus2: -0.5},
-        custom_attributes={"foo": "bar"},
+        custom_properties={"foo": "bar"},
     )
 
     assert oc.custom_properties["foo"] == "bar"


### PR DESCRIPTION
Setting the `oemof.network.Node.custom_properties` using an argument called `custom_attributes` was rather confusing. Additionally, the class Bus already called the argument `custom_properties`.

