### PR TITLE
Fix bugs in parameter as dict

### DIFF
--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -53,7 +53,8 @@ def sequence(iterable_or_scalar):
         raise ValueError(
             f"Dimension too high ({d} > 1) for {iterable_or_scalar}\n"
             "The dimension of a number is 0, of a list 1, of a table 2 and so "
-            "on."
+            "on.\nPlease notice that a table with one column is still a table "
+            "with 2 dimensions and not a Series."
         )
     if isinstance(iterable_or_scalar, str):
         return iterable_or_scalar

--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -51,7 +51,9 @@ def sequence(iterable_or_scalar):
     if len(np.shape(iterable_or_scalar)) > 1:
         d = len(np.shape(iterable_or_scalar))
         raise ValueError(
-            f"Dimension too high ({d} > 1) for {iterable_or_scalar}"
+            f"Dimension too high ({d} > 1) for {iterable_or_scalar}\n"
+            "The dimension of a number is 0, of a list 1, of a table 2 and so "
+            "on."
         )
     if isinstance(iterable_or_scalar, str):
         return iterable_or_scalar

--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -48,6 +48,11 @@ def sequence(iterable_or_scalar):
     10
 
     """
+    if len(np.shape(iterable_or_scalar)) > 1:
+        d = len(np.shape(iterable_or_scalar))
+        raise ValueError(
+            f"Dimension too high ({d} > 1) for {iterable_or_scalar}"
+        )
     if isinstance(iterable_or_scalar, str):
         return iterable_or_scalar
     elif isinstance(iterable_or_scalar, abc.Iterable):

--- a/src/oemof/solph/components/_source.py
+++ b/src/oemof/solph/components/_source.py
@@ -27,6 +27,9 @@ class Source(Node):
     outputs: dict
         A dictionary mapping input nodes to corresponding outflows
         (i.e. output values).
+    custom_properties: dict
+        Additional keyword arguments for use in user-defined equations or for
+        information purposes.
 
     Examples
     --------
@@ -47,16 +50,23 @@ class Source(Node):
 
     >>> str(pv_plant.outputs[bel].output)
     'electricity'
+    >>> bgas = solph.buses.Bus(label='gas')
+    >>> gas_source = solph.components.Source(
+    ...    label='gas_import',
+    ...    outputs={bgas: solph.flows.Flow()},
+    ...    custom_properties={"emission": 201})  # g/kWh
+    >>> gas_source.custom_properties["emission"]
+    201
     """
 
-    def __init__(self, label=None, *, outputs, custom_attributes=None):
+    def __init__(self, label=None, *, outputs, custom_properties=None):
         if outputs is None:
             outputs = {}
-        if custom_attributes is None:
-            custom_attributes = {}
+        if custom_properties is None:
+            custom_properties = {}
 
         super().__init__(
-            label=label, outputs=outputs, custom_properties=custom_attributes
+            label=label, outputs=outputs, custom_properties=custom_properties
         )
 
     def constraint_group(self):

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -16,6 +16,7 @@ SPDX-License-Identifier: MIT
 
 """
 
+import numbers
 import sys
 from collections import abc
 from itertools import groupby

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -589,7 +589,7 @@ def __separate_attrs(
 
     def move_undetected_scalars(com):
         for ckey, value in list(com["sequences"].items()):
-            if isinstance(value, str):
+            if isinstance(value, (str, int, float, np.number)):
                 com["scalars"][ckey] = value
                 del com["sequences"][ckey]
             elif isinstance(value, _FakeSequence):

--- a/tests/test_outputlib/test_processing.py
+++ b/tests/test_outputlib/test_processing.py
@@ -25,7 +25,12 @@ def test_custom_attribut_with_numeric_value():
         inputs={bs: Flow()},
         custom_properties={"numpy-float": s1["a"]},
     )
-    energysystem.add(snk_custom_float, src_custom_int)
+    src_custom_str = Source(
+        label="source_with_custom_attribute_string",
+        outputs={bs: Flow(nominal_value=5, fix=[3] * 7)},
+        custom_attributes={"string": "name"},
+    )
+    energysystem.add(snk_custom_float, src_custom_int, src_custom_str)
 
     # create optimization model based on energy_system
     optimization_model = Model(energysystem=energysystem)
@@ -40,4 +45,8 @@ def test_custom_attribut_with_numeric_value():
     assert (
         parameter[src_custom_int, None]["scalars"]["custom_properties_integer"]
         == 9
+    )
+    assert (
+        parameter[src_custom_str, None]["scalars"]["custom_properties_string"]
+        == "name"
     )

--- a/tests/test_outputlib/test_processing.py
+++ b/tests/test_outputlib/test_processing.py
@@ -1,7 +1,8 @@
 import pandas as pd
 
-from oemof.solph import EnergySystem, create_time_index
+from oemof.solph import EnergySystem
 from oemof.solph import Model
+from oemof.solph import create_time_index
 from oemof.solph import processing
 from oemof.solph.buses import Bus
 from oemof.solph.components import Sink

--- a/tests/test_outputlib/test_processing.py
+++ b/tests/test_outputlib/test_processing.py
@@ -29,7 +29,7 @@ def test_custom_attribut_with_numeric_value():
     src_custom_str = Source(
         label="source_with_custom_attribute_string",
         outputs={bs: Flow(nominal_value=5, fix=[3] * 7)},
-        custom_attributes={"string": "name"},
+        custom_properties={"string": "name"},
     )
     energysystem.add(snk_custom_float, src_custom_int, src_custom_str)
 

--- a/tests/test_outputlib/test_processing.py
+++ b/tests/test_outputlib/test_processing.py
@@ -1,0 +1,43 @@
+import pandas as pd
+
+from oemof.solph import EnergySystem, create_time_index
+from oemof.solph import Model
+from oemof.solph import processing
+from oemof.solph.buses import Bus
+from oemof.solph.components import Sink
+from oemof.solph.components import Source
+from oemof.solph.flows import Flow
+
+
+def test_custom_attribut_with_numeric_value():
+    date_time_index = create_time_index(2012, number=6)
+    energysystem = EnergySystem(timeindex=date_time_index)
+    bs = Bus(label="bus")
+    energysystem.add(bs)
+    src_custom_int = Source(
+        label="source_with_custom_attribute_int",
+        outputs={bs: Flow(nominal_value=5, fix=[3] * 7)},
+        custom_attributes={"integer": 9},
+    )
+    s1 = pd.Series([1.4, 2.3], index=["a", "b"])
+    snk_custom_float = Sink(
+        label="source_with_custom_attribute_float",
+        inputs={bs: Flow()},
+        custom_properties={"numpy-float": s1["a"]},
+    )
+    energysystem.add(snk_custom_float, src_custom_int)
+
+    # create optimization model based on energy_system
+    optimization_model = Model(energysystem=energysystem)
+
+    parameter = processing.parameter_as_dict(optimization_model)
+    assert (
+        parameter[snk_custom_float, None]["scalars"][
+            "custom_properties_numpy-float"
+        ]
+        == 1.4
+    )
+    assert (
+        parameter[src_custom_int, None]["scalars"]["custom_properties_integer"]
+        == 9
+    )

--- a/tests/test_outputlib/test_processing.py
+++ b/tests/test_outputlib/test_processing.py
@@ -18,7 +18,7 @@ def test_custom_attribut_with_numeric_value():
     src_custom_int = Source(
         label="source_with_custom_attribute_int",
         outputs={bs: Flow(nominal_value=5, fix=[3] * 7)},
-        custom_attributes={"integer": 9},
+        custom_properties={"integer": 9},
     )
     s1 = pd.Series([1.4, 2.3], index=["a", "b"])
     snk_custom_float = Sink(

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -7,6 +7,7 @@ SPDX-FileCopyrightText: Patrik Schönfeldt
 SPDX-License-Identifier: MIT
 """
 import numpy as np
+import pandas as pd
 import pytest
 
 from oemof.solph._plumbing import _FakeSequence
@@ -64,6 +65,15 @@ def test_sequence():
     seq_ab = sequence("ab")
     assert isinstance(seq_ab, str)
     assert seq_ab == "ab"
+
+
+def test_dimension_is_too_high_to_create_a_sequence():
+    df = pd.DataFrame({"epc": 5}, index=["a"])
+    with pytest.raises(ValueError, match="Dimension too high"):
+        sequence(df)
+    n2 = [[4]]
+    with pytest.raises(ValueError, match="Dimension too high"):
+        sequence(n2)
 
 
 def test_valid_sequence():


### PR DESCRIPTION
I ran into 2 problems while using `parameter_as_dict()` from the `processing` module.
    1. Using `custom_attributes` / `custom_properties` in# `solph.components` with numeric values.
    2. Using a number with a higher dimension in `sequences`, such as a DataFrame, or a nested list.

I added two failing test and fixed the issues

1. Number has not been taken account, only strings. I fixed this in the `processing` module.

2. Using higher dimensions has not caused problems in the model but in the `parameter_as_dict`. I noticed that after solving a model after 10 hours, so I added a check to raise the error directly and not at the end.
