### PR TITLE
Fix bug where InvestNonConvexFlowBlock does not eliminate Investment offset when no investment is made

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -25,10 +25,12 @@ Authors
 * Jens-Olaf Delfs
 * Johannes Kochems
 * Johannes Röder
+* Jonas Freißmann
 * Jonathan Amme
 * Julian Endres
 * Lluis Millet
 * Lennart Schürmann
+* Malte Fritz
 * Martin Soethe
 * Marie-Claire Gering
 * Patrik Schönfeldt

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -174,4 +174,12 @@ authors:
     family-names: Schischke
     given-names: Eva
     alias: "@esske"
+  -
+    family-names: Fritz
+    given-names: Malte
+    alias: "@maltefritz"
+  -
+    family-names: Freißmann
+    given-names: Jonas
+    alias: "@jfreissmann"
 ...

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -173,8 +173,8 @@ class Investment:
                 msg = (
                     "It is not necessary to set the investment to `nonconvex` "
                     "if `minimum` and `offset` are 0.\n"
-                    "This can lead to the `invest_status` variable becoming 1, "
-                    "even if the `nominal_capacity` is optimized to 0."
+                    "This can lead to the `invest_status` variable becoming "
+                    "1, even if the `nominal_capacity` is optimized to 0."
                 )
                 warn(msg, debugging.SuspiciousUsageWarning)
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -174,8 +174,8 @@ class Investment:
                 msg = (
                     "It is not necessary to set the investment to `nonconvex` "
                     "if `minimum` and `offset` are 0.\n"
-                    "This can lead to the `invest_status` variable becoming 1, "
-                    "even if the `nominal_capacity` is optimized to 0."
+                    "This can lead to the `invest_status` variable becoming "
+                    "1, even if the `nominal_capacity` is optimized to 0."
                 )
                 warn(msg, debugging.SuspiciousUsageWarning)
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -17,8 +17,9 @@ SPDX-License-Identifier: MIT
 """
 from warnings import warn
 
-from oemof.solph._plumbing import sequence
 from oemof.tools import debugging
+
+from oemof.solph._plumbing import sequence
 
 
 class Investment:
@@ -173,8 +174,8 @@ class Investment:
                 msg = (
                     "It is not necessary to set the investment to `nonconvex` "
                     "if `minimum` and `offset` are 0.\n"
-                    "This can lead to the `invest_status` variable becoming "
-                    "1, even if the `nominal_capacity` is optimized to 0."
+                    "This can lead to the `invest_status` variable becoming 1, "
+                    "even if the `nominal_capacity` is optimized to 0."
                 )
                 warn(msg, debugging.SuspiciousUsageWarning)
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -9,6 +9,8 @@ SPDX-FileCopyrightText: Stephan Günther
 SPDX-FileCopyrightText: Patrik Schönfeldt
 SPDX-FileCopyrightText: jmloenneberga
 SPDX-FileCopyrightText: Johannes Kochems
+SPDX-FileCopyrightText: Malte Fritz
+SPDX-FileCopyrightText: Jonas Freißmann
 
 SPDX-License-Identifier: MIT
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -13,7 +13,10 @@ SPDX-FileCopyrightText: Johannes Kochems
 SPDX-License-Identifier: MIT
 
 """
+from warnings import warn
+
 from oemof.solph._plumbing import sequence
+from oemof.tools import debugging
 
 
 class Investment:
@@ -115,6 +118,7 @@ class Investment:
         self._check_invest_attributes_maximum()
         self._check_invest_attributes_offset()
         self._check_age_and_lifetime()
+        self._check_nonconvex()
 
     def _check_invest_attributes(self):
         """Throw an error if existing is other than 0 and nonconvex is True"""
@@ -159,6 +163,18 @@ class Investment:
                     "expected lifetime."
                 )
                 raise AttributeError(e4)
+
+    def _check_nonconvex(self):
+        """Checking for unnecessary setting of nonconvex"""
+        if self.nonconvex:
+            if (self.minimum.min() == 0) and (self.offset.min() == 0):
+                msg = (
+                    "It is not necessary to set the investment to `nonconvex` "
+                    "if `minimum` and `offset` are 0.\n"
+                    "This can lead to the `invest_status` variable becoming 1, "
+                    "even if the `nominal_capacity` is optimized to 0."
+                )
+                warn(msg, debugging.SuspiciousUsageWarning)
 
 
 class NonConvex:

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -305,7 +305,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
     def _minimum_invest_constraint(self):
         r"""
         .. math::
-                P_{invest, min} \le P_{invest}
+                P_{invest, min} \cdot Y_{invest,status} \le P_{invest}
         """
         m = self.parent_block()
 

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -272,7 +272,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
                     \cdot c_{shutdown}
 
             .. math::
-                P_{invest} \cdot c_{ep} + c_{offset}
+                P_{invest} \cdot c_{ep} + c_{offset} \cdot Y_{invest, status}
         """
         if not hasattr(self, "INVEST_NON_CONVEX_FLOWS"):
             return 0

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -290,6 +290,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
                 investment_costs += (
                     self.invest[i, o, p] * m.flows[i, o].investment.ep_costs[p]
                     + m.flows[i, o].investment.offset[p]
+                    * self.invest_status[i, o, p]
                 )
 
         self.investment_costs = Expression(expr=investment_costs)

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -315,6 +315,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
                 for p in m.PERIODS:
                     expr = (
                         m.flows[i, o].investment.minimum[p]
+                        * self.invest_status[i, o, p]
                         <= self.invest[i, o, p]
                     )
                     self.minimum_investment.add((i, o, p), expr)

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -341,6 +341,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
                     expr = (
                         self.invest[i, o, p]
                         <= m.flows[i, o].investment.maximum[p]
+                        * self.invest_status[i, o, p]
                     )
                     self.maximum_investment.add((i, o, p), expr)
 

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -83,6 +83,10 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
             Value of the investment variable, i.e. equivalent to the nominal
             value of the flows after optimization.
 
+        :math::
+            `Y_{invest_status}(i,o,p)` `InvestNonConvexFlowBlock.invest_status`
+            Binary variable representing whether or not an investment is made. 
+
         :math::`status\_nominal(i,o,t)` (non-negative real number)
             New paramater representing the multiplication of `P_{invest}`
             (from the <class 'oemof.solph.flows.InvestmentFlow'>) and

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -119,6 +119,15 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
             bounds=_investvar_bound_rule,
         )
 
+        # `invest_status` is a parameter which represents whether or not an
+        # investment is made. This way the investment offset cost only apply
+        # when the component is installed.
+        self.invest_status = Var(
+            self.INVEST_NON_CONVEX_FLOWS,
+            m.PERIODS,
+            within=Binary,
+        )
+
         # `status_nominal` is a parameter which represents the
         # multiplication of a binary variable (`status`)
         # and a continuous variable (`invest` or `nominal_capacity`)

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -305,7 +305,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
     def _minimum_invest_constraint(self):
         r"""
         .. math::
-                P_{invest, min} \cdot Y_{invest,status} \le P_{invest}
+                P_{invest, min} \cdot Y_{invest, status} \le P_{invest}
         """
         m = self.parent_block()
 
@@ -330,7 +330,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
     def _maximum_invest_constraint(self):
         r"""
         .. math::
-            P_{invest} \le P_{invest, max}
+            P_{invest} \le P_{invest, max} \cdot Y_{invest, status}
         """
         m = self.parent_block()
 

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -13,6 +13,8 @@ SPDX-FileCopyrightText: jmloenneberga
 SPDX-FileCopyrightText: Johannes Kochems (jokochems)
 SPDX-FileCopyrightText: Saeed Sayadi
 SPDX-FileCopyrightText: Pierre-François Duc
+SPDX-FileCopyrightText: Malte Fritz
+SPDX-FileCopyrightText: Jonas Freißmann
 
 SPDX-License-Identifier: MIT
 

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -272,7 +272,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
                     \cdot c_{shutdown}
 
             .. math::
-                P_{invest} \cdot c_{invest,var}
+                P_{invest} \cdot c_{ep} + c_{offset}
         """
         if not hasattr(self, "INVEST_NON_CONVEX_FLOWS"):
             return 0

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -8,6 +8,7 @@ SPDX-License-Identifier: MIT
 """
 
 import pytest
+from oemof.tools import debugging
 
 from oemof import solph
 
@@ -17,3 +18,16 @@ def test_check_age_and_lifetime():
     msg = "A unit's age must be smaller than its expected lifetime."
     with pytest.raises(AttributeError, match=msg):
         solph.Flow(nominal_capacity=solph.Investment(age=41, lifetime=40))
+
+
+def test_check_nonconvex():
+    """
+    Check warning being thrown if minimum and offset are zero and nonconvex
+    is set
+    """
+    with pytest.warns(debugging.SuspiciousUsageWarning):
+        solph.Flow(
+            nominal_capacity=solph.Investment(
+                minimum=0, offset=0, nonconvex=solph.NonConvex()
+            )
+        )

--- a/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+++ b/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
@@ -2,10 +2,8 @@
 This example compares a cheap and an expensive heat pump, with the latter
 adding a fixed invest cost offset to the objective function.
 
-This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
-by the contributors recorded in the version control history of the file,
-available from its original location
-oemof/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+SPDX-FileCopyrightText: Jonas Freißmann
+SPDX-FileCopyrightText: Malte Fritz
 
 SPDX-License-Identifier: MIT
 """

--- a/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+++ b/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
@@ -1,0 +1,102 @@
+"""
+This example compares a cheap and an expensive heat pump, with the latter
+adding a fixed invest cost offset to the objective function.
+
+This file is part of project oemof (github.com/oemof/oemof). It's copyrighted
+by the contributors recorded in the version control history of the file,
+available from its original location
+oemof/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+
+SPDX-License-Identifier: MIT
+"""
+
+import pandas as pd
+
+from oemof.solph import EnergySystem
+from oemof.solph import Investment
+from oemof.solph import Model
+from oemof.solph import NonConvex
+from oemof.solph import components
+from oemof.solph import processing
+from oemof.solph.buses import Bus
+from oemof.solph.flows import Flow
+
+
+def test_non_convex_investment_offset():
+    # Energy System
+    energy_system = EnergySystem(
+        timeindex=pd.date_range(start='2025-01-01 12:00', freq='h', periods=2),
+        infer_last_interval=False
+    )
+
+    # Buses
+    b_el = Bus('electricity bus')
+    b_th = Bus('heat bus')
+
+    energy_system.add(b_el, b_th)
+
+    # Source & Sink
+    el_source = components.Source(
+        'electricity source', outputs={b_el: Flow()}
+    )
+
+    th_sink = components.Sink(
+        'heat sink', inputs={b_th: Flow(nominal_capacity=1, fix=[1])}
+    )
+
+    energy_system.add(el_source, th_sink)
+
+    # Converter
+    hp_expensive = components.Converter(
+        'heat pump expensive',
+        inputs={b_el: Flow()},
+        outputs={
+            b_th: Flow(
+                nominal_capacity=Investment(
+                    ep_costs=100,
+                    offset=2000,
+                    maximum=1,
+                    minimum=0,
+                    nonconvex=NonConvex()
+                ),
+                variable_costs=1,
+                max=1,
+                min=0.1,
+                nonconvex=NonConvex()
+            )
+        },
+        conversion_factors={b_el: [3]}
+    )
+
+    hp_cheap = components.Converter(
+        'heat pump cheap',
+        inputs={b_el: Flow()},
+        outputs={
+            b_th: Flow(
+                nominal_capacity=Investment(
+                    ep_costs=50,
+                    maximum=1,
+                    minimum=0,
+                    nonconvex=NonConvex()
+                ),
+                variable_costs=1,
+                max=1,
+                min=0.1,
+                nonconvex=NonConvex()
+            )
+        },
+        conversion_factors={b_el: [3]}
+    )
+
+    energy_system.add(hp_expensive, hp_cheap)
+
+    # Model
+    model = Model(energy_system)
+
+    # Optimization
+    model.solve(solver='cbc', solve_kwargs={'tee': True})
+
+    # Check Objective
+    meta_results = processing.meta_results(model)
+
+    assert meta_results['objective'] == 51.0

--- a/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+++ b/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
@@ -97,4 +97,6 @@ def test_non_convex_investment_offset():
     # Check Objective
     meta_results = processing.meta_results(model)
 
+    # Cheap heat pump should be built (50) and dispatched (1). The investment
+    # offset of the expensive heat pump (2000) should be ignored.
     assert meta_results['objective'] == 51.0


### PR DESCRIPTION
**General description**

This pull request aims to fix the issue #1172 

To fix the bug @jfreissmann and I expand the `_create_sets` method in the `_invest_non_convex_flow_block`. We decitde to name the sets linear and offset not to repeat the convetion of convex and nonconvex. But you can feel free to change those.

<details><summary>_create_sets method</summary>

```python
self.LINEAR_INVEST_NON_CONVEX_FLOWS = Set(
    initialize=[
        (g[0], g[1])
        for g in group
        if g[2].investment.nonconvex is None
    ]
)

self.OFFSET_INVEST_NON_CONVEX_FLOWS = Set(
    initialize=[
        (g[0], g[1])
        for g in group
        if isinstance(g[2].investment.nonconvex, NonConvex)
    ]
)
```

</details>

After that we expand the `_investvar_bound_rule` to differentiate between the linear and offset flows. In addition, we create the `invest_status` variable in alingment with the `GenericInvestmentStorage` class:

<details><summary>_create_variables method</summary>

```python
def _create_variables(self):
        r"""
        Status variable (binary) `om.InvestNonConvexFlowBlock.status`:
            Variable indicating if flow is >= 0 indexed by FLOWS

        :math::`P_{invest}` `InvestNonConvexFlowBlock.invest`
            Value of the investment variable, i.e. equivalent to the nominal
            value of the flows after optimization.

        :math::
            `Y_{invest_status}(i,o,p)` `InvestNonConvexFlowBlock.invest_status`
            Binary variable representing whether or not an investment is made. 

        :math::`status\_nominal(i,o,t)` (non-negative real number)
            New paramater representing the multiplication of `P_{invest}`
            (from the <class 'oemof.solph.flows.InvestmentFlow'>) and
            `status(i,o,t)` (from the
            <class 'oemof.solph.flows.NonConvexFlow'>)
            used for the constraints on the minimum and maximum
            flow constraints.

        .. automethod:: _variables_for_non_convex_flows
        """
   
        ...

        def _investvar_bound_rule(block, i, o, p):
            """Rule definition for bounds of the invest variable."""
            if (i, o) in self.LINEAR_INVEST_NON_CONVEX_FLOWS:
                return (
                    m.flows[i, o].investment.minimum[p],
                    m.flows[i, o].investment.maximum[p],
                )
            elif (i, o) in self.OFFSET_INVEST_NON_CONVEX_FLOWS:
                return 0, m.flows[i, o].investment.maximum[p] 

        ....

        # `invest_status` is a parameter which represents whether or not an
        # investment is made. This way the investment offset cost only apply
        # when the component is installed.
        self.invest_status = Var(
            self.OFFSET_INVEST_NON_CONVEX_FLOWS,
            m.PERIODS,
            within=Binary,
        )
```

</details>

To counteract the described bug, we multiply the `invest_status` to the flow in the offset variant in the `_objective_expression` method.

<details><summary>_objective_expression</summary>

```python
def _objective_expression(self):
    r"""Objective expression for nonconvex investment flows.

        If `nonconvex.startup_costs` is set by the user:
            .. math::
                \sum_{i, o \in STARTUPFLOWS} \sum_t  startup(i, o, t) \
                \cdot c_{startup}

        If `nonconvex.shutdown_costs` is set by the user:
            .. math::
                \sum_{i, o \in SHUTDOWNFLOWS} \sum_t shutdown(i, o, t) \
                \cdot c_{shutdown}

        .. math::
            P_{invest} \cdot c_{ep} + c_{offset} \cdot Y_{invest, status}
    """
    if not hasattr(self, "INVEST_NON_CONVEX_FLOWS"):
        return 0

    m = self.parent_block()

    startup_costs = self._startup_costs()
    shutdown_costs = self._shutdown_costs()
    activity_costs = self._activity_costs()
    inactivity_costs = self._inactivity_costs()
    investment_costs = 0

    for i, o in self.LINEAR_INVEST_NON_CONVEX_FLOWS:
        for p in m.PERIODS:
            investment_costs += (
                self.invest[i, o, p] * m.flows[i, o].investment.ep_costs[p]
            )

    for i, o in self.OFFSET_INVEST_NON_CONVEX_FLOWS:
        for p in m.PERIODS:
            investment_costs += (
                self.invest[i, o, p] * m.flows[i, o].investment.ep_costs[p]
                + m.flows[i, o].investment.offset[p]
                * self.invest_status[i, o, p]
            )

    self.investment_costs = Expression(expr=investment_costs)

    return (
        startup_costs
        + shutdown_costs
        + activity_costs
        + inactivity_costs
        + investment_costs
    )
```

</details>

Finally we add the `invest_status` variable to the minimum and maximum investment constraints in order to get the desired behavior:

<details><summary>_minimum_invest_constraint</summary>

```python
def _minimum_invest_constraint(self):
    r"""
    .. math::
            P_{invest, min} \cdot Y_{invest, status} \le P_{invest}
    """
    m = self.parent_block()

    def _min_invest_rule(_):
        """Rule definition for applying a minimum investment"""
        for i, o in self.OFFSET_INVEST_NON_CONVEX_FLOWS:
            for p in m.PERIODS:
                expr = (
                    m.flows[i, o].investment.minimum[p]
                    * self.invest_status[i, o, p]
                    <= self.invest[i, o, p]
                )
                self.minimum_investment.add((i, o, p), expr)

    self.minimum_investment = Constraint(
        self.INVEST_NON_CONVEX_FLOWS, m.PERIODS, noruleinit=True
    )
    self.minimum_rule_build = BuildAction(rule=_min_invest_rule)

    return self.minimum_investment
```

</details>

<details><summary>_maximum_invest_constraint</summary>

```python
def _maximum_invest_constraint(self):
    r"""
    .. math::
        P_{invest} \le P_{invest, max} \cdot Y_{invest, status}
    """
    m = self.parent_block()

    def _max_invest_rule(_):
        """Rule definition for applying a minimum investment"""
        for i, o in self.OFFSET_INVEST_NON_CONVEX_FLOWS:
            for p in m.PERIODS:
                expr = (
                    self.invest[i, o, p]
                    <= m.flows[i, o].investment.maximum[p]
                    * self.invest_status[i, o, p]
                )
                self.maximum_investment.add((i, o, p), expr)

    self.maximum_investment = Constraint(
        self.INVEST_NON_CONVEX_FLOWS, m.PERIODS, noruleinit=True
    )
    self.maximum_rule_build = BuildAction(rule=_max_invest_rule)

    return self.maximum_investment
```

</details>


**Proof of work**

Comparison between the old and new LP file created by oemof.solph. The new LP file contains the invest_status variable of the heat pump which is defined with an offset:

<details><summary>Old LP file excerpt</summary>

\ Source Pyomo model name=Model \

min 
objective:
+774240.8738468975 ONE_VAR_CONSTANT
+20.5 flow(electricity_network_heat_pump_0_0)
+0.01 flow(heat_network_st_tes_0_0)
-35.32 flow(spotmarket_node_spotmarket_0_0)
+28.75154 flow(gas_source_gas_network_0_0)
+60.34 flow(electricity_source_electricity_network_0_0)
+1.2 flow(heat_pump_heat_network_0_0)
+4.4 flow(ccet_ccet_node_0_0)
+6.6 flow(peak_load_boiler_heat_network_0_0)
+0.01 flow(st_tes_heat_network_0_0)
+185784.83113797754 InvestNonConvexFlowBlock_invest(ccet_heat_network_0)
+24824.439073550922 InvestNonConvexFlowBlock_invest(heat_pump_heat_network_0)
+6764.555231441481 InvestNonConvexFlowBlock_invest(peak_load_boiler_heat_network_0)
+21.9765694447266 GenericInvestmentStorageBlock_invest(st_tes_0)
+16635.489556160563 GenericInvestmentStorageBlock_invest_status(st_tes_0)

</details>

<details><summary>New LP file excerpt</summary>

\ Source Pyomo model name=Model \

min 
objective:
+665340.30944482092 ONE_VAR_CONSTANT
+20.5 flow(electricity_network_heat_pump_0_0)
+0.01 flow(heat_network_st_tes_0_0)
-35.32 flow(spotmarket_node_spotmarket_0_0)
+28.75154 flow(gas_source_gas_network_0_0)
+60.34 flow(electricity_source_electricity_network_0_0)
+1.2 flow(heat_pump_heat_network_0_0)
+4.4 flow(ccet_ccet_node_0_0)
+6.6 flow(peak_load_boiler_heat_network_0_0)
+0.01 flow(st_tes_heat_network_0_0)
+185784.83113797754 InvestNonConvexFlowBlock_invest(ccet_heat_network_0)
+24824.439073550922 InvestNonConvexFlowBlock_invest(heat_pump_heat_network_0)
+6764.555231441481 InvestNonConvexFlowBlock_invest(peak_load_boiler_heat_network_0)
+108900.56440207658 InvestNonConvexFlowBlock_invest_status(heat_pump_heat_network_0)
+21.9765694447266 GenericInvestmentStorageBlock_invest(st_tes_0)
+16635.489556160563 GenericInvestmentStorageBlock_invest_status(st_tes_0)

</details>

**Known issue**

With our tests the bug described in issue #1172 is fixed. Nevertheless, there is still on issue to solve. When the `minimum` parameter of the `solph.Invest` object is set to `0` and `nonconvex` is set, the `invest_status` variable is created anyway and as no cost are produced it is set to `1` by the solver erroneously. This has no consequences to the solution, but it may confuse users.