### PR TITLE
Feature/custom attributes for investments

### DIFF
--- a/examples/generic_invest_limit/example_generic_invest.py
+++ b/examples/generic_invest_limit/example_generic_invest.py
@@ -74,7 +74,7 @@ from oemof import solph
 
 def main(optimize=True):
 
-    data = [10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
+    data = [2, 2, 12, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10]
     # create an energy system
     idx = solph.create_time_index(2020, number=len(data))
     es = solph.EnergySystem(timeindex=idx, infer_last_interval=False)
@@ -83,7 +83,7 @@ def main(optimize=True):
     c_0 = 10
     c_1 = 100
 
-    epc_invest = 500
+    epc_invest = 50
 
     # commodity a
     bus_a_0 = solph.Bus(label="bus_a_0")
@@ -146,9 +146,11 @@ def main(optimize=True):
                     nominal_capacity=solph.Investment(
                         ep_costs=epc_invest,
                         custom_attributes={"space": {"cost": 1,
-                                                     "offset" : 30}},
+                                                     "offset" : 20
+                                                     }
+                                           },
                         nonconvex=True,
-                        maximum=1000
+                        maximum=100
                     ),
                     custom_attributes={"space": 0.1}
                 )
@@ -167,16 +169,32 @@ def main(optimize=True):
                     nominal_capacity=solph.Investment(
                         ep_costs=epc_invest,
                         custom_attributes={"space": {"cost": 1}},
-                        maximum=1000
+                        nonconvex=True,
+                        maximum=8
                     ),
                     custom_attributes={"space": 0.1}
                 )
             },
-            conversion_factors={bus_a_1: 1},
-
         )
     )
-
+    if True:
+        # Generic Storage
+        es.add(
+            solph.components.GenericStorage(
+                label="generic_storage_b",
+                inputs={bus_b_1: solph.Flow()},
+                outputs={bus_b_1: solph.Flow()},
+                inflow_conversion_factor=0.9,
+                nominal_capacity = solph.Investment(
+                    ep_costs=epc_invest ,
+                    nonconvex=True,
+                    maximum=10,
+                    custom_attributes={"space": {"cost": 0.5, "offset":20 }},
+                    #maximum=1000
+                    )
+                ,
+            )
+        )
     if optimize is False:
         return es
 

--- a/src/oemof/solph/constraints/__init__.py
+++ b/src/oemof/solph/constraints/__init__.py
@@ -13,6 +13,7 @@ from .integral_limit import emission_limit_per_period
 from .integral_limit import generic_integral_limit
 from .integral_limit import generic_periodical_integral_limit
 from .investment_limit import additional_investment_flow_limit
+from .investment_limit import additional_total_limit
 from .investment_limit import investment_limit
 from .investment_limit import investment_limit_per_period
 from .shared_limit import shared_limit
@@ -29,6 +30,7 @@ __all__ = [
     "generic_integral_limit",
     "generic_periodical_integral_limit",
     "additional_investment_flow_limit",
+    "additional_total_limit",
     "investment_limit",
     "investment_limit_per_period",
     "shared_limit",

--- a/src/oemof/solph/constraints/investment_limit.py
+++ b/src/oemof/solph/constraints/investment_limit.py
@@ -230,22 +230,26 @@ def additional_investment_flow_limit(model, keyword, limit=None):
 
 def additional_total_limit(model, keyword, limit=None):
     r"""
-    Global limit for investment flows weighted by an attribute keyword.
+    Global limit for investment flows and operation flows
+    weighted by an attribute keyword.
 
-    This constraint is only valid for Flows not for components such as an
+    This constraint is  valid for Flows and for an
     investment storage.
 
     The attribute named by keyword has to be added to every Investment
     attribute of the flow you want to take into account.
     Total value of keyword attributes after optimization can be retrieved
-    calling the `oemof.solph._models.Model.invest_limit_${keyword}()`.
+    calling the `oemof.solph._models.Model.total_limit_${keyword}()`.
 
     .. math::
         \sum_{p \in \textrm{PERIODS}}
-        \sum_{i \in IF}  P_{i}(p) \cdot w_i \leq limit
+        \sum_{i \in IF}  P_{i}(p) \cdot w_i
+        \sum_{i \in F_E} \sum_{t \in T} P_i(p, t) \cdot w_i(t)
+               \cdot \tau(t) \leq limit
 
     With `IF` being the set of InvestmentFlows considered for the integral
-    limit.
+    limit,  `F_I` being the set of flows considered for the integral limit and
+    `T` being the set of time steps.
 
     The symbols used are defined as follows
     (with Variables (V) and Parameters (P)):
@@ -258,6 +262,12 @@ def additional_total_limit(model, keyword, limit=None):
     | :math:`w_i`      | `keyword`                             | P    | weight given to investment flow named according to `keyword` |
     +------------------+---------------------------------------+------+--------------------------------------------------------------+
     | :math:`limit`    | `limit`                               | P    | global limit given by keyword `limit`                        |
+    +------------------+---------------------------------------+------+--------------------------------------------------------------+
+    | :math:`P_n(p, t)`| `limit`                               | P    | power flow :math:`n` at time index :math:`p, t`              |
+    +------------------+---------------------------------------+------+--------------------------------------------------------------+
+    | :math:`w_N(t)`   | `limit`                               | P    | weight given to Flow named according to `keyword`            |
+    +------------------+---------------------------------------+------+--------------------------------------------------------------+
+    | :math:`\tau(t)`  | `limit`                               | P    | width of time step :math:`t`                                 |
     +------------------+---------------------------------------+------+--------------------------------------------------------------+
 
     Parameters
@@ -319,11 +329,6 @@ def additional_total_limit(model, keyword, limit=None):
     if hasattr(model, "GenericInvestmentStorageBlock"):
         for st, _ in model.GenericInvestmentStorageBlock.invest:
             storages[st] = [st]
-    if False:
-        for st in storages:
-            getattr(storages[st][0].investment, keyword).get("cost", 0)
-        for st in storages:
-            model.GenericInvestmentStorageBlock.total[st]
     setattr(
         model,
         limit_name,


### PR DESCRIPTION
Constraints Investments for costume attributes missed the possibility of constraining not only the investment flow, but the sum of investment and operation. Furthermore no OffSet for costume Attributes in investments were considers.

This PR adds both and explains it in an example. 

It is handy to have these to run a restricted optimization, as explained in [Issue 1171](https://github.com/oemof/oemof-solph/issues/1171)