### PR TITLE
Fix InvestNonConvexFlowBlock set definition by nonconvex parameter

### DIFF
--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -173,7 +173,7 @@ class Investment:
         if not isinstance(self.nonconvex, bool):
             e5 = (
                 "The `nonconvex` parameter of the `Investment` class has to be"
-                + f"of type boolean, not {type(self.nonconvex)}."
+                + f" of type boolean, not {type(self.nonconvex)}."
             )
             raise AttributeError(e5)
 

--- a/src/oemof/solph/_options.py
+++ b/src/oemof/solph/_options.py
@@ -121,6 +121,7 @@ class Investment:
         self._check_invest_attributes_maximum()
         self._check_invest_attributes_offset()
         self._check_age_and_lifetime()
+        self._check_invest_attributes_nonconvex()
         self._check_nonconvex()
 
     def _check_invest_attributes(self):
@@ -166,6 +167,15 @@ class Investment:
                     "expected lifetime."
                 )
                 raise AttributeError(e4)
+
+    def _check_invest_attributes_nonconvex(self):
+        """Throw an error if nonconvex is not of type boolean."""
+        if not isinstance(self.nonconvex, bool):
+            e5 = (
+                "The `nonconvex` parameter of the `Investment` class has to be"
+                + f"of type boolean, not {type(self.nonconvex)}."
+            )
+            raise AttributeError(e5)
 
     def _check_nonconvex(self):
         """Checking for unnecessary setting of nonconvex"""

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -27,8 +27,6 @@ from pyomo.core import NonNegativeReals
 from pyomo.core import Set
 from pyomo.core import Var
 
-from oemof.solph._options import NonConvex
-
 from ._non_convex_flow_block import NonConvexFlowBlock
 
 

--- a/src/oemof/solph/flows/_invest_non_convex_flow_block.py
+++ b/src/oemof/solph/flows/_invest_non_convex_flow_block.py
@@ -80,7 +80,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
             initialize=[
                 (g[0], g[1])
                 for g in group
-                if g[2].investment.nonconvex is None
+                if g[2].investment.nonconvex is False
             ]
         )
 
@@ -88,7 +88,7 @@ class InvestNonConvexFlowBlock(NonConvexFlowBlock):
             initialize=[
                 (g[0], g[1])
                 for g in group
-                if isinstance(g[2].investment.nonconvex, NonConvex)
+                if g[2].investment.nonconvex is True
             ]
         )
 

--- a/tests/test_components/test_storage.py
+++ b/tests/test_components/test_storage.py
@@ -278,7 +278,7 @@ def test_invest_content_minimum_nonconvex():
         nominal_capacity=solph.Investment(
             ep_costs=0.1,
             minimum=32,
-            nonconvex=solph.NonConvex(),
+            nonconvex=True,
         ),
         balanced=False,
     )

--- a/tests/test_components/test_storage.py
+++ b/tests/test_components/test_storage.py
@@ -277,6 +277,7 @@ def test_invest_content_minimum_nonconvex():
         outputs={bus: solph.Flow(nominal_capacity=0.1, variable_costs=0.1)},
         nominal_capacity=solph.Investment(
             ep_costs=0.1,
+            maximum=42,
             minimum=32,
             nonconvex=True,
         ),

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -23,8 +23,8 @@ def test_check_age_and_lifetime():
 def test_check_invest_attributes_nonconvex():
     """Check error being thrown if nonconvex parameter is not of type bool"""
     msg = (
-        "The `nonconvex` parameter of the `Investment` class has to beof type "
-        + "boolean, not <class 'oemof.solph._options.NonConvex'>."
+        "The `nonconvex` parameter of the `Investment` class has to be of type"
+        + " boolean, not <class 'oemof.solph._options.NonConvex'>."
     )
     with pytest.raises(AttributeError, match=msg):
         solph.Flow(
@@ -44,6 +44,3 @@ def test_check_nonconvex():
                 maximum=1, minimum=0, offset=0, nonconvex=True
             )
         )
-
-
-test_check_invest_attributes_nonconvex()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -20,6 +20,17 @@ def test_check_age_and_lifetime():
         solph.Flow(nominal_capacity=solph.Investment(age=41, lifetime=40))
 
 
+def test_check_invest_attributes_nonconvex():
+    """Check error being thrown if nonconvex parameter is not of type bool"""
+    msg = (
+        "The `nonconvex` parameter of the `Investment` class has to beof type "
+        + "boolean, not <class 'oemof.solph._options.NonConvex'>."
+    )
+    with pytest.raises(AttributeError, match=msg):
+        solph.Flow(
+            nominal_capacity=solph.Investment(nonconvex=solph.NonConvex())
+        )
+
 def test_check_nonconvex():
     """
     Check warning being thrown if minimum and offset are zero and nonconvex

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -39,6 +39,9 @@ def test_check_nonconvex():
     with pytest.warns(debugging.SuspiciousUsageWarning):
         solph.Flow(
             nominal_capacity=solph.Investment(
-                minimum=0, offset=0, nonconvex=True
+                maximum=1, minimum=0, offset=0, nonconvex=True
             )
         )
+
+
+test_check_invest_attributes_nonconvex()

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -33,6 +33,7 @@ def test_check_invest_attributes_nonconvex():
             )
         )
 
+
 def test_check_nonconvex():
     """
     Check warning being thrown if minimum and offset are zero and nonconvex

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -28,6 +28,6 @@ def test_check_nonconvex():
     with pytest.warns(debugging.SuspiciousUsageWarning):
         solph.Flow(
             nominal_capacity=solph.Investment(
-                minimum=0, offset=0, nonconvex=solph.NonConvex()
+                minimum=0, offset=0, nonconvex=True
             )
         )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -28,7 +28,9 @@ def test_check_invest_attributes_nonconvex():
     )
     with pytest.raises(AttributeError, match=msg):
         solph.Flow(
-            nominal_capacity=solph.Investment(nonconvex=solph.NonConvex())
+            nominal_capacity=solph.Investment(
+                maximum=1, nonconvex=solph.NonConvex()
+            )
         )
 
 def test_check_nonconvex():

--- a/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
+++ b/tests/test_scripts/test_solph/test_non_convex_investment_offset/test_non_convex_investment_offset.py
@@ -53,7 +53,7 @@ def test_non_convex_investment_offset():
                     offset=2000,
                     maximum=1,
                     minimum=0,
-                    nonconvex=NonConvex(),
+                    nonconvex=True,
                 ),
                 variable_costs=1,
                 max=1,
@@ -70,7 +70,7 @@ def test_non_convex_investment_offset():
         outputs={
             b_th: Flow(
                 nominal_capacity=Investment(
-                    ep_costs=50, maximum=1, minimum=0, nonconvex=NonConvex()
+                    ep_costs=50, maximum=1, minimum=0, nonconvex=True
                 ),
                 variable_costs=1,
                 max=1,


### PR DESCRIPTION
The current set definitions of the `InvestNonConvexFlowBlock`, as implemented by our PR #1173, check wether the argument passed to the `nonconvex` parameter is an instance of the `solph._options.NonConvex` class. This is not the intended usage of the `nonconvex` parameter of the `solph._options.Investment` class. This PR aligns the set definition to check for boolean values `True` or `False`. A test added in the PR mentioned above also contains the erroneous usage, which is fixed as well.

Additionally, @maltefritz and I added a type check of the `nonconvex` argument, as its misaligned usage in contrast to the Flow's `nonconvex` parameter can lead to wrong usage staying undetected. A test for the check is added as well.

This should also help resolve Issue #1179.
