### PR TITLE
Feature/allow numeric timeindex

### DIFF
--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -102,16 +102,6 @@ class EnergySystem(es.EnergySystem):
             groupings = []
         groupings = GROUPINGS + groupings
 
-        if not (
-            isinstance(timeindex, pd.DatetimeIndex)
-            or isinstance(timeindex, type(None))
-        ):
-            msg = (
-                "Parameter 'timeindex' has to be of type "
-                "pandas.DatetimeIndex or NoneType and not of type {0}"
-            )
-            raise TypeError(msg.format(type(timeindex)))
-
         if infer_last_interval is None and timeindex is not None:
             msg = (
                 "The default behaviour will change in future versions.\n"
@@ -165,8 +155,10 @@ class EnergySystem(es.EnergySystem):
             else:
                 df = pd.DataFrame(timeindex)
                 timedelta = df.diff()
-                timeincrement = timedelta / np.timedelta64(1, "h")
-
+                if isinstance(timeindex, pd.DatetimeIndex):
+                    timeincrement = timedelta / np.timedelta64(1, "h")
+                else:
+                    timeincrement = timedelta
                 # we want a series (squeeze)
                 # without the first item (no delta defined for first entry)
                 # but starting with index 0 (reset)

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -87,7 +87,7 @@ class EnergySystem(es.EnergySystem):
         self,
         timeindex=None,
         timeincrement=None,
-        infer_last_interval=None,
+        infer_last_interval=False,
         periods=None,
         tsa_parameters=None,
         use_remaining_value=False,
@@ -101,18 +101,6 @@ class EnergySystem(es.EnergySystem):
         if groupings is None:
             groupings = []
         groupings = GROUPINGS + groupings
-
-        if infer_last_interval is None and timeindex is not None:
-            msg = (
-                "The default behaviour will change in future versions.\n"
-                "At the moment the last interval of an equidistant time "
-                "index is added implicitly by default. Set "
-                "'infer_last_interval' explicitly 'True' or 'False' to avoid "
-                "this warning. In future versions 'False' will be the default"
-                "behaviour"
-            )
-            warnings.warn(msg, FutureWarning)
-            infer_last_interval = True
 
         if infer_last_interval is True and timeindex is not None:
             # Add one time interval to the timeindex by adding one time point.

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -41,9 +41,9 @@ class EnergySystem(es.EnergySystem):
 
     Parameters
     ----------
-    timeindex : pandas.DatetimeIndex
-
-    timeincrement : iterable
+    timeindex : sequence of ascending numeric values
+        Typically a pandas.DatetimeIndex is used,
+        but for example also a list of floats works.
 
     infer_last_interval : bool
         Add an interval to the last time point. The end time of this interval
@@ -122,26 +122,36 @@ class EnergySystem(es.EnergySystem):
             )
 
         # catch wrong combinations and infer timeincrement from timeindex.
-        if timeincrement is not None and timeindex is not None:
-            if periods is None:
+        if timeincrement is not None:
+            if timeindex is None:
                 msg = (
-                    "Specifying the timeincrement and the timeindex parameter "
-                    "at the same time is not allowed since these might be "
-                    "conflicting to each other."
+                    "Initialising an EnergySystem using a timeincrement"
+                    " is deprecated. Please give a timeindex instead."
                 )
-                raise AttributeError(msg)
+                warnings.warn(msg, FutureWarning)
             else:
-                msg = (
-                    "Ensure that your timeindex and timeincrement are "
-                    "consistent."
-                )
-                warnings.warn(msg, debugging.ExperimentalFeatureWarning)
+                if periods is None:
+                    msg = (
+                        "Specifying the timeincrement and the timeindex"
+                        " parameter at the same time is not allowed since"
+                        " these might be conflicting to each other."
+                    )
+                    raise AttributeError(msg)
+                else:
+                    msg = (
+                        "Ensure that your timeindex and timeincrement are "
+                        "consistent."
+                    )
+                    warnings.warn(msg, debugging.ExperimentalFeatureWarning)
 
         elif timeindex is not None and timeincrement is None:
             if tsa_parameters is not None:
                 pass
             else:
-                df = pd.DataFrame(timeindex)
+                try:
+                    df = pd.DataFrame(timeindex)
+                except:
+                    raise ValueError("Invalid timeindex.")
                 timedelta = df.diff()
                 if isinstance(timeindex, pd.DatetimeIndex):
                     timeincrement = timedelta / np.timedelta64(1, "h")

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -150,7 +150,7 @@ class EnergySystem(es.EnergySystem):
             else:
                 try:
                     df = pd.DataFrame(timeindex)
-                except:
+                except ValueError:
                     raise ValueError("Invalid timeindex.")
                 timedelta = df.diff()
                 if isinstance(timeindex, pd.DatetimeIndex):


### PR DESCRIPTION
Implements #1199 in the way that the following lines will now produce the same result:

```Python
EnergySystem(time_incement=[1,1,1,2,3,1])  # deprecated
EnergySystem(timeindex=[0,1,2,3,5,8,9])  # new way
EnergySystem(timeindex=[12,13,14,15,17,20,21])  # also possible (initial value is arbitrary)
```

Of course, using pandas.DatetimeIndex still works.


Todo: Add to whatsnew.