### PR TITLE
Add results properties to nex Results class

### DIFF
--- a/src/oemof/solph/__init__.py
+++ b/src/oemof/solph/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.6.0a6"
+__version__ = "0.6.1a1"
 
 from . import buses
 from . import components

--- a/src/oemof/solph/_results.py
+++ b/src/oemof/solph/_results.py
@@ -90,12 +90,20 @@ class Results:
         # overwrite known indexes
         match tuple(dataset.index_set().subsets())[-1].name:
             case "TIMEPOINTS":
-                df.index = self._model.es.timeindex
+                df.index = self.timeindex
             case "TIMESTEPS":
-                df.index = self._model.es.timeindex[:-1]
+                df.index = self.timeindex[:-1]
             case _:
                 df.index = df.index.get_level_values(-1)
         return df
+
+    @property
+    def objective(self):
+        return self._model.objective()
+
+    @property
+    def timeindex(self):
+        return self._model.es.timeindex
 
     def __getattr__(self, key: str) -> pd.DataFrame | ListContainer:
         return self[key]

--- a/tests/test_outputlib/test_results.py
+++ b/tests/test_outputlib/test_results.py
@@ -1,0 +1,26 @@
+import pytest
+
+from oemof.solph import _results
+
+from . import optimization_model
+
+
+class TestFilterView:
+    @classmethod
+    def setup_class(cls):
+        cls.results = _results.Results(optimization_model)
+
+    def test_objective(self):
+        assert int(self.results.objective) == 8495
+
+    def test_to_set_objective(self):
+        msg = "property 'objective' of 'Results' object has no setter"
+        with pytest.raises(AttributeError, match=msg):
+            self.results.objective = 5
+
+    def test_time_index(self):
+        assert len(self.results.timeindex) == 25
+        assert (
+            self.results.timeindex[3].strftime("%m/%d/%Y, %H")
+            == "01/01/2012, 03"
+        )


### PR DESCRIPTION
I would like some basic stuff directly from the results object, so added the `objective` and the `timeindex` property.

```python
>>> results.objective
3456.78990

>>> results.timeseries
DatetimeIndex([
     '2012-01-01 00:00:00', '2012-01-01 01:00:00',
     '2012-01-01 02:00:00', '2012-01-01 03:00:00',
     '2012-01-01 04:00:00', '2012-01-01 05:00:00',
     '2012-01-01 06:00:00', '2012-01-01 07:00:00',
     '2012-01-01 08:00:00', '2012-01-01 09:00:00',
     '2012-01-01 10:00:00', '2012-01-01 11:00:00',
     '2012-01-01 12:00:00', '2012-01-01 13:00:00',
     '2012-01-01 14:00:00', '2012-01-01 15:00:00',
     '2012-01-01 16:00:00', '2012-01-01 17:00:00',
     '2012-01-01 18:00:00', '2012-01-01 19:00:00',
     '2012-01-01 20:00:00', '2012-01-01 21:00:00',
     '2012-01-01 22:00:00', '2012-01-01 23:00:00',
     '2012-01-02 00:00:00'
], dtype='datetime64[ns]', freq='h')
```