### PR TITLE
Implement `filter`ing columns of `Results` `DataFrame`s

### DIFF
--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -455,6 +455,13 @@ class Filters(dict):
         result.update(filters)
         return result
 
+    @staticmethod
+    def nofilter(*args, **kwargs):
+        return True
+
+    def __getitem__(self, variable: str) -> pd.DataFrame | pd.Series:
+        return self.get(variable, self.nofilter)
+
 
 class Results:
     filters = Filters(
@@ -504,7 +511,7 @@ class Results:
         df = self._dfs[variable]
 
         filters = self.filters if filters is None else filters
-        filter = filters.get(variable, lambda *xs: True)
+        filter = filters[variable]
         columns = [column for column in df.columns if filter(column)]
 
         return df.loc[:, columns]


### PR DESCRIPTION
Since the `DataFrame` of a `Results` variable can have a lot of columns, not all of which might be of interest for a user, this PR implements an API to easily filter specific columns in order to only retain those of interest.

NOTE: This PR description is not complete and I will write a few more bullet points with desired and implemented features later.
