### PR TITLE
Error message for duplicate label with QualifiedLabel fails

### DIFF
--- a/tests/regression_tests.py
+++ b/tests/regression_tests.py
@@ -42,7 +42,7 @@ def test_duplicate_label():
     my_label2 = "test_02"
     es.add(solph.Bus(label=my_label1))
     es.add(solph.Bus(label=my_label2))
-    msg = rf"EnergySystem already contains Node\(s\) labeled: "
+    msg = r"EnergySystem already contains Node\(s\) labeled: "
     with pytest.raises(ValueError, match=msg):
         es.add(solph.Bus(label=my_label1), solph.Bus(label=my_label2))
 
@@ -58,6 +58,6 @@ def test_duplicate_qualified_label():
     )
     es.add(solph.Bus(label=my_label1))
     es.add(solph.Bus(label=my_label2))
-    msg = rf"EnergySystem already contains Node\(s\) labeled: \('test"
+    msg = r"EnergySystem already contains Node\(s\) labeled: \('test"
     with pytest.raises(ValueError, match=msg):
         es.add(solph.Bus(label=my_label1), solph.Bus(label=my_label2))


### PR DESCRIPTION
Error message for duplicate label with QualifiedLabel fails

* I already added a failing test
* The original error message tries to connect the list of labels using `join` but this doesn't work with QualifiedLabel.
* It is not possible to test the complete error message of more than one node because the order is random and may end up in "test1, test2" or "test2, test1". The error message is part of oemof.network so it is not possible to fix this within this package.

```python
..\oemof-network\src\oemof\network\energy_system.py:185: in add
    + ", ".join(common_labels)
      ^^^^^^^^^^^^^^^^^^^^^^^^
E   TypeError: sequence item 0: expected str instance, QualifiedLabel found
```

The original code that raises the error: 
```python   
common_labels = list(self._nodes.keys() & new_nodes.keys())
raise ValueError(
    "EnergySystem already contains Node(s) labeled: "
    + ", ".join(common_labels)
)
```



