### PR TITLE
Enables specifying interest rate of Flow

### DIFF
--- a/src/oemof/solph/flows/_flow.py
+++ b/src/oemof/solph/flows/_flow.py
@@ -98,6 +98,10 @@ class Flow(Edge):
         once it reaches its lifetime (considering also
         an initial age), the flow is forced to 0.
         Note: Only applicable for a multi-period model.
+    interest_rate: numeric
+        The discount rate to calculate annuities.
+        If no interest_rate is specified a default value of 0.02 is assumed.
+        Note: Only applicable for a multi-period model.
 
     Notes
     -----
@@ -144,6 +148,7 @@ class Flow(Edge):
         lifetime=None,
         age=None,
         fixed_costs=None,
+        interest_rate=None,
         custom_attributes=None,  # To be removed for versions >= v0.7
         custom_properties=None,
     ):

--- a/src/oemof/solph/flows/_investment_flow_block.py
+++ b/src/oemof/solph/flows/_investment_flow_block.py
@@ -921,7 +921,7 @@ class InvestmentFlowBlock(ScalarBlock):
             )
             for i, o in self.CONVEX_INVESTFLOWS:
                 lifetime = m.flows[i, o].investment.lifetime
-                interest = 0
+                interest = m.flows[i, o].investment.interest_rate
                 if interest == 0:
                     warn(
                         msg.format(m.discount_rate),
@@ -964,7 +964,7 @@ class InvestmentFlowBlock(ScalarBlock):
 
             for i, o in self.NON_CONVEX_INVESTFLOWS:
                 lifetime = m.flows[i, o].investment.lifetime
-                interest = 0
+                interest = m.flows[i, o].investment.interest_rate
                 if interest == 0:
                     warn(
                         msg.format(m.discount_rate),


### PR DESCRIPTION
Fixes #1240

As long as annuities are calculated within the model (for a discussion see  #1183), this enables setting discount_rates. 
