### PR TITLE
Update warnings in solph.Results

### DIFF
--- a/src/oemof/solph/_results.py
+++ b/src/oemof/solph/_results.py
@@ -27,7 +27,6 @@ class Results:
         self._solver_results = model.solver_results
         self._meta_results = {
             "objective": model.objective(),
-            "solver_results": model.solver_results,
         }
         self._variables = {}
         self._model = model
@@ -145,8 +144,7 @@ class Results:
     def _direct_pyomo_result_waring():
         warnings.warn(
             "Direct access to Pyomo results is only provided as a"
-            + " compatibility layer and is planed to be removed."
-            + " Use key 'solver_results' instead.",
+            + " compatibility layer and is planed to be removed.",
             category=FutureWarning,
         )
 

--- a/tests/test_outputlib/test_results.py
+++ b/tests/test_outputlib/test_results.py
@@ -1,5 +1,6 @@
 import pytest
 from oemof.tools.debugging import ExperimentalFeatureWarning
+from pyomo.opt.results.container import ListContainer
 
 from oemof.solph import Results
 
@@ -47,13 +48,11 @@ class TestResultsClass:
             self.results["objective"] = 5
 
     def test_solver_result_access(self):
-        solver_problem = self.results["solver_results"]["Problem"]
-
         with pytest.warns(
             FutureWarning,
             match="Direct access to Pyomo results",
         ):
-            assert solver_problem == self.results["Problem"]
+            assert isinstance(self.results["Problem"], ListContainer)
 
     def test_economic_calculations(self):
         with pytest.warns(


### PR DESCRIPTION
The object as a whole is no longer experimental, however:

* economic calculations are, and
* people should not get used to Pyomo results backward compatibility.