### PR TITLE
Try to let workflows succeed if coveralls is unavailable

### DIFF
--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -30,9 +30,15 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions coverage
+        pip install tox tox-gh-actions coverage coveralls
     - name: Test with tox
       run: tox -e py3
 
     - name: Check test coverage
       run: coverage report -m --fail-under=80
+
+    - name: Report to coveralls
+      run: coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -30,15 +30,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions coverage coveralls
+        pip install tox tox-gh-actions coverage
     - name: Test with tox
       run: tox -e py3
 
     - name: Check test coverage
       run: coverage report -m --fail-under=80
-
-    - name: Report to coveralls
-      run: coveralls
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -42,3 +42,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         COVERALLS_SERVICE_NAME: github
+      continue-on-error: true

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 [testenv]
 basepython =
     docs: {env:TOXPYTHON:python3}
-    {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {bootstrap,clean,check,report}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -53,26 +53,11 @@ commands =
     flake8 src tests
     isort --check-only --profile black --diff src tests
 
-
 [testenv:docs]
 usedevelop = true
 commands =
     sphinx-build {posargs:-E} -W -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
-
-[testenv:coveralls]
-deps =
-    coveralls
-skip_install = true
-commands =
-    coveralls []
-
-[testenv:codecov]
-deps =
-    codecov
-skip_install = true
-commands =
-    codecov []
 
 [testenv:report]
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 [testenv]
 basepython =
     docs: {env:TOXPYTHON:python3}
-    {bootstrap,clean,check,report}: {env:TOXPYTHON:python3}
+    {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -53,11 +53,26 @@ commands =
     flake8 src tests
     isort --check-only --profile black --diff src tests
 
+
 [testenv:docs]
 usedevelop = true
 commands =
     sphinx-build {posargs:-E} -W -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
+
+[testenv:coveralls]
+deps =
+    coveralls
+skip_install = true
+commands =
+    coveralls []
+
+[testenv:codecov]
+deps =
+    codecov
+skip_install = true
+commands =
+    codecov []
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
Reporting to coveralls often fails, invalidating pipeline results. 
