### PR TITLE
Set EnergySystem.timeindex at solph level

### DIFF
--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -216,9 +216,10 @@ class EnergySystem(es.EnergySystem):
         )
         super().__init__(
             groupings=groupings,
-            timeindex=timeindex,
-            timeincrement=timeincrement,
         )
+        self.timeindex = timeindex
+        self.timeincrement = timeincrement
+
 
         self.periods = periods
         if self.periods is not None:

--- a/src/oemof/solph/_energy_system.py
+++ b/src/oemof/solph/_energy_system.py
@@ -220,7 +220,6 @@ class EnergySystem(es.EnergySystem):
         self.timeindex = timeindex
         self.timeincrement = timeincrement
 
-
         self.periods = periods
         if self.periods is not None:
             msg = (


### PR DESCRIPTION
The timeindex is not used or even needed at the level of oemof.network.