### PR TITLE
Fix Furo error when displaying ToC of result tutorial.

### DIFF
--- a/docs/basic_concepts/results.rst
+++ b/docs/basic_concepts/results.rst
@@ -34,6 +34,7 @@ The results chapter consists of three parts:
     :depth: 1
     :local:
     :backlinks: top
+    :class: this-will-duplicate-information-and-it-is-still-useful-here
 
 The first step is the processing of the results
 (:ref:`results_collect_results_label`). This is followed by basic examples of

--- a/docs/whatsnew/v0-6-4.rst
+++ b/docs/whatsnew/v0-6-4.rst
@@ -1,4 +1,4 @@
-v0.6.3
+v0.6.4
 ------
 
 API changes
@@ -12,6 +12,8 @@ New features
 Documentation
 #############
 
+* Fix Furo error when displaying the table of contents of the result handling
+  tutorial
 
 Bug fixes
 #########
@@ -24,6 +26,7 @@ Other changes
 Contributors
 ############
 
+* Jonas Freißmann
 
 Acknowledgements
 ################


### PR DESCRIPTION
In the [results handling](https://oemof-solph.readthedocs.io/en/stable/basic_concepts/results.html#) section of the documentation Furo raises an error when displaying the table of contents in the main text (because it thinks its redundant information). This PR implements the Furo suggested fix to avoid the error while still keeping the ToC.