### PR TITLE
Revision/replace coveralls

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,9 +3,9 @@ source = src
 
 [run]
 branch = true
+relative_files = true
 source =
     src
-    tests
 parallel = true
 omit = */experimental/*
        *test*

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,36 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["tox pytests"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Run tests & display coverage
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: ["3.14"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tox_checks.yml
+++ b/.github/workflows/tox_checks.yml
@@ -31,10 +31,10 @@ jobs:
       - name: Install LaTeX
         run: sudo apt install dvipng rubber texlive-latex-extra
       - name: Git clone
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python ${{ env.default_python || '3.14' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "${{ env.default_python || '3.14' }}"
 

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -20,11 +20,11 @@ jobs:
         python-version: ["3.11", "3.14"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Install cbc
       run: sudo apt install coinor-cbc
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/tox_pytests.yml
+++ b/.github/workflows/tox_pytests.yml
@@ -1,3 +1,5 @@
+# Additional copyright: Joachim Jablon, kieferro (MIT license)
+
 name: tox pytests
 
 on:
@@ -30,16 +32,64 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install tox tox-gh-actions coverage coveralls
+        pip install tox tox-gh-actions coverage
     - name: Test with tox
       run: tox -e py3
+      env:
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+        # The file name prefix must be ".coverage." for "coverage combine"
+        # enabled by "MERGE_COVERAGE_FILES: true" to work. A "subprocess"
+        # error with the message "No data to combine" will be triggered if
+        # this prefix is not used.
 
     - name: Check test coverage
       run: coverage report -m --fail-under=80
-
-    - name: Report to coveralls
-      run: coveralls
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        COVERALLS_SERVICE_NAME: github
-      continue-on-error: true
+        COVERAGE_FILE: ".coverage.${{ matrix.python-version }}"
+
+    - name: Store coverage file
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-${{ matrix.python-version }}
+        path: .coverage.${{ matrix.python-version }}
+        # By default hidden files/folders (i.e. starting with .) are ignored.
+        # You may prefer (for security reasons) not setting this and instead
+        # set COVERAGE_FILE above to not start with a `.`, but you cannot
+        # use "MERGE_COVERAGE_FILES: true" later on and need to manually
+        # combine the coverage file using "pipx run coverage combine"
+        include-hidden-files: true
+
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    needs: pytest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This is optional since by default it's to true. The git
+          # operations in python-coverage-comment-action utilize the token
+          # stored by actions/checkout.
+          persist-credentials: true
+
+      - uses: actions/download-artifact@v4
+        id: download
+        with:
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Coverage comment
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_COVERAGE_FILES: true
+
+      - name: Store Pull Request comment to be posted
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 
-|tox-pytest| |tox-checks| |packaging| |coveralls|
+|tox-pytest| |tox-checks| |packaging|
 
 |docs| |version| |supported-versions|
 
@@ -20,10 +20,6 @@
 .. |docs| image:: https://readthedocs.org/projects/oemof-solph/badge/?style=flat
     :target: https://readthedocs.org/projects/oemof-solph
     :alt: Documentation Status
-
-.. |coveralls| image:: https://coveralls.io/repos/oemof/oemof-solph/badge.svg?branch=dev&service=github
-    :alt: Coverage Status
-    :target: https://coveralls.io/github/oemof/oemof-solph
 
 .. |version| image:: https://img.shields.io/pypi/v/oemof.solph.svg
     :alt: PyPI Package latest release

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ envlist =
 [testenv]
 basepython =
     docs: {env:TOXPYTHON:python3}
-    {bootstrap,clean,check,report,codecov,coveralls}: {env:TOXPYTHON:python3}
+    {bootstrap,clean,check,report,codecov}: {env:TOXPYTHON:python3}
 setenv =
     PYTHONPATH={toxinidir}/tests
     PYTHONUNBUFFERED=yes
@@ -59,13 +59,6 @@ usedevelop = true
 commands =
     sphinx-build {posargs:-E} -W -b html docs dist/docs
     sphinx-build -b linkcheck docs dist/docs
-
-[testenv:coveralls]
-deps =
-    coveralls
-skip_install = true
-commands =
-    coveralls []
 
 [testenv:codecov]
 deps =


### PR DESCRIPTION
Often, our CI tests fail just because coveralls is unreachable. The last outage was just the longest one. A second argument is, that CI tests should just make sure that local tests were run. If local tests pass, CI tests should also pass. With Coveralls, this is no longer the case. Thirdly, we often wave through merges even if coverage decreases. The reason is simple: If code is re-factored so that lines of code can be reduced (and tested lines are removed), often also nominal coverage decreases. Thus, the coverage (change) only has informative character anyway.

Concluding, I think it makes sense to remove coveralls from the CI pipeline. (I still like to have the coverage information accessible, nonetheless.)

- [x] Remove coveralls
- [x] Use https://github.com/py-cov-action/python-coverage-comment-action
- Add new GitHub internal badge. (Need to run action in dev, first.)

Process successfully tested at https://github.com/oemof/oemof-demand/pull/88, see https://htmlpreview.github.io/?https://github.com/oemof/oemof-demand/blob/python-coverage-comment-action-data/htmlcov/index.html for coverage report.