### PR TITLE
Feature/return results

### DIFF
--- a/docs/whatsnew/v0-6-4.rst
+++ b/docs/whatsnew/v0-6-4.rst
@@ -4,6 +4,8 @@ v0.6.4
 API changes
 ###########
 
+* `Model.solve()` now directly returns the optimisation `Results`. (For some
+  time, they will be backwards compatible with the old meta_results.)
 
 New features
 ############
@@ -30,6 +32,7 @@ Contributors
 
 * Jonas Freißmann
 * Lena Rosin
+* Patrik Schönfeldt
 
 Acknowledgements
 ################

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -34,6 +34,8 @@ from oemof.solph.flows._investment_flow_block import InvestmentFlowBlock
 from oemof.solph.flows._non_convex_flow_block import NonConvexFlowBlock
 from oemof.solph.flows._simple_flow_block import SimpleFlowBlock
 
+from ._results import Results
+
 
 class LoggingError(BaseException):
     """Raised when the wrong logging level is used."""
@@ -458,6 +460,14 @@ class Model(po.ConcreteModel):
             \Gurobi solver takes numeric parameter values such as
             {"method": 2}
         """
+        if allow_nonoptimal:
+            warnings.warn(
+                "Setting allow_nonoptimal does not allow to guearntee that"
+                + " results are returned. Thus, it is depreciated and will be"
+                + " removed in a future version.",
+                FutureWarning,
+            )
+
         solve_kwargs = kwargs.get("solve_kwargs", {})
         solver_cmdline_options = kwargs.get("cmdline_options", {})
         opt = SolverFactory(solver, solver_io=solver_io)
@@ -489,10 +499,11 @@ class Model(po.ConcreteModel):
                 warnings.warn(
                     msg.format(status, termination_condition), UserWarning
                 )
+                return solver_results
             else:
                 raise RuntimeError(msg)
 
-        return solver_results
+        return Results(self)
 
     def relax_problem(self):
         """Relaxes integer variables to reals of optimization model self."""

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -432,7 +432,12 @@ class Model(po.ConcreteModel):
         return processing.results(self)
 
     def solve(
-        self, solver="cbc", solver_io="lp", allow_nonoptimal=False, **kwargs
+        self,
+        solver="cbc",
+        solver_io="lp",
+        allow_nonoptimal=False,
+        solve_kwargs=None,
+        cmdline_options=None,
     ):
         r"""Takes care of communication with solver to solve the model.
 
@@ -445,11 +450,6 @@ class Model(po.ConcreteModel):
         allow_nonoptimal : bool
             False: If no optimal solution is found, an error will be risen.
             True: If no optimal solution is found, there will be a warning.
-        \**kwargs : keyword arguments
-            Possible keys can be set see below:
-
-        Other Parameters
-        ----------------
         solve_kwargs : dict
             Other arguments for the pyomo.opt.SolverFactory.solve() method
             Example : {"tee":True}
@@ -468,14 +468,16 @@ class Model(po.ConcreteModel):
                 FutureWarning,
             )
 
-        solve_kwargs = kwargs.get("solve_kwargs", {})
-        solver_cmdline_options = kwargs.get("cmdline_options", {})
+        if solve_kwargs is None:
+            solve_kwargs = {}
+        if cmdline_options is None:
+            cmdline_options = {}
         opt = SolverFactory(solver, solver_io=solver_io)
 
         # set command line options
         options = opt.options
-        for k in solver_cmdline_options:
-            options[k] = solver_cmdline_options[k]
+        for k in cmdline_options:
+            options[k] = cmdline_options[k]
 
         solver_results = opt.solve(self, **solve_kwargs)
 
@@ -490,8 +492,8 @@ class Model(po.ConcreteModel):
         else:
             msg = (
                 f"The solver did not return an optimal solution. "
-                f"Instead the optimization ended with\n "
-                f"      - status: {status}\n"
+                f"Instead the optimization ended with\n"
+                f"       - status: {status}\n"
                 f"       - termination condition: {termination_condition}"
             )
 

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -450,6 +450,8 @@ class Model(po.ConcreteModel):
         allow_nonoptimal : bool
             False: If no optimal solution is found, an error will be risen.
             True: If no optimal solution is found, there will be a warning.
+            This is an option for experts. There will be no results in case
+            no optimum is found.
         solve_kwargs : dict
             Other arguments for the pyomo.opt.SolverFactory.solve() method
             Example : {"tee":True}
@@ -460,14 +462,6 @@ class Model(po.ConcreteModel):
             \Gurobi solver takes numeric parameter values such as
             {"method": 2}
         """
-        if allow_nonoptimal:
-            warnings.warn(
-                "Setting allow_nonoptimal does not allow to guearntee that"
-                + " results are returned. Thus, it is depreciated and will be"
-                + " removed in a future version.",
-                FutureWarning,
-            )
-
         if solve_kwargs is None:
             solve_kwargs = {}
         if cmdline_options is None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -54,10 +54,10 @@ def test_unbounded_model():
     es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
     bel = solph.buses.Bus(label="bus")
     es.add(bel)
-    # Add a Sink with a higher demand
+    # unbound Sink
     es.add(solph.components.Sink(inputs={bel: solph.flows.Flow()}))
 
-    # Add a Source with a very high supply
+    # unbound Source with a revenue
     es.add(
         solph.components.Source(
             outputs={bel: solph.flows.Flow(variable_costs=-5)}
@@ -69,6 +69,36 @@ def test_unbounded_model():
         RuntimeError, match="The solver did not return an optimal solution"
     ):
         m.solve(solver="cbc", allow_nonoptimal=False)
+
+
+def test_cmdline_options(capsys):
+    es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
+    bel = solph.buses.Bus(label="bus")
+    es.add(bel)
+    # bound Sink
+    es.add(
+        solph.components.Sink(
+            inputs={bel: solph.flows.Flow(nominal_capacity=4)}
+        )
+    )
+
+    # Source with a revenue
+    es.add(
+        solph.components.Source(
+            outputs={bel: solph.flows.Flow(variable_costs=-5)}
+        )
+    )
+    m = solph.Model(es)
+
+    m.solve(
+        solver="cbc",
+        cmdline_options={"ratio": 0.01},
+        solve_kwargs={"tee": True},  # need to set to see command line
+    )
+
+    captured = capsys.readouterr()
+
+    assert "-ratio 0.01" in captured.out
 
 
 @pytest.mark.filterwarnings(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,7 @@ import warnings
 
 import pandas as pd
 import pytest
+from pyomo.opt.results import SolverResults
 
 from oemof import solph
 
@@ -37,7 +38,11 @@ def test_infeasible_model():
     with pytest.warns(
         UserWarning, match="The solver did not return an optimal solution"
     ):
-        m.solve(solver="cbc", allow_nonoptimal=True)
+        with pytest.warns(
+            FutureWarning, match="allow_nonoptimal",
+        ):
+            result = m.solve(solver="cbc", allow_nonoptimal=True)
+            assert isinstance(result, SolverResults)
 
     with pytest.raises(
         RuntimeError, match="The solver did not return an optimal solution"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -38,11 +38,8 @@ def test_infeasible_model():
     with pytest.warns(
         UserWarning, match="The solver did not return an optimal solution"
     ):
-        with pytest.warns(
-            FutureWarning, match="allow_nonoptimal",
-        ):
-            result = m.solve(solver="cbc", allow_nonoptimal=True)
-            assert isinstance(result, SolverResults)
+        result = m.solve(solver="cbc", allow_nonoptimal=True)
+        assert isinstance(result, SolverResults)
 
     with pytest.raises(
         RuntimeError, match="The solver did not return an optimal solution"

--- a/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
+++ b/tests/test_scripts/test_solph/test_connect_invest/test_connect_invest.py
@@ -117,7 +117,7 @@ def test_connect_invest():
 
     # if tee_switch is true solver messages will be displayed
     logging.info("Solve the optimization problem")
-    om.solve(solver="cbc", tee=True)
+    om.solve(solver="cbc", solve_kwargs={"tee": True})
 
     # check if the new result object is working for custom components
     results = processing.results(om)


### PR DESCRIPTION
*  Model.solve() now returns `Results`.
* As the Results object assumes that the model is feasible, the return type now depends on the feasibility of the model. Thus, I introduced a warning that suggests a phase out of the option "allow_nonoptimal".

Old API (still possible):
```
model = Model(energy_system)
model.solve()
results = Results(model)
```

New API:
```
model = Model(energy_system)
results = model.solve()
```

I think, at some point we should exclusively describe the new API, as it prevents the following error:

Never worked:
```Python
model = Model(energy_system)
# not solve the model but directly:
results = Results(model)  # needs to be solved, first
```

But I think that is something for a separate PR after we have released an alpha with this status.