### PR TITLE
Fix NonConvex flows tsam disaggreation + route invest_status as period scalar

### DIFF
--- a/docs/whatsnew/v0-6-4.rst
+++ b/docs/whatsnew/v0-6-4.rst
@@ -38,6 +38,7 @@ Contributors
 * Jonas Freißmann
 * Lena Rosin
 * Patrik Schönfeldt
+* Jelmer de Wit
 
 Acknowledgements
 ################

--- a/docs/whatsnew/v0-6-4.rst
+++ b/docs/whatsnew/v0-6-4.rst
@@ -22,6 +22,8 @@ Documentation
 Bug fixes
 #########
 
+* Fix TSAM result disaggregation for ``NonConvex`` and ``InvestNonConvex``
+  flows, which silently dropped per-timestep variables from the output
 
 Other changes
 #############

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -36,7 +36,7 @@ from oemof.solph.components._generic_storage import GenericStorage
 from ._plumbing import _FakeSequence
 from .helpers import flatten
 
-PERIOD_INDEXES = ("invest", "total", "old", "old_end", "old_exo")
+PERIOD_INDEXES = ("invest", "total", "old", "old_end", "old_exo", "invest_status")
 
 
 def get_tuple(x):
@@ -491,28 +491,42 @@ def _disaggregate_tsa_result(df_dict, tsa_parameters):
     for key in multiplexer_keys:
         del flow_dict[key]
 
-    # Disaggregate flows
+    # Note: flows from NonConvexFlowBlock carry extra per-timestep fields
+    # (status, startup, etc.) alongside `flow`, so we need to group by
+    # variable_name first, otherwise iloc slicing doesnt line up.
     for flow in flow_dict:
-        disaggregated_flow_frames = []
-        period_offset = 0
-        for tsa_period in tsa_parameters:
-            for k in tsa_period["order"]:
-                flow_k = flow_dict[flow].iloc[
-                    period_offset
-                    + k * tsa_period["timesteps"] : period_offset
-                    + (k + 1) * tsa_period["timesteps"]
-                ]
-                # Disaggregate segmentation
-                if "segments" in tsa_period:
-                    flow_k = _disaggregate_segmentation(
-                        flow_k, tsa_period["segments"], k
-                    )
-                disaggregated_flow_frames.append(flow_k)
-            period_offset += tsa_period["timesteps"] * len(
-                tsa_period["occurrences"]
-            )
-        ts = pd.concat(disaggregated_flow_frames)
-        ts.timestep = range(len(ts))
+        if flow_dict[flow].empty:
+            continue
+        disaggregated_parts = []
+        for var_name in flow_dict[flow]["variable_name"].unique():
+            var_df = flow_dict[flow][
+                flow_dict[flow]["variable_name"] == var_name
+            ].reset_index(drop=True)
+
+            var_frames = []
+            period_offset = 0
+            for tsa_period in tsa_parameters:
+                for k in tsa_period["order"]:
+                    flow_k = var_df.iloc[
+                        period_offset
+                        + k * tsa_period["timesteps"] : period_offset
+                        + (k + 1) * tsa_period["timesteps"]
+                    ]
+                    # Disaggregate segmentation
+                    if "segments" in tsa_period:
+                        flow_k = _disaggregate_segmentation(
+                            flow_k, tsa_period["segments"], k
+                        )
+                    var_frames.append(flow_k)
+                period_offset += tsa_period["timesteps"] * len(
+                    tsa_period["occurrences"]
+                )
+
+            var_result = pd.concat(var_frames).copy()
+            var_result["timestep"] = range(len(var_result))
+            disaggregated_parts.append(var_result)
+
+        ts = pd.concat(disaggregated_parts)
         ts = ts.set_index("timestep")  # Have to set and reset index as
         # interpolation in pandas<2.1.0 cannot handle NANs in index
         flow_dict[flow] = ts.ffill().reset_index("timestep")

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -495,8 +495,6 @@ def _disaggregate_tsa_result(df_dict, tsa_parameters):
     # (status, startup, etc.) alongside `flow`, so we need to group by
     # variable_name first, otherwise iloc slicing doesnt line up.
     for flow in flow_dict:
-        if flow_dict[flow].empty:
-            continue
         disaggregated_parts = []
         for var_name in flow_dict[flow]["variable_name"].unique():
             var_df = flow_dict[flow][

--- a/tests/test_tsam_processing.py
+++ b/tests/test_tsam_processing.py
@@ -29,3 +29,106 @@ def test_disaggregate_timeindex():
             )
 
     assert all(result_index == ti)
+
+
+# Long-format / "melted" frame (see pandas.DataFrame.melt); matches the
+# shape the processing module uses internally for flow results
+def _make_melted_var(var_name, values):
+    return pd.DataFrame(
+        {
+            "timestep": range(len(values)),
+            "variable_name": [var_name] * len(values),
+            "value": list(values),
+        }
+    )
+
+
+def test_disaggregate_tsa_result_single_sequence_flow():
+    """A plain Flow frame (single sequence variable) disaggregates by order"""
+    flow_df = _make_melted_var("flow", [10.0, 11.0, 12.0, 20.0, 21.0, 22.0])
+    df_dict = {("source", "target"): flow_df}
+    tsa_parameters = [
+        {"timesteps": 3, "order": [1, 0, 1], "occurrences": {0: 1, 1: 2}},
+    ]
+
+    result = processing._disaggregate_tsa_result(df_dict, tsa_parameters)
+
+    disaggregated = result[("source", "target")]
+    flow_values = disaggregated.loc[
+        disaggregated["variable_name"] == "flow", "value"
+    ].tolist()
+    # order [1, 0, 1] picks period 1, then period 0, then period 1
+    assert flow_values == [20.0, 21.0, 22.0, 10.0, 11.0, 12.0, 20.0, 21.0, 22.0]
+
+
+def test_disaggregate_tsa_result_multi_sequence_flow():
+    """A flow carrying multiple per-timestep sequences disaggregates each
+    independently.
+
+    Regression test for a bug where position-based iloc slicing silently
+    assumed each flow's melted frame contained exactly one sequence
+    variable. Flows emitted by ``NonConvexFlowBlock`` /
+    ``InvestNonConvexFlowBlock`` carry ``flow``, ``status``,
+    ``status_nominal``, ``startup`` and friends together, which broke the
+    assumption and produced misaligned results.
+    """
+    flow_df = _make_melted_var("flow", [10.0, 11.0, 12.0, 20.0, 21.0, 22.0])
+    status_df = _make_melted_var("status", [1, 1, 1, 0, 1, 1])
+    status_nominal_df = _make_melted_var(
+        "status_nominal", [100.0, 100.0, 100.0, 0.0, 150.0, 150.0]
+    )
+    combined = pd.concat([flow_df, status_df, status_nominal_df], ignore_index=True)
+    df_dict = {("source", "target"): combined}
+    tsa_parameters = [
+        {"timesteps": 3, "order": [1, 0, 1], "occurrences": {0: 1, 1: 2}},
+    ]
+
+    result = processing._disaggregate_tsa_result(df_dict, tsa_parameters)
+    disaggregated = result[("source", "target")]
+
+    def _values(var):
+        return disaggregated.loc[
+            disaggregated["variable_name"] == var, "value"
+        ].tolist()
+
+    assert _values("flow") == [20.0, 21.0, 22.0, 10.0, 11.0, 12.0, 20.0, 21.0, 22.0]
+    assert _values("status") == [0, 1, 1, 1, 1, 1, 0, 1, 1]
+    assert _values("status_nominal") == [
+        0.0, 150.0, 150.0, 100.0, 100.0, 100.0, 0.0, 150.0, 150.0,
+    ]
+
+
+def test_disaggregate_tsa_result_invest_status_is_periodic():
+    """``invest_status`` (binary from nonconvex Investment /
+    InvestNonConvexFlow) is a scalar per period and must be passed through
+    via ``PERIOD_INDEXES`` rather than iloc-sliced as a sequence.
+    """
+    flow_df = _make_melted_var("flow", [10.0, 11.0, 12.0])
+    invest_status_df = pd.DataFrame(
+        {
+            "timestep": [0],
+            "variable_name": ["invest_status"],
+            "value": [1.0],
+        }
+    )
+    combined = pd.concat([flow_df, invest_status_df], ignore_index=True)
+    df_dict = {("source", "target"): combined}
+    tsa_parameters = [
+        {"timesteps": 3, "order": [0, 0], "occurrences": {0: 2}},
+    ]
+
+    assert "invest_status" in processing.PERIOD_INDEXES
+
+    result = processing._disaggregate_tsa_result(df_dict, tsa_parameters)
+    disaggregated = result[("source", "target")]
+
+    # invest_status should appear exactly once, as a period-scalar, not
+    # iloc-sliced into the sequence path
+    invest_status_rows = disaggregated[
+        disaggregated["variable_name"] == "invest_status"
+    ]
+    assert len(invest_status_rows) == 1
+    assert invest_status_rows["value"].iloc[0] == 1.0
+
+    flow_rows = disaggregated[disaggregated["variable_name"] == "flow"]
+    assert flow_rows["value"].tolist() == [10.0, 11.0, 12.0, 10.0, 11.0, 12.0]


### PR DESCRIPTION
First off, thanks for this project; it is great to work with!

I ran into an issue while using NonConvex investments together with tsam time clustering. I think btw that combination can be quite common since NonConvex makes problems expensive fast, and clustering can keep solving time manageable.

## Problem

The tsam disaggregation loop in `_disaggregate_tsa_result` sliced each flow's long-format frame by position, assuming exactly one per-timestep variable per flow. That is true for plain `Flow` and convex `InvestmentFlowBlock`, because their extras (`invest`, `total`, `old`, etc.) are period scalars and already get stripped via `PERIOD_INDEXES` before the loop runs. 

However NonConvex is different: there are extra variables that are per-timestep `status`, `status_nominal`, etc. They live alongside `flow` in the same frame. The old loop silently dropped these extra values from the disaggregated output.

## Fix

- Group each flow's frame by `variable_name` before slicing, so the per-period math runs once per variable against its own row positions.

- Route `invest_status` through `PERIOD_INDEXES` - it is a period scalar rather than a per-timestep sequence, and was being iloc-sliced incorrectly.

- Add three regression tests in `tests/test_tsam_processing.py`

BTW: The contributing guide mentions contributors should add themselves to `AUTHORS.rst` - is that necessary for this PR?
