### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/basic_concepts/results.rst
+++ b/docs/basic_concepts/results.rst
@@ -51,7 +51,7 @@ Working with results
 --------------------
 
 First of all, it should be mentioned that a Node is considered to be equal
-to its label. Thus, the above code is completely equivilent to:
+to its label. Thus, the above code is completely equivalent to:
 
 .. code-block:: python
 
@@ -61,8 +61,8 @@ to its label. Thus, the above code is completely equivilent to:
     storage_content = results["storage_content"]["storage_node_label"]
 
 However, there is a big advantage in having the original nodes in the
-column name. This way, you can use information not provided in the label.
-For example, to collect all Flows going to a GenericStorage,
+column name. This way, you can use information not provided within the label.
+For example, to collect all flows going to a GenericStorage,
 the following code can be used:
 
 .. code-block:: python
@@ -102,7 +102,7 @@ visualised. See how you can extract flows from the results to plot them:
     ax.legend()
     plt.show()
 
-If you want to have a DataFrame that contains all flows fromand to
+If you want to have a DataFrame that contains all flows from and to
 a specific node, you can also use masking.
 
 .. code-block:: python
@@ -115,7 +115,7 @@ a specific node, you can also use masking.
     flows_bel = flows.loc[:, mask_bel]
 
 This way, you can also migrate from ``solph.views``.
-That modeule was designed to extract node specific from
+That module was designed to extract node specific from
 the nested result dictionary that is returned by calling
 ``solph.processing.results(Model)``. With the new results object,
 this approach is no longer advised.

--- a/docs/introductory_tutorials/ev_charging.rst
+++ b/docs/introductory_tutorials/ev_charging.rst
@@ -338,9 +338,9 @@ The final energy system graph now looks like this:
 
 Looking at the results:
 
-- The charging and discharing within the beginning does not accure anymore
+- The charging and discharing within the beginning does not occure anymore
 - The battery will be loaded for free within the working period
-- There is a discharging at home at the evening to save money
+- There is a discharging at home in the evening to save money
 
 .. figure:: /./_files/tutorial_ev-charging/driving_bidirectional_constant_costs.svg
     :align: center
@@ -372,7 +372,7 @@ Step 5: Variable electricity prices
 ------------------------------------
 
 Within the last step we want to regard dynamic prices for the the charging and discharging at home.
-So the optimization is going to load when the prices are are load and discharge if the prices are high.
+So the optimization is going to load when the prices are load and discharge if the prices are high.
 Assuming the following prices:
 
 - Before 6 a.m.: 5 ct/kWh

--- a/docs/showcase_examples.rst
+++ b/docs/showcase_examples.rst
@@ -23,7 +23,7 @@ accessible freely, so other users can explore and learn from your project.
       :alt: openplan-tool
       :target: https://open-plan-tool.org
 
-    The OpenPlan Tool is an online app with a grafical user interface, that
+    The OpenPlan Tool is an online app with a graphical user interface, that
     let's you create, solve and explore your :code:`EnergySystem`
     interactively. You can use the online variant or clone it to run it on
     self-hosted servers.
@@ -46,9 +46,9 @@ accessible freely, so other users can explore and learn from your project.
       :class: only-dark
       :target: https://owp-inno-nord.streamlit.app
 
-    The streamlit dashboard supports the creation of heating supply system 
-    concepts. This user-friendly tool is developed as part of a research 
-    project at the Flensburg University of Applied Sciences with the aim of 
+    The streamlit dashboard supports the creation of heating supply system
+    concepts. This user-friendly tool is developed as part of a research
+    project at the Flensburg University of Applied Sciences with the aim of
     lowering the entry barrier to energy system analysis for non-experts.
 
     +++

--- a/docs/whatsnew/v0-6-4.rst
+++ b/docs/whatsnew/v0-6-4.rst
@@ -23,7 +23,7 @@ Documentation
   tutorial.
 * Use `solph.Results` in the
   :ref:`Results section of the documentation <basic_concepts_results_label>`,
-  in examples (partally), and tutorials (all of them),
+  in examples (partially), and tutorials (all of them),
   where previously `solph.processing.results` was used.
   (Documentation of the processing module is still available
   as part of the API reference.)


### PR DESCRIPTION
As I reviewed #1275 after its merge, I noticed a few typos which I address here
