### PR TITLE
Update to current TSAM API

### DIFF
--- a/docs/introductory_tutorials/temporal_aggregation.rst
+++ b/docs/introductory_tutorials/temporal_aggregation.rst
@@ -17,6 +17,13 @@ The full tutorial consists of the following:
 * Step 3: Upfront investment using time series aggregation
 * Step 4: Pathway planning using time series aggregation
 
+To run the tutorial code on the typical periods in step 2 you will need the
+extra dependencies:
+
+- oemof.demand
+- workalendar
+- tsam
+
 
 Step 1: Sampling of high resolution input data
 ----------------------------------------------

--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -24,6 +24,7 @@ Other changes
 
 * Interenally, sequences of 'None' are now avoided and a simple 'None'
   is used instead. We expect no effect for end users.
+* Updated respective examples ant tutorials to use current TSAM API (v3).
 
 Contributors
 ############

--- a/examples/time_series_aggragation/invest_optimize_all_technologies_using_mp_and_tsam.py
+++ b/examples/time_series_aggragation/invest_optimize_all_technologies_using_mp_and_tsam.py
@@ -86,7 +86,7 @@ import pprint as pp
 import warnings
 
 import pandas as pd
-import tsam.timeseriesaggregation as tsam
+import tsam
 from oemof.tools import economics
 from oemof.tools import logger
 
@@ -131,30 +131,28 @@ def main(optimize=True):
     typical_periods = 40
     hours_per_period = 24
 
-    aggregation1 = tsam.TimeSeriesAggregation(
-        timeSeries=data.iloc[:8760],
-        noTypicalPeriods=typical_periods,
-        hoursPerPeriod=hours_per_period,
-        clusterMethod="k_means",
-        sortValues=False,
-        rescaleClusterPeriods=False,
-        extremePeriodMethod="replace_cluster_center",
-        addPeakMin=["wind", "pv"],
-        representationMethod="durationRepresentation",
+    aggregation1 = tsam.aggregate(
+        data=data.iloc[:8760],
+        n_clusters=typical_periods,
+        period_duration=hours_per_period,
+        cluster=tsam.ClusterConfig(method="kmeans"),
+        extremes=tsam.ExtremeConfig(
+            method="replace",
+            min_value=["wind", "pv"],
+        ),
     )
-    aggregation1.createTypicalPeriods()
-    aggregation2 = tsam.TimeSeriesAggregation(
-        timeSeries=data.iloc[8760:],
-        noTypicalPeriods=typical_periods,
-        hoursPerPeriod=hours_per_period,
-        clusterMethod="hierarchical",
-        sortValues=False,
-        rescaleClusterPeriods=False,
-        extremePeriodMethod="replace_cluster_center",
-        addPeakMin=["wind", "pv"],
-        representationMethod="durationRepresentation",
+    aggregation2 = tsam.aggregate(
+        data=data.iloc[:8760],
+        n_clusters=typical_periods,
+        period_duration=hours_per_period,
+        cluster=tsam.ClusterConfig(method="hierarchical"),
+        extremes=tsam.ExtremeConfig(
+            method="replace",
+            min_value=["wind", "pv"],
+        ),
     )
-    aggregation2.createTypicalPeriods()
+    representatives1 = aggregation1.cluster_representatives
+    representatives2 = aggregation2.cluster_representatives
 
     t1_agg = pd.date_range(
         "2022-01-01", periods=typical_periods * hours_per_period, freq="h"
@@ -170,14 +168,14 @@ def main(optimize=True):
         periods=[t1_agg, t2_agg],
         tsa_parameters=[
             {
-                "timesteps_per_period": aggregation1.hoursPerPeriod,
-                "order": aggregation1.clusterOrder,
-                "timeindex": aggregation1.timeIndex,
+                "timesteps_per_period": aggregation1.n_timesteps_per_period,
+                "order": aggregation1.cluster_assignments,
+                "timeindex": aggregation1.cluster_representatives.index,
             },
             {
-                "timesteps_per_period": aggregation2.hoursPerPeriod,
-                "order": aggregation2.clusterOrder,
-                "timeindex": aggregation2.timeIndex,
+                "timesteps_per_period": aggregation2.n_timesteps_per_period,
+                "order": aggregation2.cluster_assignments,
+                "timeindex": aggregation2.cluster_representatives.index,
             },
         ],
         infer_last_interval=False,
@@ -216,8 +214,8 @@ def main(optimize=True):
 
     wind_profile = pd.concat(
         [
-            aggregation1.typicalPeriods["wind"],
-            aggregation2.typicalPeriods["wind"],
+            representatives1["wind"],
+            representatives2["wind"],
         ],
         ignore_index=True,
     )
@@ -237,7 +235,7 @@ def main(optimize=True):
     )
 
     pv_profile = pd.concat(
-        [aggregation1.typicalPeriods["pv"], aggregation2.typicalPeriods["pv"]],
+        [representatives1["pv"], representatives2["pv"]],
         ignore_index=True,
     )
     pv_profile.iloc[-24:] = 0
@@ -249,8 +247,8 @@ def main(optimize=True):
             bel: solph.Flow(
                 fix=pd.concat(
                     [
-                        aggregation1.typicalPeriods["pv"],
-                        aggregation2.typicalPeriods["pv"],
+                        representatives1["pv"],
+                        representatives2["pv"],
                     ],
                     ignore_index=True,
                 ),
@@ -268,8 +266,8 @@ def main(optimize=True):
             bel: solph.Flow(
                 fix=pd.concat(
                     [
-                        aggregation1.typicalPeriods["demand_el"],
-                        aggregation2.typicalPeriods["demand_el"],
+                        representatives1["demand_el"],
+                        representatives2["demand_el"],
                     ],
                     ignore_index=True,
                 ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ dev = [
     "furo",
     "matplotlib",
     "nbformat",
+    "oemof.demand",
     "openpyxl",
     "pytest",
     "sphinx",
@@ -95,6 +96,7 @@ dev = [
     "termcolor",
     "tox",
     "tsam>=3.0",
+    "workalendar",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ dev = [
     "sphinx-design",
     "termcolor",
     "tox",
-    "tsam",
+    "tsam>=3.0",
 ]
 
 [project.scripts]

--- a/tutorials/advanced/time_index/input_data.py
+++ b/tutorials/advanced/time_index/input_data.py
@@ -10,7 +10,7 @@ from os import environ
 from pathlib import Path
 import requests
 
-import demandlib
+from oemof.demand.bdew import HeatBuilding
 import numpy as np
 import pandas as pd
 from oemof.tools.economics import annuity
@@ -106,10 +106,11 @@ def prepare_input_data(proxy_url=None, proxy_port=None):
     specific_heat_demand = 60  # kWh/m²/a  (educated guess)
     holidays = dict(Germany().holidays(2019))
 
-    # We estimate the heat demand from the ambient temperature using demandlib.
-    # This returns energy per time step in units of kWh, but we want kW.
+    # We estimate the heat demand from the ambient temperature using
+    # oemof.demand. This returns energy per time step in units of kWh,
+    # but we want kW.
     df["heat demand (kW)"] = (
-        demandlib.bdew.HeatBuilding(
+        HeatBuilding(
             df.index,
             holidays=holidays,
             temperature=df["Air Temperature (°C)"],

--- a/tutorials/advanced/time_index/timeindex_2_typical_periods.py
+++ b/tutorials/advanced/time_index/timeindex_2_typical_periods.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import datetime
 
 import pandas as pd
-import tsam.timeseriesaggregation as tsam
+import tsam
 from input_data import discounted_average_price
 from input_data import energy_prices
 from input_data import get_parameter
@@ -79,31 +79,30 @@ def run_for_typical_periods(
     """
     # %%[tsam_aggregation_start]
     # --- TSAM clustering ---
-    aggregation = tsam.TimeSeriesAggregation(
-        timeSeries=data.iloc[:8760],
-        noTypicalPeriods=typical_periods,
-        hoursPerPeriod=hours_per_period,
-        clusterMethod="k_means",
-        sortValues=False,
-        rescaleClusterPeriods=False,
+    aggregation = tsam.aggregate(
+        data=data.iloc[:8760],
+        n_clusters=typical_periods,
+        period_duration=hours_per_period,
     )
-    aggregation.createTypicalPeriods()
+    representatives = aggregation.cluster_representatives
     # %%[tsam_aggregation_end]
     time_series = {
-        "cop": aggregation.typicalPeriods["cop"],
-        "electricity demand (kW)": aggregation.typicalPeriods[
+        "cop": representatives["cop"],
+        "electricity demand (kW)": representatives[
             "electricity demand (kW)"
         ],
-        "heat demand (kW)": aggregation.typicalPeriods["heat demand (kW)"],
-        "PV (kW/kWp)": aggregation.typicalPeriods["PV (kW/kWp)"],
-        "Electricity for Car Charging_HH1": aggregation.typicalPeriods[
+        "heat demand (kW)": representatives[
+            "heat demand (kW)"
+        ],
+        "PV (kW/kWp)": representatives["PV (kW/kWp)"],
+        "Electricity for Car Charging_HH1": representatives[
             "Electricity for Car Charging_HH1"
         ],
     }
     # %%[ti_index_and_energy_system_start]
     tindex_agg = pd.date_range(
         "2022-01-01",
-        periods=len(aggregation.clusterPeriodIdx) * hours_per_period,
+        periods=typical_periods * hours_per_period,
         freq="h",
     )
 
@@ -113,9 +112,9 @@ def run_for_typical_periods(
         periods=[tindex_agg],
         tsa_parameters=[
             {
-                "timesteps_per_period": aggregation.hoursPerPeriod,
-                "order": aggregation.clusterOrder,
-                "timeindex": aggregation.timeIndex,
+                "timesteps_per_period": aggregation.n_timesteps_per_period,
+                "order": aggregation.cluster_assignments,
+                "timeindex": aggregation.cluster_representatives.index,
             }
         ],
         infer_last_interval=False,

--- a/tutorials/advanced/time_index/timeindex_3_pathway_planning.py
+++ b/tutorials/advanced/time_index/timeindex_3_pathway_planning.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 import matplotlib.pyplot as plt
 import pandas as pd
-import tsam.timeseriesaggregation as tsam
+import tsam
 from input_data import energy_prices
 from input_data import investment_costs
 from input_data import prepare_input_data
@@ -91,15 +91,12 @@ hours_per_period = 24
 
 start = datetime.now()
 
-aggregation = tsam.TimeSeriesAggregation(
-    timeSeries=data.iloc[:8760],
-    noTypicalPeriods=typical_periods,
-    hoursPerPeriod=hours_per_period,
-    clusterMethod="k_means",
-    sortValues=False,
-    rescaleClusterPeriods=False,
+aggregation = tsam.aggregate(
+    data=data.iloc[:8760],
+    n_clusters=typical_periods,
+    period_duration=hours_per_period,
 )
-aggregation.createTypicalPeriods()
+representatives = aggregation.cluster_representatives
 
 # create a time index for the aggregated time series
 tindex_agg = pd.date_range(
@@ -138,8 +135,8 @@ print("---------------------------------------------")
 # with one dict per year
 tsa_parameters = [
     {
-        "timesteps_per_period": aggregation.hoursPerPeriod,
-        "order": aggregation.clusterOrder,
+        "timesteps_per_period": aggregation.n_timesteps_per_period,
+        "order": aggregation.cluster_assignments,
         "timeindex": tindex_agg + pd.DateOffset(years=i),
     }
     for i in range(len(years))
@@ -150,23 +147,23 @@ timeincrement = [1] * (len(tindex_agg_full))
 
 time_series = {
     "cop": pd.concat(
-        [aggregation.typicalPeriods["cop"]] * len(years),
+        [representatives["cop"]] * len(years),
         ignore_index=True,
     ),
     "electricity demand (kW)": pd.concat(
-        [aggregation.typicalPeriods["electricity demand (kW)"]] * len(years),
+        [representatives["electricity demand (kW)"]] * len(years),
         ignore_index=True,
     ),
     "heat demand (kW)": pd.concat(
-        [aggregation.typicalPeriods["heat demand (kW)"]] * len(years),
+        [representatives["heat demand (kW)"]] * len(years),
         ignore_index=True,
     ),
     "PV (kW/kWp)": pd.concat(
-        [aggregation.typicalPeriods["PV (kW/kWp)"]] * len(years),
+        [representatives["PV (kW/kWp)"]] * len(years),
         ignore_index=True,
     ),
     "Electricity for Car Charging_HH1": pd.concat(
-        [aggregation.typicalPeriods["Electricity for Car Charging_HH1"]]
+        [representatives["Electricity for Car Charging_HH1"]]
         * len(years),
         ignore_index=True,
     ),


### PR DESCRIPTION
This fixes the following warning : "LegacyAPIWarning: TimeSeriesAggregation will be removed in tsam v4.0. Use tsam.aggregate() instead."

* [x] Set minimum TSAM version to 3.0
* [x] Update tutorials
* [x] Update example

Also fixes #1293 (I thought, this was only about fixing the tutorial, but there is also an example.)