### PR TITLE
Configure Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,4 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      target-branch: "dev"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    target-branch: "dev"
   - package-ecosystem: "pip"
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-      target-branch: "dev"
+    target-branch: "dev"


### PR DESCRIPTION
This adds a minimal Dependabot config, that checks pip and github workflow versions and creates PRs if updates are recommended by the bot.