### PR TITLE
Let len(_FakeSequence) always return integers

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -24,6 +24,8 @@ Other changes
 
 * Interenally, sequences of 'None' are now avoided and a simple 'None'
   is used instead. We expect no effect for end users.
+* _FakeSequences with no defined length will now evaluate to have
+  ``len(fake_sequence) == 0``, as len is defined to return integers only.
 * Updated respective examples ant tutorials to use current TSAM API (v3).
 
 Contributors

--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -153,7 +153,10 @@ class _FakeSequence:
             return f"[{self._value}, {self._value}, ..., {self._value}]"
 
     def __len__(self):
-        return self._length
+        if self._length is not None:
+            return self._length
+        else:
+            return 0
 
     def __iter__(self):
         return repeat(self._value, self._length)
@@ -173,8 +176,12 @@ class _FakeSequence:
     def to_numpy(self, length=None):
         if length is not None:
             return np.full(length, self._value)
+        elif self._length is not None:
+            return np.full(self._length, self._value)
         else:
-            return np.full(len(self), self._value)
+            raise ValueError(
+                "Length needs to be defined for casting to numpy."
+            )
 
     def __mul__(self, other):
         return sequence(self._value * other, length=self._length)

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -36,12 +36,11 @@ def test_fake_sequence():
 
         assert str(seq) == "[42.0, 42.0, ..., 42.0]"
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match="Length needs to be defined"):
             seq.to_numpy()
         assert (seq.to_numpy(length=5) == np.array(5 * [42])).all()
 
-        with pytest.raises(TypeError):
-            len(seq)
+        assert len(seq) == 0
 
         seq.size = 2
         assert seq.size == 2


### PR DESCRIPTION
`_FakeSequence`s with no defined length will now evaluate to have `len(fake_sequence) == 0`, as `len` is defined to return integers only. (The operation is expected to fail only if the `__len__` is not implemented. We returned `None` in some cases, which is unexpected.)