### PR TITLE
name disaggregated tsa storage soc storage_content

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -21,6 +21,9 @@ Bug fixes
 * Fix inconsistency in the assignment of sequences using scalar variables;
   e.g. `flow = Flow(variable_costs=5)` worked, but `flow.variable_costs = 5`
   failed when constructing the model.
+* Name the TSA-disaggregated storage SOC result ``storage_content`` to match
+  non-clustered ``GenericStorage`` results, so result readers (e.g. ``views``)
+  find it by the same key regardless of clustering.
 
 Other changes
 #############

--- a/src/oemof/solph/processing.py
+++ b/src/oemof/solph/processing.py
@@ -662,7 +662,7 @@ def _calculate_soc_from_inter_and_intra_soc(soc, storage, tsa_parameters):
 
     soc_ts["timestep"] = range(len(soc_ts))
     interpolated_soc = soc_ts.interpolate()
-    interpolated_soc["variable_name"] = "soc"
+    interpolated_soc["variable_name"] = "storage_content"
 
     return interpolated_soc.iloc[:-1]
 

--- a/tests/test_scripts/test_solph/test_tsam/test_storage_tsam_integration.py
+++ b/tests/test_scripts/test_solph/test_tsam/test_storage_tsam_integration.py
@@ -211,7 +211,8 @@ def test_soc():
 
 
 def test_storage_soc_uses_storage_content_name():
-    # clustered runs used to label SOC "soc", but "storage_content" is the canonical name and should stay consistent
+    # clustered runs used to label SOC "soc", but "storage_content" is the
+    # canonical name and should stay consistent
     all_columns = [
         col
         for entry in results.values()

--- a/tests/test_scripts/test_solph/test_tsam/test_storage_tsam_integration.py
+++ b/tests/test_scripts/test_solph/test_tsam/test_storage_tsam_integration.py
@@ -208,3 +208,14 @@ def test_soc():
     assert flow.iloc[5] == pytest.approx((50 * 1 / 0.8) / (1 - 0.01), abs=1e-2)
     assert flow.iloc[6] == pytest.approx(0, abs=1e-2)
     assert flow.iloc[7] == pytest.approx((init_soc + (100 * 1 / 0.8)) / 0.99)
+
+
+def test_storage_soc_uses_storage_content_name():
+    # clustered runs used to label SOC "soc", but "storage_content" is the canonical name and should stay consistent
+    all_columns = [
+        col
+        for entry in results.values()
+        for col in entry["sequences"].columns
+    ]
+    assert "storage_content" in all_columns
+    assert "soc" not in all_columns


### PR DESCRIPTION
When working with results from a model that uses tsam clustering, I noticed an inconsistency in column naming: non-clustered results use `storage_content` for tracking state of charge and clustered results use the column name `soc`.

This should be consistent and results structure should be stable no matter if using temporal clustering or not.

I think currently the `views` module already misses it in the current version and this will be fixed by this PR (see `views.py:401-402`, I think since they are currently named `soc`, results are silently dropped).
