### PR TITLE
Add HiGHS solver

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -8,6 +8,13 @@ API changes
 New features
 ############
 
+* HiGHS is now a fully supported solver. ``model.solve(solver="highs")``
+  returns a ``solph.Results`` object compatible with the full results API,
+  including ``receive_duals()`` for dual variables and reduced costs,
+  ``cmdline_options`` to pass native HiGHS options, and
+  ``solve_kwargs={"tee": True}`` for solver output streaming.
+  Requires the ``highspy`` package. To check whether HiGHS is available
+  in your installation, run ``oemof_installation_test``.
 
 Documentation
 #############
@@ -22,11 +29,13 @@ Bug fixes
 Other changes
 #############
 
-
 Contributors
 ############
 
+* Francesco Witte
 * Jelmer de Wit
+* Patrik Schönfeldt
+* Uwe Krien
 
 
 Acknowledgements

--- a/examples/storage_investment/v1_invest_optimize_all_technologies.py
+++ b/examples/storage_investment/v1_invest_optimize_all_technologies.py
@@ -220,7 +220,7 @@ def main(optimize=True):
 
     # if tee_switch is true solver messages will be displayed
     logging.info("Solve the optimization problem")
-    om.solve(solver="appsi_highs", solve_kwargs={"tee": True})
+    om.solve(solver="highs", solve_kwargs={"tee": True})
 
     ##########################################################################
     # Check and plot the results
@@ -231,8 +231,8 @@ def main(optimize=True):
 
     electricity_bus = solph.views.node(results, "electricity")
 
-    meta_results = solph.processing.meta_results(om)
-    pp.pprint(meta_results)
+    # meta_results = solph.processing.meta_results(om)
+    # pp.pprint(meta_results)
 
     # returns a pandas Series with all scalar values (investment, total) of
     # components connected to the electricity bus

--- a/examples/storage_investment/v1_invest_optimize_all_technologies.py
+++ b/examples/storage_investment/v1_invest_optimize_all_technologies.py
@@ -220,7 +220,7 @@ def main(optimize=True):
 
     # if tee_switch is true solver messages will be displayed
     logging.info("Solve the optimization problem")
-    om.solve(solver="cbc", solve_kwargs={"tee": True})
+    om.solve(solver="appsi_highs", solve_kwargs={"tee": True})
 
     ##########################################################################
     # Check and plot the results

--- a/examples/storage_investment/v1_invest_optimize_all_technologies.py
+++ b/examples/storage_investment/v1_invest_optimize_all_technologies.py
@@ -231,8 +231,6 @@ def main(optimize=True):
 
     electricity_bus = solph.views.node(results, "electricity")
 
-    # meta_results = solph.processing.meta_results(om)
-    # pp.pprint(meta_results)
 
     # returns a pandas Series with all scalar values (investment, total) of
     # components connected to the electricity bus

--- a/examples/time_index_example/simple_time_step_example.py
+++ b/examples/time_index_example/simple_time_step_example.py
@@ -44,10 +44,11 @@ License
 import matplotlib.pyplot as plt
 
 from oemof import solph
+from oemof.tools import logger
 
 
 def main(optimize=True):
-    solver = "cbc"  # 'glpk', 'gurobi',...
+    solver = "highs"  # 'glpk', 'gurobi',...
     solver_verbose = False  # show/hide solver output
 
     date_time_index = solph.create_time_index(2000, interval=0.25, number=8)
@@ -127,4 +128,5 @@ def main(optimize=True):
 
 
 if __name__ == "__main__":
+    logger.define_logging()
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ Changelog = "https://oemof-solph.readthedocs.io/en/latest/changelog.html"
 dev = [
     "flit",
     "furo",
+    "highspy",
     "matplotlib",
     "nbformat",
     "openpyxl",

--- a/src/oemof/solph/_console_scripts.py
+++ b/src/oemof/solph/_console_scripts.py
@@ -67,7 +67,7 @@ def _check_oemof_installation(solvers):
 
 
 def check_oemof_installation():
-    solvers_to_test = ["cbc", "glpk", "gurobi", "cplex", "scip"]
+    solvers_to_test = ["cbc", "glpk", "gurobi", "cplex", "scip", "highs"]
 
     solver_status = _check_oemof_installation(solvers_to_test)
 

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -471,11 +471,17 @@ class Model(po.ConcreteModel):
         if tc == appsi.base.TerminationCondition.optimal:
             appsi_results.solution_loader.load_vars()
             if self.dual is not None:
-                for c, val in appsi_results.solution_loader.get_duals().items():
-                    self.dual[c] = val
+                try:
+                    for c, val in appsi_results.solution_loader.get_duals().items():
+                        self.dual[c] = val
+                except RuntimeError:
+                    pass  # duals not available for MIP models
             if self.rc is not None:
-                for v, val in appsi_results.solution_loader.get_reduced_costs().items():
-                    self.rc[v] = val
+                try:
+                    for v, val in appsi_results.solution_loader.get_reduced_costs().items():
+                        self.rc[v] = val
+                except RuntimeError:
+                    pass  # reduced costs not available for MIP models
             logging.info(
                 f"Optimization successful with condition: {tc.name}"
             )

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -444,24 +444,53 @@ class Model(po.ConcreteModel):
         solve_kwargs=None,
         cmdline_options=None,
     ):
-        msg = (
-            "Using the 'HiGHS'-solver is experimental in solph.\n Using "
-            "options and accessing the meta results might be different."
-        )
-        warnings.warn(msg)
+        if solve_kwargs is None:
+            solve_kwargs = {}
+        if cmdline_options is None:
+            cmdline_options = {}
+
         opt = appsi.solvers.Highs()
-        results = opt.solve(self)
-        if results.termination_condition.value == 5:
+        opt.config.load_solution = False
+
+        if solve_kwargs.get("tee"):
+            opt.config.stream_solver = True
+
+        opt.highs_options = cmdline_options
+
+        appsi_results = opt.solve(self)
+        tc = appsi_results.termination_condition
+
+        solver_results_dict = {
+            "termination_condition": tc.name,
+            "best_feasible_objective": appsi_results.best_feasible_objective,
+            "best_objective_bound": appsi_results.best_objective_bound,
+        }
+        self.es.results = solver_results_dict
+        self.solver_results = solver_results_dict
+
+        if tc == appsi.base.TerminationCondition.optimal:
+            appsi_results.solution_loader.load_vars()
+            if self.dual is not None:
+                for c, val in appsi_results.solution_loader.get_duals().items():
+                    self.dual[c] = val
+            if self.rc is not None:
+                for v, val in appsi_results.solution_loader.get_reduced_costs().items():
+                    self.rc[v] = val
             logging.info(
-                f"Optimization successful with condition: "
-                f"{results.termination_condition.name}"
+                f"Optimization successful with condition: {tc.name}"
             )
+            return Results(self)
         else:
-            warnings.warn("Optimization ended with an unclear status ")
-            print(results)
-        self.solver_results = results
-        # results = Results(self)  # ToDo: This does not work!!
-        return results
+            msg = (
+                f"The solver did not return an optimal solution. "
+                f"Instead the optimization ended with\n"
+                f"       - termination condition: {tc.name}"
+            )
+            if allow_nonoptimal:
+                warnings.warn(msg, UserWarning)
+                return solver_results_dict
+            else:
+                raise RuntimeError(msg)
 
     def solve(
         self,

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -21,6 +21,7 @@ from logging import getLogger
 
 from oemof.tools import debugging
 from pyomo import environ as po
+from pyomo.contrib import appsi
 from pyomo.core.plugins.transform.relax_integrality import RelaxIntegrality
 from pyomo.opt import SolverFactory
 
@@ -436,6 +437,32 @@ class Model(po.ConcreteModel):
         )
         return processing.results(self)
 
+    def solve_highs(
+        self,
+        solver_io="lp",
+        allow_nonoptimal=False,
+        solve_kwargs=None,
+        cmdline_options=None,
+    ):
+        msg = (
+            "Using the 'HiGHS'-solver is experimental in solph.\n Using "
+            "options and accessing the meta results might be different."
+        )
+        warnings.warn(msg)
+        opt = appsi.solvers.Highs()
+        results = opt.solve(self)
+        if results.termination_condition.value == 5:
+            logging.info(
+                f"Optimization successful with condition: "
+                f"{results.termination_condition.name}"
+            )
+        else:
+            warnings.warn("Optimization ended with an unclear status ")
+            print(results)
+        self.solver_results = results
+        # results = Results(self)  # ToDo: This does not work!!
+        return results
+
     def solve(
         self,
         solver="cbc",
@@ -471,10 +498,19 @@ class Model(po.ConcreteModel):
             solve_kwargs = {}
         if cmdline_options is None:
             cmdline_options = {}
+        if solver == "highs":
+            return self.solve_highs(
+                solver_io=solver_io,
+                allow_nonoptimal=allow_nonoptimal,
+                solve_kwargs=solve_kwargs,
+                cmdline_options=cmdline_options,
+            )
+
         if "appsi" in solver:
             solver_io = {}
         else:
             solver_io = {"solver_io": solver_io}
+
         opt = SolverFactory(solver, **solver_io)
 
         # set command line options

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -471,7 +471,11 @@ class Model(po.ConcreteModel):
             solve_kwargs = {}
         if cmdline_options is None:
             cmdline_options = {}
-        opt = SolverFactory(solver, solver_io=solver_io)
+        if "appsi" in solver:
+            solver_io = {}
+        else:
+            solver_io = {"solver_io": solver_io}
+        opt = SolverFactory(solver, **solver_io)
 
         # set command line options
         options = opt.options

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -534,13 +534,29 @@ class Model(po.ConcreteModel):
         if cmdline_options is None:
             cmdline_options = {}
         if solver == "highs":
-            return self.solve_highs(
+            return self._solve_highs(
+                solver_io=solver_io,
+                allow_nonoptimal=allow_nonoptimal,
+                solve_kwargs=solve_kwargs,
+                cmdline_options=cmdline_options,
+            )
+        else:
+            return self._solve_traditional(
+                solver=solver,
                 solver_io=solver_io,
                 allow_nonoptimal=allow_nonoptimal,
                 solve_kwargs=solve_kwargs,
                 cmdline_options=cmdline_options,
             )
 
+    def _solve_traditional(
+        self,
+        solver,
+        solver_io,
+        allow_nonoptimal,
+        solve_kwargs,
+        cmdline_options,
+    ):
         if "appsi" in solver:
             solver_io = {}
         else:

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -557,11 +557,7 @@ class Model(po.ConcreteModel):
         solve_kwargs,
         cmdline_options,
     ):
-        if "appsi" in solver:
-            solver_io = {}
-        else:
-            solver_io = {"solver_io": solver_io}
-
+        opt = SolverFactory(solver, solver_io=solver_io)
         opt = SolverFactory(solver, **solver_io)
 
         # set command line options

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -554,7 +554,6 @@ class Model(po.ConcreteModel):
         cmdline_options,
     ):
         opt = SolverFactory(solver, solver_io=solver_io)
-        opt = SolverFactory(solver, **solver_io)
 
         # set command line options
         options = opt.options

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -15,7 +15,10 @@ SPDX-License-Identifier: MIT
 
 """
 
+import contextlib
+import io
 import logging
+import sys
 import warnings
 from logging import getLogger
 
@@ -36,6 +39,47 @@ from oemof.solph.flows._non_convex_flow_block import NonConvexFlowBlock
 from oemof.solph.flows._simple_flow_block import SimpleFlowBlock
 
 from ._results import Results
+
+
+@contextlib.contextmanager
+def _ensure_std_streams():
+    """Ensure sys.stdout/stderr and fd 2 are valid for pyomo's appsi HiGHS.
+
+    In console-less Windows environments (pythonw.exe, .pyw scripts, some IDEs)
+    sys.stdout and sys.stderr are None and fd 2 may point to an invalid Windows
+    handle. pyomo's appsi.Highs.solve() calls stream.flush() and
+    os.fdopen(os.dup(2), 'w') unconditionally, so both must be valid.
+    """
+    import os as _os
+
+    orig_stdout, orig_stderr = sys.stdout, sys.stderr
+    if sys.stdout is None:
+        sys.stdout = io.StringIO()
+    if sys.stderr is None:
+        sys.stderr = io.StringIO()
+
+    # Also fix fd 2 if its underlying OS handle is not writable.
+    # pyomo calls os.fdopen(os.dup(2), 'w') regardless of stream_solver.
+    fd2_fixed = False
+    try:
+        duped = _os.dup(2)
+        try:
+            _os.fdopen(duped, "w", closefd=False)
+            _os.close(duped)
+        except OSError:
+            _os.close(duped)
+            raise
+    except OSError:
+        null_fd = _os.open(_os.devnull, _os.O_WRONLY)
+        _os.dup2(null_fd, 2)
+        _os.close(null_fd)
+        fd2_fixed = True
+
+    try:
+        yield
+    finally:
+        sys.stdout, sys.stderr = orig_stdout, orig_stderr
+        # fd 2 was invalid before; leaving it pointing to devnull is fine.
 
 
 class LoggingError(BaseException):
@@ -453,7 +497,8 @@ class Model(po.ConcreteModel):
 
         opt.highs_options = cmdline_options
 
-        appsi_results = opt.solve(self)
+        with _ensure_std_streams():
+            appsi_results = opt.solve(self)
         tc = appsi_results.termination_condition
 
         solver_results_dict = {

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -437,17 +437,13 @@ class Model(po.ConcreteModel):
         )
         return processing.results(self)
 
-    def solve_highs(
+    def _solve_highs(
         self,
-        solver_io="lp",
-        allow_nonoptimal=False,
-        solve_kwargs=None,
-        cmdline_options=None,
+        solver_io,
+        allow_nonoptimal,
+        solve_kwargs,
+        cmdline_options,
     ):
-        if solve_kwargs is None:
-            solve_kwargs = {}
-        if cmdline_options is None:
-            cmdline_options = {}
 
         opt = appsi.solvers.Highs()
         opt.config.load_solution = False

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -80,6 +80,34 @@ def _make_feasible_es():
     return es
 
 
+def _make_mip_es():
+    """Same as feasible LP but with a NonConvex flow → MIP."""
+    es = solph.EnergySystem(timeindex=[0, 1, 2], infer_last_interval=False)
+    bus = solph.buses.Bus(label="bus")
+    es.add(bus)
+    es.add(
+        solph.components.Source(
+            label="source",
+            outputs={
+                bus: solph.flows.Flow(
+                    variable_costs=10,
+                    nominal_capacity=100,
+                    nonconvex=solph.NonConvex(),
+                )
+            },
+        )
+    )
+    es.add(
+        solph.components.Sink(
+            label="sink",
+            inputs={
+                bus: solph.flows.Flow(fix=[0.5, 0.8, 0.3], nominal_capacity=100)
+            },
+        )
+    )
+    return es
+
+
 # ---------------------------------------------------------------------------
 # Parametrized: CBC and HiGHS must behave identically
 # ---------------------------------------------------------------------------
@@ -169,6 +197,39 @@ def test_highs_duals_match_cbc():
     assert highs_duals.keys() == cbc_duals.keys()
     for key in highs_duals:
         assert highs_duals[key] == pytest.approx(cbc_duals[key], abs=1e-6)
+
+
+def test_highs_reduced_costs_match_cbc():
+    """Reduced costs match CBC for variables both solvers report.
+
+    HiGHS omits RC for fixed-bound variables while CBC includes them,
+    so we only assert equality on the intersection.
+    """
+    es = _make_feasible_es()
+
+    m_highs = solph.Model(es)
+    m_highs.receive_duals()
+    m_highs.solve(solver="highs")
+
+    m_cbc = solph.Model(es)
+    m_cbc.receive_duals()
+    m_cbc.solve(solver="cbc")
+
+    highs_rc = {str(v): val for v, val in m_highs.rc.items()}
+    cbc_rc = {str(v): val for v, val in m_cbc.rc.items()}
+
+    common_keys = highs_rc.keys() & cbc_rc.keys()
+    assert len(common_keys) > 0, "No common RC variables to compare"
+    for key in common_keys:
+        assert highs_rc[key] == pytest.approx(cbc_rc[key], abs=1e-6)
+
+
+@pytest.mark.parametrize("solver", ["cbc", "highs"])
+def test_receive_duals_on_mip_does_not_crash(solver):
+    """receive_duals() followed by solve must not crash for MIP models."""
+    m = solph.Model(_make_mip_es())
+    m.receive_duals()
+    m.solve(solver=solver)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,59 +16,168 @@ import pytest
 from pyomo.opt.results import SolverResults
 
 from oemof import solph
+from oemof.solph._results import Results
 
 
-def test_infeasible_model():
+# ---------------------------------------------------------------------------
+# Shared energy-system factories
+# ---------------------------------------------------------------------------
+
+
+def _make_infeasible_es():
+    """Source capacity (4) < sink demand (5) → infeasible."""
     es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
-    bel = solph.buses.Bus(label="bus")
-    es.add(bel)
+    bus = solph.buses.Bus(label="bus")
+    es.add(bus)
     es.add(
         solph.components.Sink(
-            inputs={bel: solph.flows.Flow(nominal_capacity=5, fix=[1])}
+            inputs={bus: solph.flows.Flow(nominal_capacity=5, fix=[1])}
         )
     )
     es.add(
         solph.components.Source(
-            outputs={
-                bel: solph.flows.Flow(nominal_capacity=4, variable_costs=5)
-            }
+            outputs={bus: solph.flows.Flow(nominal_capacity=4, variable_costs=5)}
         )
     )
-    m = solph.Model(es)
+    return es
+
+
+def _make_unbounded_es():
+    """Negative variable cost with no upper bound → unbounded."""
+    es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
+    bus = solph.buses.Bus(label="bus")
+    es.add(bus)
+    es.add(solph.components.Sink(inputs={bus: solph.flows.Flow()}))
+    es.add(
+        solph.components.Source(
+            outputs={bus: solph.flows.Flow(variable_costs=-5)}
+        )
+    )
+    return es
+
+
+def _make_feasible_es():
+    """Simple LP: one source, one fixed-demand sink."""
+    es = solph.EnergySystem(timeindex=[0, 1, 2], infer_last_interval=False)
+    bus = solph.buses.Bus(label="bus")
+    es.add(bus)
+    es.add(
+        solph.components.Source(
+            label="source",
+            outputs={
+                bus: solph.flows.Flow(variable_costs=10, nominal_capacity=100)
+            },
+        )
+    )
+    es.add(
+        solph.components.Sink(
+            label="sink",
+            inputs={
+                bus: solph.flows.Flow(fix=[0.5, 0.8, 0.3], nominal_capacity=100)
+            },
+        )
+    )
+    return es
+
+
+# ---------------------------------------------------------------------------
+# Parametrized: CBC and HiGHS must behave identically
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("solver", ["cbc", "highs"])
+def test_feasible_returns_results(solver):
+    """A feasible model must return a solph.Results object for any solver."""
+    result = solph.Model(_make_feasible_es()).solve(solver=solver)
+    assert isinstance(result, Results)
+
+
+@pytest.mark.parametrize("solver", ["cbc", "highs"])
+def test_infeasible_warns_when_nonoptimal_allowed(solver):
+    """allow_nonoptimal=True must issue a UserWarning for any solver."""
+    m = solph.Model(_make_infeasible_es())
     with pytest.warns(
         UserWarning, match="The solver did not return an optimal solution"
     ):
+        m.solve(solver=solver, allow_nonoptimal=True)
+
+
+def test_infeasible_cbc_returns_solver_results():
+    """CBC specifically returns a SolverResults object when non-optimal."""
+    m = solph.Model(_make_infeasible_es())
+    with pytest.warns(UserWarning):
         result = m.solve(solver="cbc", allow_nonoptimal=True)
-        assert isinstance(result, SolverResults)
+    assert isinstance(result, SolverResults)
 
+
+@pytest.mark.parametrize("solver", ["cbc", "highs"])
+def test_infeasible_raises_by_default(solver):
+    """allow_nonoptimal=False (default) must raise RuntimeError for any solver."""
+    m = solph.Model(_make_infeasible_es())
     with pytest.raises(
         RuntimeError, match="The solver did not return an optimal solution"
     ):
-        m.solve(solver="cbc", allow_nonoptimal=False)
+        m.solve(solver=solver, allow_nonoptimal=False)
 
 
-def test_unbounded_model():
-    es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
-    bel = solph.buses.Bus(label="bus")
-    es.add(bel)
-    # unbound Sink
-    es.add(solph.components.Sink(inputs={bel: solph.flows.Flow()}))
+@pytest.mark.parametrize("solver", ["cbc", "highs"])
+def test_unbounded_raises(solver):
+    """An unbounded model must raise RuntimeError for any solver."""
+    m = solph.Model(_make_unbounded_es())
+    with pytest.raises(
+        RuntimeError, match="The solver did not return an optimal solution"
+    ):
+        m.solve(solver=solver)
 
-    # unbound Source with a revenue
-    es.add(
-        solph.components.Source(
-            outputs={bel: solph.flows.Flow(variable_costs=-5)}
-        )
+
+# ---------------------------------------------------------------------------
+# Cross-validation: HiGHS and CBC must agree on numerics
+# ---------------------------------------------------------------------------
+
+
+def test_highs_objective_matches_cbc():
+    es = _make_feasible_es()
+    r_highs = solph.Model(es).solve(solver="highs")
+    r_cbc = solph.Model(es).solve(solver="cbc")
+    assert r_highs["objective"] == pytest.approx(r_cbc["objective"])
+
+
+def test_highs_flow_values_match_cbc():
+    es = _make_feasible_es()
+    r_highs = solph.Model(es).solve(solver="highs")
+    r_cbc = solph.Model(es).solve(solver="cbc")
+    pd.testing.assert_frame_equal(
+        r_highs.get("flow").sort_index(axis=1),
+        r_cbc.get("flow").sort_index(axis=1),
     )
-    m = solph.Model(es)
-
-    with pytest.raises(
-        RuntimeError, match="The solver did not return an optimal solution"
-    ):
-        m.solve(solver="cbc", allow_nonoptimal=False)
 
 
-def test_cmdline_options(capsys):
+def test_highs_duals_match_cbc():
+    es = _make_feasible_es()
+
+    m_highs = solph.Model(es)
+    m_highs.receive_duals()
+    m_highs.solve(solver="highs")
+
+    m_cbc = solph.Model(es)
+    m_cbc.receive_duals()
+    m_cbc.solve(solver="cbc")
+
+    highs_duals = {str(c): v for c, v in m_highs.dual.items()}
+    cbc_duals = {str(c): v for c, v in m_cbc.dual.items()}
+
+    assert highs_duals.keys() == cbc_duals.keys()
+    for key in highs_duals:
+        assert highs_duals[key] == pytest.approx(cbc_duals[key], abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Solver-specific: command-line options are forwarded correctly
+# ---------------------------------------------------------------------------
+
+
+def test_cbc_cmdline_options(capsys):
+    """CBC echoes command-line options in its solver output."""
     es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
     bel = solph.buses.Bus(label="bus")
     es.add(bel)
@@ -90,12 +199,30 @@ def test_cmdline_options(capsys):
     m.solve(
         solver="cbc",
         cmdline_options={"ratio": 0.01},
-        solve_kwargs={"tee": True},  # need to set to see command line
+        solve_kwargs={"tee": True},
     )
 
     captured = capsys.readouterr()
-
     assert "-ratio 0.01" in captured.out
+
+
+def test_highs_cmdline_options(capsys):
+    """HiGHS options passed via cmdline_options are applied to the solver."""
+    m = solph.Model(_make_feasible_es())
+
+    m.solve(
+        solver="highs",
+        cmdline_options={"presolve": "off"},
+        solve_kwargs={"tee": True},
+    )
+
+    captured = capsys.readouterr()
+    assert "without presolve" in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Multi-period
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.filterwarnings(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,7 +16,6 @@ import pytest
 from pyomo.opt.results import SolverResults
 
 from oemof import solph
-from oemof.solph._results import Results
 
 
 # ---------------------------------------------------------------------------
@@ -117,7 +116,7 @@ def _make_mip_es():
 def test_feasible_returns_results(solver):
     """A feasible model must return a solph.Results object for any solver."""
     result = solph.Model(_make_feasible_es()).solve(solver=solver)
-    assert isinstance(result, Results)
+    assert isinstance(result, solph.Results)
 
 
 @pytest.mark.parametrize("solver", ["cbc", "highs"])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ from oemof.solph._results import Results
 
 
 def _make_infeasible_es():
-    """Source capacity (4) < sink demand (5) → infeasible."""
+    """Source capacity (4) < sink demand (5) -> infeasible."""
     es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
     bus = solph.buses.Bus(label="bus")
     es.add(bus)
@@ -43,7 +43,7 @@ def _make_infeasible_es():
 
 
 def _make_unbounded_es():
-    """Negative variable cost with no upper bound → unbounded."""
+    """Negative variable cost with no upper bound -> unbounded."""
     es = solph.EnergySystem(timeindex=[0, 1], infer_last_interval=False)
     bus = solph.buses.Bus(label="bus")
     es.add(bus)
@@ -81,7 +81,7 @@ def _make_feasible_es():
 
 
 def _make_mip_es():
-    """Same as feasible LP but with a NonConvex flow → MIP."""
+    """Same as feasible LP but with a NonConvex flow -> MIP."""
     es = solph.EnergySystem(timeindex=[0, 1, 2], infer_last_interval=False)
     bus = solph.buses.Bus(label="bus")
     es.add(bus)


### PR DESCRIPTION
I want to use the HiGHS solver with oemof-solph (see #855 for earlier discussions)

## Installation

`pip install highspy` found here: https://pyomo.readthedocs.io/en/6.9.5/getting_started/solvers.html

## Example

I started with a simple example from the oemof-solph example directory and changed the solver name to `appsi_highs`, accoding to https://or.stackexchange.com/a/12688

```
solver = SolverFactory("appsi_highs")
```

In oemof-solph solph it looks like this
```
model.solve(solver="appsi_highs")
```

## Adapting the `Model` class

This collides with the `solver_io` parameter, so I removed it for "appsi"-solver.

## Stucked

I got stuck with the following error. **Can anybody help?**

```python
  File "...oemof-solph\src\oemof\solph\_models.py", line 485, in solve
    solver_results = opt.solve(self, **solve_kwargs)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "...my_env\Lib\site-packages\pyomo\contrib\appsi\base.py", line 1607, in solve
    if hasattr(model, 'dual') and model.dual.import_enabled():
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'import_enabled'
```


