### PR TITLE
Make Link parent Node of Converters

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -37,6 +37,8 @@ Other changes
   by convention. Thus, it can now be reliably cast; not to an array but to
   a scalar float. We expect no effect for end users.
 * Updated respective examples and tutorials to use current TSAM API (v3).
+* The component ``Link`` now uses the nested Node capability and is internally
+  represented by two ``Converter`` s.
 
 Contributors
 ############

--- a/examples/electrical/transshipment.py
+++ b/examples/electrical/transshipment.py
@@ -3,7 +3,7 @@
 """
 General description:
 ---------------------
-This script shows how use the custom component `solph.custom.Link` to build
+This script shows how use the component `solph.components.Link` to build
 a simple transshipment model.
 
 Code
@@ -204,9 +204,6 @@ def main(optimize=True):
     print(results["flow"][("gen_1", "b_1")])
 
     results["flow"].plot(kind="bar")
-
-    # look at constraints of Links in the pyomo model LinkBlock
-    m.LinkBlock.pprint()
 
     plt.show()
 

--- a/examples/electrical/transshipment.py
+++ b/examples/electrical/transshipment.py
@@ -14,7 +14,7 @@ Download source code: :download:`transshipment.py </../examples/electrical/trans
 
     .. literalinclude:: /../examples/electrical/transshipment.py
         :language: python
-        :lines: 39-211
+        :lines: 39-
 
 Installation requirements
 -------------------------

--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -30,6 +30,7 @@ from oemof.solph._helpers import warn_if_missing_attribute
 from oemof.solph._plumbing import Apply
 from oemof.solph._plumbing import SequenceDict
 
+from ._converter import Converter
 
 class Link(Node):
     """A Link object with 2 inputs and 2 outputs.
@@ -67,20 +68,7 @@ class Link(Node):
     ...    outputs={bel0: solph.flows.Flow(),
     ...             bel1: solph.flows.Flow()},
     ...    conversion_factors={(bel0, bel1): 0.8, (bel1, bel0): 0.9})
-    >>> print(sorted([x[1][5] for x in link.conversion_factors.items()]))
-    [0.8, 0.9]
-
-    >>> type(link)
-    <class 'oemof.solph.components._link.Link'>
-
-    >>> sorted([str(i) for i in link.inputs])
-    ['el0', 'el1']
-
-    >>> link.conversion_factors[(bel0, bel1)][3]
-    0.8
     """
-
-    conversion_factors = Apply(SequenceDict)
 
     def __init__(
         self,
@@ -100,22 +88,12 @@ class Link(Node):
             custom_properties = {}
         super().__init__(
             label,
-            inputs=inputs,
-            outputs=outputs,
             parent_node=parent_node,
             custom_properties=custom_properties,
         )
-        if not inputs:
-            warn_if_missing_attribute(self, "inputs")
-        if not outputs:
-            warn_if_missing_attribute(self, "outputs")
-        if conversion_factors is None:
-            warn_if_missing_attribute(self, "conversion_factors")
-            conversion_factors = {}
 
-        self.conversion_factors = {k: v for k, v in conversion_factors.items()}
         msg = (
-            "Component `Link` should have exactly "
+            "Component `Link` must have exactly "
             + "2 inputs, 2 outputs, and 2 "
             + "conversion factors connecting these. You are initializing "
             + "a `Link`without obeying this specification. "
@@ -124,88 +102,19 @@ class Link(Node):
         )
 
         if (
-            len(self.inputs) != 2
-            or len(self.outputs) != 2
-            or len(self.conversion_factors) != 2
+            len(inputs) != 2
+            or len(outputs) != 2
+            or len(conversion_factors) != 2
         ):
-            warn(msg, debugging.SuspiciousUsageWarning)
+            raise ValueError(msg)
 
-    def constraint_group(self):
-        return LinkBlock
-
-
-class LinkBlock(ScalarBlock):
-    r"""Block for the relation of nodes with type
-    :class:`~oemof.solph.components.Link`
-
-    **The following constraints are created:**
-
-    .. _Link-equations:
-
-    .. math::
-        &
-        (1) \qquad P_{\mathrm{in},n}(p, t) = c_n(t)
-        \times P_{\mathrm{out},n}(p, t)
-            \quad \forall t \in T, \forall n in {1,2} \\
-        &
-
-    """
-
-    CONSTRAINT_GROUP = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _create(self, group=None):
-        """Creates the relation for the class:`Link`.
-
-        Parameters
-        ----------
-        group : list
-            List of oemof.solph.components.Link objects for which
-            the relation of inputs and outputs is createdBuildAction
-            e.g. group = [link1, link2, link3, ...]. The components inside
-            the list need to hold an attribute `conversion_factors` of type
-            dict containing the conversion factors for all inputs to outputs.
-        """
-        if group is None:
-            return None
-
-        m = self.parent_block()
-
-        all_conversions = {}
-        for n in group:
-            all_conversions[n] = {
-                k: v for k, v in n.conversion_factors.items()
-            }
-
-        self.LINKS = Set(initialize=[g for g in group])
-
-        def _input_output_relation(block):
-            for t in m.TIMESTEPS:
-                for n, conversion in all_conversions.items():
-                    for cidx, c in conversion.items():
-                        try:
-                            expr = (
-                                m.flow[n, cidx[1], t]
-                                == c[t] * m.flow[cidx[0], n, t]
-                            )
-                        except KeyError:
-                            raise KeyError(
-                                "Error in constraint creation "
-                                f"from: {cidx[0]}, to: {cidx[1]}, via: {n}. "
-                                "Check if all connected buses match "
-                                "the conversion factors.",
-                            )
-                        block.relation.add((n, cidx[0], cidx[1], t), expr)
-
-        self.relation = Constraint(
-            [
-                (n, cidx[0], cidx[1], t)
-                for t in m.TIMESTEPS
-                for n, conversion in all_conversions.items()
-                for cidx, c in conversion.items()
-            ],
-            noruleinit=True,
-        )
-        self.relation_build = BuildAction(rule=_input_output_relation)
+        for k, v in conversion_factors.items():
+            from_node = k[0]
+            to_node = k[1]
+            self.subnode(
+                Converter,
+                f"({k[0].label}) -> {k[1].label})",
+                inputs={from_node: inputs[from_node]},
+                outputs={to_node: outputs[to_node]},
+                conversion_factors={to_node: v},
+            )

--- a/src/oemof/solph/components/_link.py
+++ b/src/oemof/solph/components/_link.py
@@ -17,20 +17,10 @@ SPDX-License-Identifier: MIT
 
 """
 
-from warnings import warn
-
 from oemof.network import Node
-from oemof.tools import debugging
-from pyomo.core import Set
-from pyomo.core.base.block import ScalarBlock
-from pyomo.environ import BuildAction
-from pyomo.environ import Constraint
-
-from oemof.solph._helpers import warn_if_missing_attribute
-from oemof.solph._plumbing import Apply
-from oemof.solph._plumbing import SequenceDict
 
 from ._converter import Converter
+
 
 class Link(Node):
     """A Link object with 2 inputs and 2 outputs.

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -101,11 +101,11 @@ def test_nonconvex_investment_without_maximum_raises_warning(warning_fixture):
         )
 
 
-def test_link_to_warn_about_not_matching_number_of_flows(warning_fixture):
+def test_link_to_fails_about_not_matching_number_of_flows(warning_fixture):
     """Link warns about missing parameters and not matching number of flows."""
 
     msg = (
-        "Component `Link` should have exactly "
+        "Component `Link` must have exactly "
         + "2 inputs, 2 outputs, and 2 "
         + "conversion factors connecting these. You are initializing "
         + "a `Link`without obeying this specification. "
@@ -113,16 +113,10 @@ def test_link_to_warn_about_not_matching_number_of_flows(warning_fixture):
         + "disable the SuspiciousUsageWarning globally."
     )
 
-    with warnings.catch_warnings(record=True) as w:
+    with pytest.raises(ValueError, match=msg):
         solph.components.Link(
             label="empty_link",
         )
-        assert len(w) == 4
-        # Check  number of raised warnings:
-        # 1. empty inputs, 2. empty outputs 3. empty conversion_factors
-        # 4. unmatched number of flows
-        # Check warning for unmatched number of flows
-        assert msg in str(w[-1].message)
 
 
 def test_link_raise_key_error_in_Linkblock(warning_fixture):
@@ -137,22 +131,16 @@ def test_link_raise_key_error_in_Linkblock(warning_fixture):
     bel0 = solph.buses.Bus(label="el0")
     bel1 = solph.buses.Bus(label="el1")
     look_out = solph.buses.Bus(label="look_out")
-    link = solph.components.Link(
-        label="transshipment_link",
-        inputs={
-            bel0: solph.flows.Flow(nominal_capacity=4),
-            bel1: solph.flows.Flow(nominal_capacity=2),
-        },
-        outputs={bel0: solph.flows.Flow(), look_out: solph.flows.Flow()},
-        conversion_factors={(bel0, bel1): 0.8, (bel1, bel0): 0.7},
-    )
 
-    energysystem.add(bel0, bel1, link)
+    msg = "el1"
 
-    msg = (
-        "Error in constraint creation from: el0, to: el1, via: "
-        "transshipment_link. Check if all connected buses match the "
-        "conversion factors."
-    )
     with pytest.raises(KeyError, match=msg):
-        solph.Model(energysystem)
+        _ = solph.components.Link(
+            label="transshipment_link",
+            inputs={
+                bel0: solph.flows.Flow(nominal_capacity=4),
+                bel1: solph.flows.Flow(nominal_capacity=2),
+            },
+            outputs={bel0: solph.flows.Flow(), look_out: solph.flows.Flow()},
+            conversion_factors={(bel0, bel1): 0.8, (bel1, bel0): 0.7},
+        )

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -11,7 +11,6 @@ SPDX-License-Identifier: MIT
 
 import warnings
 
-import pandas as pd
 import pytest
 from oemof.tools.debugging import SuspiciousUsageWarning
 
@@ -123,18 +122,11 @@ def test_link_raise_key_error_in_Linkblock(warning_fixture):
     """Link raises KeyError if conversion factors don't match the connected
     busses."""
 
-    date_time_index = pd.date_range("1/1/2012", periods=3, freq="h")
-    energysystem = solph.EnergySystem(
-        timeindex=date_time_index,
-        infer_last_interval=True,
-    )
     bel0 = solph.buses.Bus(label="el0")
     bel1 = solph.buses.Bus(label="el1")
     look_out = solph.buses.Bus(label="look_out")
 
-    msg = "el1"
-
-    with pytest.raises(KeyError, match=msg):
+    with pytest.raises(KeyError, match="el1"):
         _ = solph.components.Link(
             label="transshipment_link",
             inputs={


### PR DESCRIPTION
The `Link` is actually equivalent to two `Converter`s. Having subnodes, we can now implement it this way without loosing any functionality. For those, who want it more visually, here is the result plot of the transshipment example:

<img width="320" height="240" alt="old_link" src="https://github.com/user-attachments/assets/5bba15c1-835d-4eb7-a188-3293ed29087c" />

<img width="340" height="240" alt="bundled_converters" src="https://github.com/user-attachments/assets/59d0e096-3f79-4140-b2a3-238a8ecea9cf" />


PS: I came up with this idea while answering the [question at openmod, when Bus or Converter should be used](https://forum.openmod.org/t/bus-connection-patterns-in-oemof-solph-bus-link-and-converter/5831).