### PR TITLE
Add logical operators for _FakeSequence

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -31,12 +31,13 @@ Bug fixes
 Other changes
 #############
 
+* Updated respective examples and tutorials to use current TSAM API (v3).
 * Internally, sequences of 'None' are now avoided and a simple 'None'
   is used instead. We expect no effect for end users.
 * _FakeSequences can no longer have a defined length. It has "every length"
   by convention. Thus, it can now be reliably cast; not to an array but to
   a scalar float. We expect no effect for end users.
-* Updated respective examples and tutorials to use current TSAM API (v3).
+* _FakeSequences have operators defined. We expect no effect for end users.
 
 Contributors
 ############

--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -223,6 +223,16 @@ class _FakeSequence:
     def __abs__(self):
         return _FakeSequence(abs(self.value))
 
+    def __and__(self, other):
+        return sequence(self.value & other)
+
+    __rand__ = __and__
+
+    def __or__(self, other):
+        return sequence(self.value | other)
+
+    __ror__ = __or__
+
     def __eq__(self, other):
         return sequence(self.value == other)
 

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -181,29 +181,41 @@ def test_fake_sequence_logic_operators():
     assert _FakeSequence(True)
     assert not _FakeSequence(False)
 
-    # _FakeSequence and bool
-    assert _FakeSequence(True) and True
-    assert not (_FakeSequence(True) and False)
-    assert not (_FakeSequence(False) and True)
-    assert not (_FakeSequence(False) and False)
+    # _FakeSequence & bool
+    assert _FakeSequence(True) & True
+    assert not (_FakeSequence(True) & False)
+    assert not (_FakeSequence(False) & True)
+    assert not (_FakeSequence(False) & False)
 
-    # bool and _FakeSequence
-    assert True and _FakeSequence(True)
-    assert not (True and _FakeSequence(False))
-    assert not (False and _FakeSequence(True))
-    assert not (False and _FakeSequence(False))
+    # bool & _FakeSequence
+    assert True & _FakeSequence(True)
+    assert not (True & _FakeSequence(False))
+    assert not (False & _FakeSequence(True))
+    assert not (False & _FakeSequence(False))
 
-    # _FakeSequence or bool
-    assert _FakeSequence(True) or True
-    assert (_FakeSequence(True) or False)
-    assert (_FakeSequence(False) or True)
-    assert not (_FakeSequence(False) or False)
+    # _FakeSequence and _FakeSequence
+    assert _FakeSequence(True) & _FakeSequence(True)
+    assert not (_FakeSequence(True) & _FakeSequence(False))
+    assert not (_FakeSequence(False) & _FakeSequence(True))
+    assert not (_FakeSequence(False) & _FakeSequence(False))
 
-    # bool or _FakeSequence
-    assert True or _FakeSequence(True)
-    assert (True or _FakeSequence(False))
-    assert (False or _FakeSequence(True))
-    assert not (False or _FakeSequence(False))
+    # _FakeSequence | bool
+    assert _FakeSequence(True) | True
+    assert _FakeSequence(True) | False
+    assert _FakeSequence(False) | True
+    assert not (_FakeSequence(False) | False)
+
+    # bool | _FakeSequence
+    assert True | _FakeSequence(True)
+    assert True | _FakeSequence(False)
+    assert False | _FakeSequence(True)
+    assert not (False | _FakeSequence(False))
+
+    # _FakeSequence | _FakeSequence
+    assert _FakeSequence(True) | _FakeSequence(True)
+    assert _FakeSequence(True) | _FakeSequence(False)
+    assert _FakeSequence(False) or _FakeSequence(True)
+    assert not (_FakeSequence(False) | _FakeSequence(False))
 
 
 def test_fake_sequence_addition():

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -193,7 +193,7 @@ def test_fake_sequence_logic_operators():
     assert not (False & _FakeSequence(True))
     assert not (False & _FakeSequence(False))
 
-    # _FakeSequence and _FakeSequence
+    # _FakeSequence & _FakeSequence
     assert _FakeSequence(True) & _FakeSequence(True)
     assert not (_FakeSequence(True) & _FakeSequence(False))
     assert not (_FakeSequence(False) & _FakeSequence(True))

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -176,6 +176,36 @@ def test_fake_sequence_compare():
     assert other < seq_gt
 
 
+def test_fake_sequence_logic_operators():
+    # only _FakeSequence
+    assert _FakeSequence(True)
+    assert not _FakeSequence(False)
+
+    # _FakeSequence and bool
+    assert _FakeSequence(True) and True
+    assert not (_FakeSequence(True) and False)
+    assert not (_FakeSequence(False) and True)
+    assert not (_FakeSequence(False) and False)
+
+    # bool and _FakeSequence
+    assert True and _FakeSequence(True)
+    assert not (True and _FakeSequence(False))
+    assert not (False and _FakeSequence(True))
+    assert not (False and _FakeSequence(False))
+
+    # _FakeSequence or bool
+    assert _FakeSequence(True) or True
+    assert (_FakeSequence(True) or False)
+    assert (_FakeSequence(False) or True)
+    assert not (_FakeSequence(False) or False)
+
+    # bool or _FakeSequence
+    assert True or _FakeSequence(True)
+    assert (True or _FakeSequence(False))
+    assert (False or _FakeSequence(True))
+    assert not (False or _FakeSequence(False))
+
+
 def test_fake_sequence_addition():
     n1 = 12
     seq1_var = _FakeSequence(12)


### PR DESCRIPTION
We somehow forgot these but should have them for consistency. (Also: I want them for MTRESS.)
