### PR TITLE
Fix district heating converter efficiency

### DIFF
--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -99,7 +99,7 @@ def valid_sequence(sequence, length: int) -> bool:
             warnings.warn(
                 "Sequence longer than needed"
                 f" ({sequence.size} items instead of {length})."
-                " This will be trated as an error in the future.",
+                " This will be treated as an error in the future.",
                 FutureWarning,
             )
             return True

--- a/tutorials/introductory/district_heating_supply/district_heating_supply_1.py
+++ b/tutorials/introductory/district_heating_supply/district_heating_supply_1.py
@@ -53,7 +53,7 @@ gas_boiler = solph.components.Converter(
             nominal_capacity=data["heat demand"].max(), variable_costs=1.10
         )
     },
-    conversion_factors={gas_bus: 0.95},
+    conversion_factors={heat_bus: 0.95},
 )
 
 district_heating_system.add(gas_boiler)

--- a/tutorials/introductory/district_heating_supply/district_heating_supply_2.py
+++ b/tutorials/introductory/district_heating_supply/district_heating_supply_2.py
@@ -75,7 +75,7 @@ gas_boiler = solph.components.Converter(
             variable_costs=var_cost_gas_boiler,
         )
     },
-    conversion_factors={gas_bus: 0.95},
+    conversion_factors={heat_bus: 0.95},
 )
 
 district_heating_system.add(gas_boiler)

--- a/tutorials/introductory/district_heating_supply/district_heating_supply_3.py
+++ b/tutorials/introductory/district_heating_supply/district_heating_supply_3.py
@@ -68,7 +68,7 @@ gas_boiler = solph.components.Converter(
             variable_costs=var_cost_gas_boiler,
         )
     },
-    conversion_factors={gas_bus: 0.95},
+    conversion_factors={heat_bus: 0.95},
 )
 
 district_heating_system.add(gas_boiler)

--- a/tutorials/introductory/district_heating_supply/district_heating_supply_4.py
+++ b/tutorials/introductory/district_heating_supply/district_heating_supply_4.py
@@ -70,7 +70,7 @@ gas_boiler = solph.components.Converter(
             variable_costs=var_cost_gas_boiler,
         )
     },
-    conversion_factors={gas_bus: 0.95},
+    conversion_factors={heat_bus: 0.95},
 )
 
 district_heating_system.add(gas_boiler)


### PR DESCRIPTION
 ## Description

This PR fixes the district heating introductory tutorial gas boiler efficiency setup.

The tutorial used:

```python
conversion_factors={gas_bus: 0.95}
```

tutorials/introductory/district_heating_supply/district_heating_supply_1.py
tutorials/introductory/district_heating_supply/district_heating_supply_2.py
tutorials/introductory/district_heating_supply/district_heating_supply_3.py
tutorials/introductory/district_heating_supply/district_heating_supply_4.py
 fixed a small typo in:
src/oemof/solph/_plumbing.py

No API changes.

Addresses #1269.

The district heating docs use these tutorial scripts via literalinclude, so updating the Python tutorial files should also correct the rendered documentation examples.

Validation
python3 -m pytest tests/test_plumbing.py -q
python3 -m py_compile tutorials/introductory/district_heating_supply/district_heating_supply_1.py tutorials/introductory/district_heating_supply/district_heating_supply_2.py tutorials/introductory/district_heating_supply/district_heating_supply_3.py tutorials/introductory/district_heating_supply/district_heating_supply_4.py