### PR TITLE
Fix casting _FakeSequence to number

### DIFF
--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -14,6 +14,7 @@ SPDX-License-Identifier: MIT
 import warnings
 from collections import UserDict
 from collections import abc
+from numbers import Number
 
 import numpy as np
 
@@ -180,7 +181,7 @@ class _FakeSequence:
     42
     """
 
-    def __init__(self, value):
+    def __init__(self, value: Number):
         self._value = value
 
     def __getitem__(self, i):

--- a/src/oemof/solph/_plumbing.py
+++ b/src/oemof/solph/_plumbing.py
@@ -203,7 +203,10 @@ class _FakeSequence:
         return f"[{self._value}, {self._value}, ..., {self._value}]"
 
     def __float__(self):
-        return self._value
+        return float(self._value)
+
+    def __int__(self):
+        return int(self._value)
 
     def max(self):
         return self._value

--- a/tests/test_plumbing.py
+++ b/tests/test_plumbing.py
@@ -89,13 +89,26 @@ def test_fake_sequence_slice():
         _ = seq[1:-5]
 
 
-def test_fake_sequence_float():
+def test_fake_sequence_numeric_cast():
     seq = _FakeSequence(3.14)
-    assert float(seq) == 3.14
-    assert isinstance(float(seq), float)
 
-    seq_int = _FakeSequence(42.0)
-    assert float(seq_int) == 42.0
+    value_f = float(seq)
+    assert value_f == 3.14
+    assert isinstance(value_f, float)
+
+    value_i = int(seq)
+    assert value_i == 3
+    assert isinstance(value_i, int)
+
+    seq_int = _FakeSequence(42)
+
+    value_f = float(seq_int)
+    assert value_f == 42.0
+    assert isinstance(value_f, float)
+
+    value_i = int(seq_int)
+    assert value_i == 42
+    assert isinstance(value_i, int)
 
 
 def test_sequence_from_fake_sequence_with_length():


### PR DESCRIPTION
We just assumed that values stored in a `_FakeSequence` are floats, but this is not always the case. Fortunately, this was easy to fix.