### PR TITLE
Fix flow count limit for invest and nonconvex flows

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -27,6 +27,8 @@ Bug fixes
 * Name the TSA-disaggregated storage SOC result ``storage_content`` to match
   non-clustered ``GenericStorage`` results, so result readers (e.g. ``views``)
   find it by the same key regardless of clustering.
+* Fix ``limit_active_flow_count`` and ``limit_active_flow_count_by_keyword ``
+  constraints for flows of type ``INVEST_NON_CONVEX_FLOWS``
 
 Other changes
 #############
@@ -47,6 +49,7 @@ Contributors
 * Pierre Francois Bachibouzouk
 * Stephan Günther
 * Diana Maldonado Castro
+* Jonas Freißmann
 
 Acknowledgements
 ################

--- a/src/oemof/solph/constraints/flow_count_limit.py
+++ b/src/oemof/solph/constraints/flow_count_limit.py
@@ -136,8 +136,20 @@ def limit_active_flow_count_by_keyword(
     --------
     limit_active_flow_count
     """
+    nonconvex_flows = []
+    if hasattr(
+        model.NonConvexFlowBlock, "FIXED_CAPACITY_NONCONVEX_FLOWS"
+    ):
+        nonconvex_flows += list(
+            model.NonConvexFlowBlock.FIXED_CAPACITY_NONCONVEX_FLOWS
+        )
+    if hasattr(model.InvestNonConvexFlowBlock, "INVEST_NON_CONVEX_FLOWS"):
+        nonconvex_flows += list(
+            model.InvestNonConvexFlowBlock.INVEST_NON_CONVEX_FLOWS
+        )
+
     flows = []
-    for i, o in model.NonConvexFlowBlock.FIXED_CAPACITY_NONCONVEX_FLOWS:
+    for i, o in nonconvex_flows:
         if keyword in model.flows[i, o].custom_properties:
             flows.append((i, o))
 

--- a/src/oemof/solph/constraints/flow_count_limit.py
+++ b/src/oemof/solph/constraints/flow_count_limit.py
@@ -88,10 +88,10 @@ def limit_active_flow_count(
         for ts in m.TIMESTEPS:
             lhs = 0
             for fi, fo in flows:
-                if (fi, fo) in invest_flows:
-                    lhs += m.InvestNonConvexFlowBlock.status[fi, fo, ts]
-                else:
+                if (fi, fo) not in invest_flows:
                     lhs += m.NonConvexFlowBlock.status[fi, fo, ts]
+                else:
+                    lhs += m.InvestNonConvexFlowBlock.status[fi, fo, ts]
             rhs = getattr(model, constraint_name)[ts]
             expr = lhs == rhs
             if expr is not True:

--- a/src/oemof/solph/constraints/flow_count_limit.py
+++ b/src/oemof/solph/constraints/flow_count_limit.py
@@ -79,10 +79,17 @@ def limit_active_flow_count(
     attrname_constraint = constraint_name + "_constraint"
 
     def _flow_count_rule(m):
+        if hasattr(m.InvestNonConvexFlowBlock, "INVEST_NON_CONVEX_FLOWS"):
+            invest_flows = m.InvestNonConvexFlowBlock.INVEST_NON_CONVEX_FLOWS
+        else:
+            invest_flows = []
         for ts in m.TIMESTEPS:
-            lhs = sum(
-                m.NonConvexFlowBlock.status[fi, fo, ts] for fi, fo in flows
-            )
+            lhs = 0
+            for fi, fo in flows:
+                if (fi, fo) in invest_flows:
+                    lhs += m.InvestNonConvexFlowBlock.status[fi, fo, ts]
+                else:
+                    lhs += m.NonConvexFlowBlock.status[fi, fo, ts]
             rhs = getattr(model, constraint_name)[ts]
             expr = lhs == rhs
             if expr is not True:

--- a/src/oemof/solph/constraints/flow_count_limit.py
+++ b/src/oemof/solph/constraints/flow_count_limit.py
@@ -32,7 +32,8 @@ def limit_active_flow_count(
     constraint_name: string
         name for the constraint
     flows: list of flows
-        flows (have to be NonConvex) in the format [(in, out)]
+        flows (have to be NonConvex, with or without investment) in the
+        format [(in, out)]
     lower_limit: integer
         minimum number of active flows in the list
     upper_limit: integer
@@ -44,7 +45,8 @@ def limit_active_flow_count(
 
     Note
     ----
-    SimpleFlowBlock objects required to be NonConvex
+    Flow objects are required to be NonConvex. They may additionally be
+    investment optimized (InvestNonConvexFlow).
 
 
     **Constraint:**
@@ -122,7 +124,8 @@ def limit_active_flow_count_by_keyword(
     model: oemof.solph.Model
         Model to which constraints are added
     keyword: string
-        keyword to consider (searches all NonConvexFlows)
+        keyword to consider (searches all NonConvexFlows and
+        InvestNonConvexFlows)
     lower_limit: integer
         minimum number of active flows having the keyword
     upper_limit: integer

--- a/tests/test_constraints/test_flow_count_limit.py
+++ b/tests/test_constraints/test_flow_count_limit.py
@@ -94,3 +94,127 @@ def test_flow_count_limit():
     assert flow[1] == pytest.approx([2, 0])
     assert flow[2] == pytest.approx([0, 1.5])
     assert flow[3] == pytest.approx([3, 0])
+
+
+def test_flow_count_limit_investment():
+    """The count limit must also cover investment nonconvex flows."""
+    date_time_index = pd.date_range("1/1/2012", periods=3, freq="h")
+    energysystem = solph.EnergySystem(
+        timeindex=date_time_index,
+        infer_last_interval=False,
+    )
+
+    b1 = solph.buses.Bus(label="b1", balanced=False)
+    # Three investment + nonconvex sinks. Running is profitable, so each would
+    # be active without the limit; the distinct variable_costs make the two
+    # cheapest run at full capacity and the most expensive one stay off.
+    sinks = [
+        solph.components.Sink(
+            label=f"s{i}",
+            inputs={
+                b1: solph.Flow(
+                    variable_costs=vc,
+                    nominal_capacity=solph.Investment(
+                        maximum=4, ep_costs=0.01
+                    ),
+                    minimum=0.5,
+                    nonconvex=solph.NonConvex(),
+                    custom_properties={"keyword1": "group 1"},
+                )
+            },
+        )
+        for i, vc in enumerate([-3, -2, -1])
+    ]
+    energysystem.add(b1, *sinks)
+
+    model = solph.Model(energysystem)
+
+    solph.constraints.limit_active_flow_count_by_keyword(
+        model,
+        "keyword1",
+        lower_limit=0,
+        upper_limit=2,
+    )
+
+    model.solve()
+    results = solph.processing.results(model)
+
+    flow = [
+        list(results[(b1, s)]["sequences"]["flow"][:-1]) for s in sinks
+    ]
+
+    # Only two of the three investment nonconvex flows may be active at once.
+    assert flow[0] == pytest.approx([4, 4])
+    assert flow[1] == pytest.approx([4, 4])
+    assert flow[2] == pytest.approx([0, 0])
+
+
+def test_flow_count_limit_mixed():
+    """The count limit must count plain and investment nonconvex flows
+    together within a single constraint."""
+    date_time_index = pd.date_range("1/1/2012", periods=3, freq="h")
+    energysystem = solph.EnergySystem(
+        timeindex=date_time_index,
+        infer_last_interval=False,
+    )
+
+    b1 = solph.buses.Bus(label="b1", balanced=False)
+    # One plain and one investment nonconvex sink are cheapest and run; the
+    # other plain and investment sinks are blocked by the shared count limit.
+    plain_sinks = [
+        solph.components.Sink(
+            label=f"plain{i}",
+            inputs={
+                b1: solph.Flow(
+                    variable_costs=vc,
+                    nominal_capacity=4,
+                    minimum=0.5,
+                    nonconvex=solph.NonConvex(),
+                    custom_properties={"keyword1": "group 1"},
+                )
+            },
+        )
+        for i, vc in enumerate([-4, -2])
+    ]
+    invest_sinks = [
+        solph.components.Sink(
+            label=f"invest{i}",
+            inputs={
+                b1: solph.Flow(
+                    variable_costs=vc,
+                    nominal_capacity=solph.Investment(
+                        maximum=4, ep_costs=0.01
+                    ),
+                    minimum=0.5,
+                    nonconvex=solph.NonConvex(),
+                    custom_properties={"keyword1": "group 1"},
+                )
+            },
+        )
+        for i, vc in enumerate([-3, -1])
+    ]
+    sinks = plain_sinks + invest_sinks
+    energysystem.add(b1, *sinks)
+
+    model = solph.Model(energysystem)
+
+    solph.constraints.limit_active_flow_count_by_keyword(
+        model,
+        "keyword1",
+        lower_limit=0,
+        upper_limit=2,
+    )
+
+    model.solve()
+    results = solph.processing.results(model)
+
+    flow = [
+        list(results[(b1, s)]["sequences"]["flow"][:-1]) for s in sinks
+    ]
+
+    # The limit is shared across both blocks: the cheapest plain sink and the
+    # cheapest investment sink run, the two more expensive ones are blocked.
+    assert flow[0] == pytest.approx([4, 4])  # plain, vc=-4
+    assert flow[1] == pytest.approx([0, 0])  # plain, vc=-2
+    assert flow[2] == pytest.approx([4, 4])  # invest, vc=-3
+    assert flow[3] == pytest.approx([0, 0])  # invest, vc=-1


### PR DESCRIPTION
This PR aims at fixing issue #946 by also iterating through `model.InvestNonConvexFlowBlock.INVEST_NON_CONVEX_FLOWS` when building the `limit_active_flow_count` and `limit_active_flow_count_by_keyword` constraints. I also adjusted the respective doc strings and added tests for solely nonconvex flows with investment and a mixed case with both purely nonconvex flows and nonconvex flows with investment.

This PR can be deleted, if another approach is intended in order to fix the current issue with these constraints not working for nonconvex flows with investment, e.g., when the set definition of `NON_CONVEX_FLOWS` & `INVEST_NON_CONVEX_FLOWS` fundamently changes.