### PR TITLE
Add meta data to results object

### DIFF
--- a/examples/simple_dispatch/temporary_meta_example.py
+++ b/examples/simple_dispatch/temporary_meta_example.py
@@ -1,0 +1,163 @@
+import os
+import pprint
+
+import matplotlib.pyplot as plt
+import pandas as pd
+
+from oemof.solph import Bus
+from oemof.solph import EnergySystem
+from oemof.solph import Flow
+from oemof.solph import Model
+from oemof.solph import create_time_index
+from oemof.solph.components import Converter
+from oemof.solph.components import Sink
+from oemof.solph.components import Source
+
+
+def main(solver="cbc"):
+    # Read data file
+    filename = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "input_data.csv"
+    )
+    data = pd.read_csv(filename)
+    data = data.iloc[:24]
+
+    # Create an energy system and optimize the dispatch at least costs.
+    # ####################### initialize and provide data #####################
+    datetimeindex = create_time_index(2016, number=len(data))
+    energysystem = EnergySystem(
+        timeindex=datetimeindex, infer_last_interval=False
+    )
+
+    # ######################### create energysystem components ################
+
+    # resource buses
+    bcoal = Bus(label="coal", balanced=False)
+    bgas = Bus(label="gas", balanced=False)
+    boil = Bus(label="oil", balanced=False)
+    blig = Bus(label="lignite", balanced=False)
+
+    # electricity and heat
+    bel = Bus(label="bel")
+    bth = Bus(label="bth")
+
+    energysystem.add(bcoal, bgas, boil, blig, bel, bth)
+
+    # an excess and a shortage variable can help to avoid infeasible problems
+    energysystem.add(Sink(label="excess_el", inputs={bel: Flow()}))
+    # shortage_el = Source(label='shortage_el',
+    #                      outputs={bel: Flow(variable_costs=200)})
+
+    # sources
+    energysystem.add(
+        Source(
+            label="wind",
+            outputs={bel: Flow(fix=data["wind"], nominal_capacity=66.3)},
+        )
+    )
+
+    energysystem.add(
+        Source(
+            label="pv",
+            outputs={bel: Flow(fix=data["pv"], nominal_capacity=65.3)},
+        )
+    )
+
+    # demands (electricity/heat)
+    energysystem.add(
+        Sink(
+            label="demand_el",
+            inputs={bel: Flow(nominal_capacity=85, fix=data["demand_el"])},
+        )
+    )
+
+    energysystem.add(
+        Sink(
+            label="demand_th",
+            inputs={bth: Flow(nominal_capacity=40, fix=data["demand_th"])},
+        )
+    )
+
+    # power plants
+    energysystem.add(
+        Converter(
+            label="pp_coal",
+            inputs={bcoal: Flow()},
+            outputs={bel: Flow(nominal_capacity=20.2, variable_costs=25)},
+            conversion_factors={bel: 0.39},
+        )
+    )
+
+    energysystem.add(
+        Converter(
+            label="pp_lig",
+            inputs={blig: Flow()},
+            outputs={bel: Flow(nominal_capacity=11.8, variable_costs=19)},
+            conversion_factors={bel: 0.41},
+        )
+    )
+
+    energysystem.add(
+        Converter(
+            label="pp_gas",
+            inputs={bgas: Flow()},
+            outputs={bel: Flow(nominal_capacity=41, variable_costs=40)},
+            conversion_factors={bel: 0.50},
+        )
+    )
+
+    energysystem.add(
+        Converter(
+            label="pp_oil",
+            inputs={boil: Flow()},
+            outputs={bel: Flow(nominal_capacity=5, variable_costs=50)},
+            conversion_factors={bel: 0.28},
+        )
+    )
+
+    # combined heat and power plant (chp)
+    energysystem.add(
+        Converter(
+            label="pp_chp",
+            inputs={bgas: Flow()},
+            outputs={
+                bel: Flow(nominal_capacity=30, variable_costs=42),
+                bth: Flow(nominal_capacity=40),
+            },
+            conversion_factors={bel: 0.3, bth: 0.4},
+        )
+    )
+
+    # heat pump with a coefficient of performance (COP) of 3
+    b_heat_source = Bus(label="b_heat_source")
+    energysystem.add(b_heat_source)
+
+    energysystem.add(
+        Source(label="heat_source", outputs={b_heat_source: Flow()})
+    )
+
+    cop = 3
+    energysystem.add(
+        Converter(
+            label="heat_pump",
+            inputs={bel: Flow(), b_heat_source: Flow()},
+            outputs={bth: Flow(nominal_capacity=10)},
+            conversion_factors={bel: 1 / cop, b_heat_source: (cop - 1) / cop},
+        )
+    )
+
+    # create optimization model based on energy_system
+    optimization_model = Model(energysystem=energysystem)
+
+    # solve problem
+    results = optimization_model.solve(
+        solver=solver, solve_kwargs={"tee": False, "keepfiles": False}
+    )
+
+    pprint.pprint(results.keys())
+
+
+if __name__ == "__main__":
+    for solver_name in ["highs", "cbc", "scip"]:
+        print(solver_name)
+        main(solver=solver_name)

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -464,11 +464,23 @@ class Model(po.ConcreteModel):
         if optimal or appsi_results.best_feasible_objective is not None:
             appsi_results.solution_loader.load_vars()
 
+        ub = appsi_results.best_feasible_objective
+        lb = appsi_results.best_objective_bound
+        if ub not in (None, 0) and lb is not None:
+            gap = abs(ub - lb) / abs(ub)
+        else:
+            gap = None
+
         return solver_info(
             optimal=optimal,
             termination_condition=tc,
             status=tc.value,
             solver_results=solver_results,
+            wallclock_time=solver_results.get("wallclock_time"),
+            ub=ub,
+            lb=lb,
+            gap=gap,
+            message=None,
         )
 
     def solve_factory(
@@ -484,13 +496,30 @@ class Model(po.ConcreteModel):
         factory_results = opt.solve(self, **solve_kwargs)
 
         status = factory_results.Solver.Status
-        message = factory_results.Solver.Termination_condition
+        tc = factory_results.Solver.Termination_condition
+        msg = getattr(factory_results.Solver, "Message", None)
+        wt = getattr(factory_results.Solver, "Time", None)
+        ub = getattr(
+            factory_results.Problem[0], "Upper_bound", None
+        )
+        lb = getattr(
+            factory_results.Problem[0], "Lower_bound", None
+        )
+        if ub not in (None, 0) and lb is not None:
+            gap = abs(ub - lb) / abs(ub)
+        else:
+            gap = None
 
         return solver_info(
-            optimal=status == "ok" and message == "optimal",
-            termination_condition=message,
-            status=factory_results.Solver.Status,
+            optimal=status == "ok" and tc == "optimal",
+            termination_condition=tc,
+            status=status,
             solver_results=factory_results,
+            wallclock_time=wt,
+            ub=ub,
+            lb=lb,
+            gap=gap,
+            message=msg,
         )
 
     def solve(
@@ -528,9 +557,20 @@ class Model(po.ConcreteModel):
             solve_kwargs = {}
         if cmdline_options is None:
             cmdline_options = {}
+        solver_result_keys = [
+            "optimal",
+            "status",
+            "termination_condition",
+            "solver_results",
+            "message",
+            "wallclock_time",
+            "gap",
+            "ub",
+            "lb",
+        ]
+
         solver_info = namedtuple(
-            "SolverReturn",
-            ["optimal", "solver_results", "termination_condition", "status"],
+            "SolverReturn", [key for key in solver_result_keys]
         )
         if solver == "highs":
             solver_return = self.solve_highs(

--- a/src/oemof/solph/_models.py
+++ b/src/oemof/solph/_models.py
@@ -20,6 +20,7 @@ import warnings
 from collections import namedtuple
 from logging import getLogger
 
+import pandas as pd
 from oemof.tools import debugging
 from pyomo import environ as po
 from pyomo.contrib import appsi
@@ -178,6 +179,7 @@ class Model(po.ConcreteModel):
         self.flows = self.es.flows()
 
         self.solver_results = None
+        self.meta_results = None
         self.dual = None
         self.rc = None
 
@@ -439,7 +441,7 @@ class Model(po.ConcreteModel):
         return processing.results(self)
 
     def solve_highs(
-        self, solver_info, cmdline_options=None, solve_kwargs=None
+        self, solver_info, solver, cmdline_options=None, solve_kwargs=None
     ):
         opt = appsi.solvers.Highs()
         opt.config.load_solution = False
@@ -472,8 +474,10 @@ class Model(po.ConcreteModel):
             gap = None
 
         return solver_info(
+            objective=ub,
+            solver=solver,
             optimal=optimal,
-            termination_condition=tc,
+            termination_condition=tc.name,
             status=tc.value,
             solver_results=solver_results,
             wallclock_time=solver_results.get("wallclock_time"),
@@ -499,12 +503,8 @@ class Model(po.ConcreteModel):
         tc = factory_results.Solver.Termination_condition
         msg = getattr(factory_results.Solver, "Message", None)
         wt = getattr(factory_results.Solver, "Time", None)
-        ub = getattr(
-            factory_results.Problem[0], "Upper_bound", None
-        )
-        lb = getattr(
-            factory_results.Problem[0], "Lower_bound", None
-        )
+        ub = getattr(factory_results.Problem[0], "Upper_bound", None)
+        lb = getattr(factory_results.Problem[0], "Lower_bound", None)
         if ub not in (None, 0) and lb is not None:
             gap = abs(ub - lb) / abs(ub)
         else:
@@ -512,8 +512,10 @@ class Model(po.ConcreteModel):
 
         return solver_info(
             optimal=status == "ok" and tc == "optimal",
-            termination_condition=tc,
-            status=status,
+            solver=solver,
+            objective=po.value(self.objective),
+            termination_condition=tc.name,
+            status=status.name,
             solver_results=factory_results,
             wallclock_time=wt,
             ub=ub,
@@ -564,6 +566,8 @@ class Model(po.ConcreteModel):
             "solver_results",
             "message",
             "wallclock_time",
+            "objective",
+            "solver",
             "gap",
             "ub",
             "lb",
@@ -577,6 +581,7 @@ class Model(po.ConcreteModel):
                 solver_info=solver_info,
                 solve_kwargs=solve_kwargs,
                 cmdline_options=cmdline_options,
+                solver=solver,
             )
         else:
             solver_return = self.solve_factory(
@@ -589,17 +594,20 @@ class Model(po.ConcreteModel):
 
         self.es.results = solver_return.solver_results
         self.solver_results = solver_return.solver_results
+        self.meta_results = pd.Series(solver_return._asdict()).drop(
+            "solver_results"
+        )
 
         if solver_return.optimal:
-            msg = "Optimization successful."
+            msg = "Optimisation successful."
             logging.info(msg)
         else:
             msg = (
                 f"The solver did not return an optimal solution. "
-                f"Instead the optimization ended with\n"
+                f"Instead the optimisation ended with\n"
                 f"       - status: {solver_return.status}\n"
                 f"       - termination condition: "
-                f"{solver_return.termination_condition.name}"
+                f"{solver_return.termination_condition}"
             )
 
             if allow_nonoptimal:

--- a/src/oemof/solph/_results.py
+++ b/src/oemof/solph/_results.py
@@ -43,9 +43,7 @@ class Results:
 
     def __init__(self, model: ConcreteModel):
         self._solver_results = model.solver_results
-        self._meta_results = {
-            "objective": model.objective(),
-        }
+        self._meta_results = model.meta_results
         self._variables = {}
         self._model = model
 


### PR DESCRIPTION
Here’s a draft for sharing the meta results.

What I’d like to see is:

- A "meta" key for the meta results as a pandas series
- A "solver_results" key for the objects—for people who want to dig around in them—but I’d prefer to hide that one.

Right now, though, the keywords are being phased out as single keys. I don't like that.

In general, we can still discuss the keywords I chose for the meta results—I didn't spend much time on them, so there might still be some mapping errors. My first priority is the concept itself, and only then do I focus on the keywords within the meta results.

