### PR TITLE
Make ExtractionTurbineCHP a generic component

### DIFF
--- a/examples/variable_chp/variable_chp.py
+++ b/examples/variable_chp/variable_chp.py
@@ -110,7 +110,7 @@ def write_lp_file(model):
     model.write(lp_filename, io_options={"symbolic_solver_labels": True})
 
 
-def main(optimize=True, solver="cbc"):
+def main(optimize=True, solver="cbc", new=True):
     # Read data file
     filename = os.path.join(os.getcwd(), "variable_chp.csv")
     try:
@@ -223,32 +223,41 @@ def main(optimize=True, solver="cbc"):
         conversion_factors={noded["bel2"]: 0.3, noded["bth2"]: 0.5},
     )
 
-    # # create a fixed Converter to distribute to the heat and elec buses
-    # noded["variable_chp_gas"] = solph.components.ExtractionTurbineCHP(
-    #     label="variable_chp_gas",
-    #     inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
-    #     outputs={noded["bel"]: solph.Flow(), noded["bth"]: solph.Flow()},
-    #     conversion_factors={noded["bel"]: 0.3, noded["bth"]: 0.5},
-    #     conversion_factor_full_condensation={noded["bel"]: 0.5},
-    # )
-    # create a fixed Converter to distribute to the heat and elec buses
-    abel = [0.5] * 192
-    abth = [0.3] * 192
+    if not new:
+        # create a fixed Converter to distribute to the heat and elec buses
+        noded["variable_chp_gas"] = solph.components.ExtractionTurbineCHP(
+            label="variable_chp_gas",
+            inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
+            outputs={noded["bel"]: solph.Flow(), noded["bth"]: solph.Flow()},
+            conversion_factors={noded["bel"]: 0.3, noded["bth"]: 0.5},
+            conversion_factor_full_condensation={noded["bel"]: 0.5},
+        )
+    else:
+        # create a fixed Converter to distribute to the heat and elec buses
+        # Try with iterable or floats and try with equal points
+        # If allow_equal_states=False equal states are not allowed and will
+        # raise an error even if the equal state is just in one time step.
+        # Otherwise, only in this time step two more constraints will be
+        # written to the lp-file to avoid mismatches.
+        abel = [0.5] * 192
+        abth = [0.3] * 192
+        bbel = [0.3] * 192
+        bbth = [0.5] * 192
 
-    noded["variable_chp_gas"] = solph.components.VariableSplitConverter(
-        label="variable_chp_gas",
-        inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
-        outputs={noded["bth"]: solph.Flow(), noded["bel"]: solph.Flow()},
-        conversion_factors={
-            noded["bel"]: abel,
-            noded["bth"]: abth,
-        },
-        # allow_equal_states=True,
-        conversion_factors_secondary_state={
-            noded["bel"]: [0.3] * 192,
-            noded["bth"]: [0.5] * 192,
-        },
-    )
+        noded["variable_chp_gas"] = solph.components.VariableSplitConverter(
+            label="variable_chp_gas",
+            inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
+            outputs={noded["bth"]: solph.Flow(), noded["bel"]: solph.Flow()},
+            conversion_factors={
+                noded["bel"]: abel,
+                noded["bth"]: abth,
+            },
+            allow_equal_states=False,
+            conversion_factors_secondary_state={
+                noded["bel"]: bbel,
+                noded["bth"]: bbth,
+            },
+        )
 
     ##########################################################################
     # Optimise the energy system
@@ -498,4 +507,4 @@ def main(optimize=True, solver="cbc"):
 
 
 if __name__ == "__main__":
-    main()
+    main(new=True)

--- a/examples/variable_chp/variable_chp.py
+++ b/examples/variable_chp/variable_chp.py
@@ -110,22 +110,19 @@ def write_lp_file(model):
     model.write(lp_filename, io_options={"symbolic_solver_labels": True})
 
 
+def get_data_from_file_path(file_path: str) -> pd.DataFrame:
+    try:
+        data = pd.read_csv(file_path)
+    except FileNotFoundError:
+        dir = os.path.dirname(os.path.abspath(__file__))
+        data = pd.read_csv(dir + "/" + file_path)
+    return data
+
+
 def main(optimize=True, solver="cbc", new=True):
     # Read data file
-    filename = os.path.join(os.getcwd(), "variable_chp.csv")
-    try:
-        data = pd.read_csv(filename)
-    except FileNotFoundError:
-        msg = "Data file not found: {0}. Only one value used!"
-        warnings.warn(msg.format(filename), UserWarning)
-        data = pd.DataFrame(
-            {
-                "pv": [0.3],
-                "wind": [0.6],
-                "demand_el": [500],
-                "demand_th": [344],
-            }
-        )
+    data = get_data_from_file_path("variable_chp.csv")
+
     data.loc[180:, "demand_th"] = 0
     logger.define_logging()
     logging.info("Initialize the energy system")

--- a/examples/variable_chp/variable_chp.py
+++ b/examples/variable_chp/variable_chp.py
@@ -260,12 +260,13 @@ def main(optimize=True, solver="cbc", new=True):
     # Optimise the energy system
     ##########################################################################
 
+
+    energysystem.add(*noded.values())
+
     if optimize is False:
         return energysystem
 
     logging.info("Optimise the energy system")
-
-    energysystem.add(*noded.values())
 
     om = solph.Model(energysystem)
 

--- a/examples/variable_chp/variable_chp.py
+++ b/examples/variable_chp/variable_chp.py
@@ -59,7 +59,7 @@ import pandas as pd
 from oemof.tools import logger
 
 from oemof import solph
-
+from oemof.visio import plot as oeplot
 # import oemof plots
 try:
     from oemof.visio import plot as oeplot
@@ -125,7 +125,7 @@ def main(optimize=True, solver="cbc"):
                 "demand_th": [344],
             }
         )
-
+    data.loc[180:, "demand_th"] = 0
     logger.define_logging()
     logging.info("Initialize the energy system")
 

--- a/examples/variable_chp/variable_chp.py
+++ b/examples/variable_chp/variable_chp.py
@@ -60,6 +60,7 @@ from oemof.tools import logger
 
 from oemof import solph
 from oemof.visio import plot as oeplot
+
 # import oemof plots
 try:
     from oemof.visio import plot as oeplot
@@ -222,13 +223,31 @@ def main(optimize=True, solver="cbc"):
         conversion_factors={noded["bel2"]: 0.3, noded["bth2"]: 0.5},
     )
 
+    # # create a fixed Converter to distribute to the heat and elec buses
+    # noded["variable_chp_gas"] = solph.components.ExtractionTurbineCHP(
+    #     label="variable_chp_gas",
+    #     inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
+    #     outputs={noded["bel"]: solph.Flow(), noded["bth"]: solph.Flow()},
+    #     conversion_factors={noded["bel"]: 0.3, noded["bth"]: 0.5},
+    #     conversion_factor_full_condensation={noded["bel"]: 0.5},
+    # )
     # create a fixed Converter to distribute to the heat and elec buses
-    noded["variable_chp_gas"] = solph.components.ExtractionTurbineCHP(
+    abel = [0.5] * 192
+    abth = [0.3] * 192
+
+    noded["variable_chp_gas"] = solph.components.VariableSplitConverter(
         label="variable_chp_gas",
         inputs={noded["bgas"]: solph.Flow(nominal_capacity=10e10)},
-        outputs={noded["bel"]: solph.Flow(), noded["bth"]: solph.Flow()},
-        conversion_factors={noded["bel"]: 0.3, noded["bth"]: 0.5},
-        conversion_factor_full_condensation={noded["bel"]: 0.5},
+        outputs={noded["bth"]: solph.Flow(), noded["bel"]: solph.Flow()},
+        conversion_factors={
+            noded["bel"]: abel,
+            noded["bth"]: abth,
+        },
+        # allow_equal_states=True,
+        conversion_factors_secondary_state={
+            noded["bel"]: [0.3] * 192,
+            noded["bth"]: [0.5] * 192,
+        },
     )
 
     ##########################################################################

--- a/src/oemof/solph/components/__init__.py
+++ b/src/oemof/solph/components/__init__.py
@@ -20,6 +20,7 @@ from ._offset_converter import slope_offset_from_nonconvex_input
 from ._offset_converter import slope_offset_from_nonconvex_output
 from ._sink import Sink
 from ._source import Source
+from ._variable_split_converter import VariableSplitConverter
 
 __all__ = [
     "Converter",

--- a/src/oemof/solph/components/__init__.py
+++ b/src/oemof/solph/components/__init__.py
@@ -11,6 +11,7 @@ experimental code should be included in oemof.experimental.
 
 from . import experimental
 from ._converter import Converter
+from ._variable_split_converter import VariableSplitConverter
 from ._extraction_turbine_chp import ExtractionTurbineCHP
 from ._generic_chp import GenericCHP
 from ._generic_storage import GenericStorage
@@ -20,7 +21,6 @@ from ._offset_converter import slope_offset_from_nonconvex_input
 from ._offset_converter import slope_offset_from_nonconvex_output
 from ._sink import Sink
 from ._source import Source
-from ._variable_split_converter import VariableSplitConverter
 
 __all__ = [
     "Converter",
@@ -34,4 +34,5 @@ __all__ = [
     "Source",
     "slope_offset_from_nonconvex_input",
     "slope_offset_from_nonconvex_output",
+    "VariableSplitConverter"
 ]

--- a/src/oemof/solph/components/_extraction_turbine_chp.py
+++ b/src/oemof/solph/components/_extraction_turbine_chp.py
@@ -280,3 +280,19 @@ class ExtractionTurbineCHPBlock(ScalarBlock):
         self.out_flow_relation_build = BuildAction(
             rule=_out_flow_relation_rule
         )
+
+        eta_th_min = 0.10  # Wirkungsgrad Wärme im Minimalpunkt
+
+        def _min_heat_extraction_rule(block):
+            for t in m.TIMESTEPS:
+                for g in group:
+                    lhs = 0.1 * m.flow[g.inflow, g, t]
+                    rhs = m.flow[g, g.tapped_output, t]
+                    block.min_heat_extraction.add((g, t), (lhs <= rhs))
+
+        self.min_heat_extraction = Constraint(
+            group, m.TIMESTEPS, noruleinit=True
+        )
+        self.min_heat_extraction_build = BuildAction(
+            rule=_min_heat_extraction_rule
+        )

--- a/src/oemof/solph/components/_extraction_turbine_chp.py
+++ b/src/oemof/solph/components/_extraction_turbine_chp.py
@@ -19,16 +19,10 @@ SPDX-License-Identifier: MIT
 
 """
 
-from pyomo.core.base.block import ScalarBlock
-from pyomo.environ import BuildAction
-from pyomo.environ import Constraint
-
-from oemof.solph._plumbing import Apply
-from oemof.solph._plumbing import SequenceDict
-from oemof.solph.components import Converter
+from oemof.solph.components import VariableSplitConverter
 
 
-class ExtractionTurbineCHP(Converter):
+class ExtractionTurbineCHP(VariableSplitConverter):
     r"""
     A CHP with an extraction turbine in a linear model. For a more
     detailled modelling approach providing more options, also see
@@ -71,8 +65,6 @@ class ExtractionTurbineCHP(Converter):
     ...    conversion_factor_full_condensation={bel: 0.5})
     """  # noqa: E501
 
-    conversion_factor_full_condensation = Apply(SequenceDict)
-
     def __init__(
         self,
         conversion_factor_full_condensation,
@@ -83,6 +75,19 @@ class ExtractionTurbineCHP(Converter):
         conversion_factors=None,
         custom_properties=None,
     ):
+        # super().__init__(
+        #     label=label,
+        #     inputs=inputs,
+        #     outputs=outputs,
+        #     parent_node=parent_node,
+        #     conversion_factors=conversion_factors,
+        #     custom_properties=custom_properties,
+        # )
+        bus2 = set(conversion_factors).difference(
+            set(conversion_factor_full_condensation)
+        ).pop()
+        conversion_factor_full_condensation[bus2] = 0
+
         super().__init__(
             label=label,
             inputs=inputs,
@@ -90,209 +95,6 @@ class ExtractionTurbineCHP(Converter):
             parent_node=parent_node,
             conversion_factors=conversion_factors,
             custom_properties=custom_properties,
-        )
-        self.conversion_factor_full_condensation = {
-            k: v for k, v in conversion_factor_full_condensation.items()
-        }
-
-    def constraint_group(self):
-        return ExtractionTurbineCHPBlock
-
-
-class ExtractionTurbineCHPBlock(ScalarBlock):
-    r"""Block for all instances of
-    :class:`~oemof.solph.components.experimental._ExtractionTurbineCHP`
-
-    **Variables**
-
-    The following variables are used:
-
-    * :math:`\dot H_{Fuel}`
-
-        Fuel input flow, represented in code as `flow[i, n, t]`
-
-    * :math:`P_{el}`
-
-        Electric power outflow, represented in code as
-        `flow[n, main_output, t]`
-
-    * :math:`\dot Q_{th}`
-
-        Thermal output flow, represented in code as
-        `flow[n, tapped_output, t]`
-
-    **Parameters**
-
-    The following parameters are created as attributes of
-    :attr:`om.ExtractionTurbineCHP`:
-
-    * :math:`\eta_{el,woExtr}`
-
-        Electric efficiency without heat extraction, represented in code as
-        `conversion_factor_full_condensation[n, t]`
-
-    * :math:`\eta_{el,maxExtr}`
-
-        Electric efficiency with maximal heat extraction, represented in code
-        as `conversion_factors[main_output][n, t]`
-
-    * :math:`\eta_{th,maxExtr}`
-
-        Thermal efficiency with maximal heat extraction, represented in code
-        as `conversion_factors[tapped_output][n, t]`
-
-    **Constraints**
-
-    The following constraints are created for all
-    instances of :class:`oemof.solph.components.ExtractionTurbineCHP`:
-
-    .. _ETCHP-equations:
-
-        .. math::
-            &
-            (1)\dot H_{Fuel}(t) =
-               \frac{P_{el}(t) + \dot Q_{th}(t) \cdot \beta(t)}
-                 {\eta_{el,woExtr}(t)} \\
-            &
-            (2)P_{el}(t) \geq \dot Q_{th}(t) \cdot C_b
-
-    where:
-
-    .. math::
-
-        \beta(t) = \frac{\eta_{el,woExtr}(t) -
-            \eta_{el,maxExtr}(t)}{\eta_{th,maxExtr}(t)}
-
-    and:
-
-    .. math::
-
-        C_b = \frac{\eta_{el,maxExtr}(t)}{\eta_{th,maxExtr}(t)}
-
-    The first equation is the result of the relation between the input
-    flow and the two output flows, the second equation stems from how the two
-    output flows relate to each other, and the symbols used are defined as
-    follows (with Variables (V) and Parameters (P)):
-
-    ========================= ============================================ ==== =========
-    symbol                    attribute                                    type explanation
-    ========================= ============================================ ==== =========
-    :math:`\dot H_{Fuel}`     `flow[i, n, t]`                              V    fuel input flow
-
-    :math:`P_{el}`            `flow[n, main_output, t]`                    V    electric power
-
-    :math:`\dot Q_{th}`       `flow[n, tapped_output, t]`                  V    thermal output
-
-    :math:`\beta`             `main_flow_loss_index[n, t]`                 P    power loss index
-
-    :math:`\eta_{el,woExtr}`  `conversion_factor_full_condensation[n, t]`  P    electric efficiency
-                                                                                        without heat extraction
-    :math:`\eta_{el,maxExtr}` `conversion_factors[main_output][n, t]`      P    electric efficiency
-                                                                                        with max heat extraction
-    :math:`\eta_{th,maxExtr}` `conversion_factors[tapped_output][n, t]`    P    thermal efficiency with
-                                                                                        maximal heat extraction
-    ========================= ============================================ ==== =========
-
-    """  # noqa: E501
-
-    CONSTRAINT_GROUP = True
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    def _create(self, group=None):
-        """Creates the constraints for
-        :class:`oemof.solph.components.experimental._extraction_turbine_chp.ExtractionTurbineCHPBlock`.
-
-        Parameters
-        ----------
-        group : list
-            List of
-            :class:`oemof.solph.components.experimental._extraction_turbine_chp.ExtractionTurbineCHP`
-            (trsf) objects for which the linear relation of inputs
-            and outputs is created e.g. group = [trsf1, trsf2, trsf3, ...].
-            Note that the relation is created for all existing relations
-            of the inputs and all outputs of the converter-like object.
-            The components inside the list need to hold all needed attributes.
-        """
-        if group is None:
-            return None
-
-        m = self.parent_block()
-
-        for n in group:
-            n.inflow = list(n.inputs)[0]
-            n.main_flow = [
-                k for k, v in n.conversion_factor_full_condensation.items()
-            ][0]
-            n.main_output = [o for o in n.outputs if n.main_flow == o][0]
-            n.tapped_output = [o for o in n.outputs if n.main_flow != o][0]
-            n.conversion_factor_full_condensation_sq = (
-                n.conversion_factor_full_condensation[n.main_output]
-            )
-            n.flow_relation_index = [
-                n.conversion_factors[n.main_output][t]
-                / n.conversion_factors[n.tapped_output][t]
-                for t in m.TIMESTEPS
-            ]
-            n.main_flow_loss_index = [
-                (
-                    n.conversion_factor_full_condensation_sq[t]
-                    - n.conversion_factors[n.main_output][t]
-                )
-                / n.conversion_factors[n.tapped_output][t]
-                for t in m.TIMESTEPS
-            ]
-
-        def _input_output_relation_rule(block):
-            """Connection between input, main output and tapped output."""
-            for t in m.TIMESTEPS:
-                for g in group:
-                    lhs = m.flow[g.inflow, g, t]
-                    rhs = (
-                        m.flow[g, g.main_output, t]
-                        + m.flow[g, g.tapped_output, t]
-                        * g.main_flow_loss_index[t]
-                    ) / g.conversion_factor_full_condensation_sq[t]
-                    block.input_output_relation.add((g, t), (lhs == rhs))
-
-        self.input_output_relation = Constraint(
-            group, m.TIMESTEPS, noruleinit=True
-        )
-        self.input_output_relation_build = BuildAction(
-            rule=_input_output_relation_rule
-        )
-
-        def _out_flow_relation_rule(block):
-            """Relation between main and tapped output in full chp mode."""
-            for t in m.TIMESTEPS:
-                for g in group:
-                    lhs = m.flow[g, g.main_output, t]
-                    rhs = (
-                        m.flow[g, g.tapped_output, t]
-                        * g.flow_relation_index[t]
-                    )
-                    block.out_flow_relation.add((g, t), (lhs >= rhs))
-
-        self.out_flow_relation = Constraint(
-            group, m.TIMESTEPS, noruleinit=True
-        )
-        self.out_flow_relation_build = BuildAction(
-            rule=_out_flow_relation_rule
-        )
-
-        eta_th_min = 0.10  # Wirkungsgrad Wärme im Minimalpunkt
-
-        def _min_heat_extraction_rule(block):
-            for t in m.TIMESTEPS:
-                for g in group:
-                    lhs = 0.1 * m.flow[g.inflow, g, t]
-                    rhs = m.flow[g, g.tapped_output, t]
-                    block.min_heat_extraction.add((g, t), (lhs <= rhs))
-
-        self.min_heat_extraction = Constraint(
-            group, m.TIMESTEPS, noruleinit=True
-        )
-        self.min_heat_extraction_build = BuildAction(
-            rule=_min_heat_extraction_rule
+            allow_equal_states=False,
+            conversion_factors_secondary_state=conversion_factor_full_condensation,
         )

--- a/src/oemof/solph/components/_variable_split_converter.py
+++ b/src/oemof/solph/components/_variable_split_converter.py
@@ -332,9 +332,10 @@ class VariableSplitConverterBlock(ScalarBlock):
         def _out_a_lower_bound_rule(block):
             for t in m.TIMESTEPS:
                 for g in self.EQUAL_STATES:
-                    lhs = g.out_a_min[t] * m.flow[g.inflow, g, t]
-                    rhs = m.flow[g, g.output_a, t]
-                    block.out_a_lower_bound.add((g, t), (lhs <= rhs))
+                    if g.coef_out_b[t] == 0:
+                        lhs = g.out_a_min[t] * m.flow[g.inflow, g, t]
+                        rhs = m.flow[g, g.output_a, t]
+                        block.out_a_lower_bound.add((g, t), (lhs <= rhs))
 
         self.out_a_lower_bound = Constraint(
             self.EQUAL_STATES, m.TIMESTEPS, noruleinit=True
@@ -346,9 +347,10 @@ class VariableSplitConverterBlock(ScalarBlock):
         def _out_a_upper_bound_rule(block):
             for t in m.TIMESTEPS:
                 for g in self.EQUAL_STATES:
-                    lhs = m.flow[g, g.output_a, t]
-                    rhs = g.out_a_max[t] * m.flow[g.inflow, g, t]
-                    block.out_a_upper_bound.add((g, t), (lhs <= rhs))
+                    if g.coef_out_b[t] == 0:
+                        lhs = m.flow[g, g.output_a, t]
+                        rhs = g.out_a_max[t] * m.flow[g.inflow, g, t]
+                        block.out_a_upper_bound.add((g, t), (lhs <= rhs))
 
         self.out_a_upper_bound = Constraint(
             self.EQUAL_STATES, m.TIMESTEPS, noruleinit=True

--- a/src/oemof/solph/components/_variable_split_converter.py
+++ b/src/oemof/solph/components/_variable_split_converter.py
@@ -1,0 +1,358 @@
+# -*- coding: utf-8 -*-
+
+"""
+VariableSplitConverter and associated individual constraints (blocks)
+and groupings.
+
+SPDX-FileCopyrightText: Uwe Krien <krien@uni-bremen.de>
+SPDX-FileCopyrightText: Simon Hilpert
+SPDX-FileCopyrightText: Cord Kaldemeyer
+SPDX-FileCopyrightText: Patrik Schönfeldt
+SPDX-FileCopyrightText: FranziPl
+SPDX-FileCopyrightText: jnnr
+SPDX-FileCopyrightText: Stephan Günther
+SPDX-FileCopyrightText: FabianTU
+SPDX-FileCopyrightText: Johannes Röder
+SPDX-FileCopyrightText: Johannes Kochems
+
+SPDX-License-Identifier: MIT
+
+"""
+
+from pyomo.core.base.block import ScalarBlock
+from pyomo.environ import BuildAction
+from pyomo.environ import Constraint
+from pyomo.environ import Set
+
+from oemof.solph._plumbing import Apply
+from oemof.solph._plumbing import SequenceDict
+from oemof.solph._plumbing import sequence
+from oemof.solph.components import Converter
+
+
+def _conversion_points_are_equal(point_1, point_2):
+    """Check whether two conversion factor dicts are identical for all
+    shared keys (same outputs, same values at every timestep)."""
+    if set(point_1) != set(point_2):
+        return False
+    return all(point_1[k] == point_2[k] for k in point_1)
+
+
+class VariableSplitConverter(Converter):
+    r"""
+    A converter with one input and two competing outputs, where the split
+    between the outputs can vary linearly between two given, real
+    operating points (e.g. an extraction/backpressure turbine, where the
+    split between electricity and heat varies with the amount of heat
+    extracted).
+
+    The linear relation between the two output flows and the input flow is
+    fully determined by **two real, measurable operating points**. At each
+    point, conversion factors for *both* outputs must be given. Which point
+    is passed as `conversion_factors` and which as
+    `conversion_factors_at_second_point` does **not matter** -- the
+    underlying relation is a straight line through both points and is
+    computed symmetrically. Likewise, it does not matter which of the two
+    outputs is listed first; both outputs are treated symmetrically.
+
+    Note that neither point needs to correspond to a "degenerate" case
+    (e.g. zero output of one flow, such as full condensation in a turbine)
+    -- the converter will never operate outside the interval spanned by the
+    two given points.
+
+    Parameters
+    ----------
+    conversion_factors : dict
+        Conversion factors for **both** outputs at the first operating
+        point. Keys are the two output bus objects. Values can be scalar
+        or a sequence with length of the simulation's time horizon.
+    conversion_factors_secondary_state : dict
+        Conversion factors for **both** outputs at the second operating
+        point. Same structure as `conversion_factors`. Must use the same
+        two output bus objects as keys.
+
+    Notes
+    -----
+    The following sets, variables, constraints and objective parts are
+    created:
+     * :py:class:`~oemof.solph.components.variable_split_converter.VariableSplitConverterBlock`
+
+    Examples
+    --------
+    Extraction turbine CHP (electricity / heat trade-off):
+
+    >>> from oemof import solph
+    >>> bel = solph.buses.Bus(label='electricityBus')
+    >>> bth = solph.buses.Bus(label='heatBus')
+    >>> bgas = solph.buses.Bus(label='commodityBus')
+    >>> et_chp = solph.components.VariableSplitConverter(
+    ...    label='variable_chp_gas',
+    ...    inputs={bgas: solph.flows.Flow(nominal_capacity=10e10)},
+    ...    outputs={bel: solph.flows.Flow(), bth: solph.flows.Flow()},
+    ...    conversion_factors={bel: 0.30, bth: 0.50},
+    ...    conversion_factors_secondary_state={bel: 0.48, bth: 0.10})
+    """  # noqa: E501
+
+    conversion_factors_secondary_state = Apply(SequenceDict)
+    conversion_factors = Apply(SequenceDict)
+
+    def __init__(
+        self,
+        label=None,
+        inputs=None,
+        outputs=None,
+        parent_node=None,
+        conversion_factors=None,
+        conversion_factors_secondary_state=None,
+        custom_properties=None,
+        allow_equal_states=False,
+    ):
+        super().__init__(
+            label=label,
+            inputs=inputs,
+            outputs=outputs,
+            parent_node=parent_node,
+            conversion_factors=conversion_factors,
+            custom_properties=custom_properties,
+        )
+        self.conversion_factors_secondary_state = (
+            conversion_factors_secondary_state
+        )
+        self.allow_equal_states = allow_equal_states
+
+        if set(conversion_factors_secondary_state) != set(conversion_factors):
+            raise ValueError("Use the same buses for both states.")
+        try:
+            length = len(
+                conversion_factors_secondary_state[
+                    list(conversion_factors_secondary_state.keys())[0]
+                ]
+            )
+            if not allow_equal_states and any(
+                [
+                    any(
+                        sequence(conversion_factors[k], length)
+                        == sequence(
+                            conversion_factors_secondary_state[k], length
+                        )
+                    )
+                    for k in conversion_factors
+                ]
+            ):
+                raise ValueError("That is not okay.")
+        except TypeError:
+            if not allow_equal_states and any(
+                [
+                    conversion_factors[k]
+                    == conversion_factors_secondary_state[k]
+                    for k in conversion_factors
+                ]
+            ):
+                raise ValueError("That is not okay.")
+
+    def constraint_group(self):
+        return VariableSplitConverterBlock
+
+
+class VariableSplitConverterBlock(ScalarBlock):
+    r"""Block for all instances of
+    :class:`~oemof.solph.components.experimental._VariableSplitConverter`
+
+    **Variables**
+
+    * :math:`\dot H_{in}`
+
+        Input flow, represented in code as `flow[i, n, t]`
+
+    * :math:`A`
+
+        First output flow, represented in code as `flow[n, output_1, t]`
+
+    * :math:`B`
+
+        Second output flow, represented in code as `flow[n, output_2, t]`
+
+    **Parameters**
+
+    Given (real, measurable) operating points -- `output_1`/`output_2` are
+    simply the two dictionary keys of `conversion_factors` in iteration
+    order; which physical flow ends up as `output_1` is arbitrary and does
+    not affect the result:
+
+    * :math:`a_1, b_1`
+
+        Conversion factors for output_1 / output_2 at the first point,
+        `conversion_factors[output_1][n, t]` /
+        `conversion_factors[output_2][n, t]`.
+
+    * :math:`a_2, b_2`
+
+        Conversion factors for output_1 / output_2 at the second point,
+        `conversion_factors_at_second_point[output_1][n, t]` /
+        `conversion_factors_at_second_point[output_2][n, t]`.
+
+    Derived (computed internally in :py:meth:`_create`, no division
+    involved):
+
+    .. math::
+        c_A(t) &= b_1(t) - b_2(t) \\
+        c_B(t) &= a_2(t) - a_1(t) \\
+        c_{in}(t) &= a_2(t)\, b_1(t) - a_1(t)\, b_2(t)
+
+    **Constraints**
+
+        .. math::
+            &
+            (1)\ c_A(t)\cdot A(t) + c_B(t)\cdot B(t) = c_{in}(t)\cdot
+                \dot H_{in}(t) \\
+            &
+            (2)\ \min(b_1(t), b_2(t))\cdot \dot H_{in}(t) \leq B(t) \\
+            &
+            (3)\ B(t) \leq \max(b_1(t), b_2(t))\cdot \dot H_{in}(t)
+
+    Equation (1) is the (symmetric) line through both given operating
+    points. Equations (2) and (3) restrict operation to the interval
+    spanned by the two points -- the converter can never move beyond
+    either of them.
+
+    ============ ======================================================== ==== =========
+    symbol       attribute                                                type explanation
+    ============ ======================================================== ==== =========
+    :math:`\dot H_{in}` `flow[i, n, t]`                                   V    input flow
+    :math:`A`    `flow[n, output_1, t]`                                   V    first output flow
+    :math:`B`    `flow[n, output_2, t]`                                   V    second output flow
+    :math:`a_1`  `conversion_factors[output_1][n, t]`                     P    efficiency of output_1 at point 1
+    :math:`b_1`  `conversion_factors[output_2][n, t]`                     P    efficiency of output_2 at point 1
+    :math:`a_2`  `conversion_factors_at_second_point[output_1][n, t]`     P    efficiency of output_1 at point 2
+    :math:`b_2`  `conversion_factors_at_second_point[output_2][n, t]`     P    efficiency of output_2 at point 2
+    ============ ======================================================== ==== =========
+
+    """  # noqa: E501
+
+    CONSTRAINT_GROUP = True
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _create(self, group=None):
+        """Creates the constraints for
+        :class:`oemof.solph.components.experimental._variable_split_converter.VariableSplitConverterBlock`.
+
+        Parameters
+        ----------
+        group : list
+            List of
+            :class:`oemof.solph.components.experimental._variable_split_converter.VariableSplitConverter`
+            (trsf) objects for which the linear relation of inputs
+            and outputs is created e.g. group = [trsf1, trsf2, trsf3, ...].
+            Note that the relation is created for all existing relations
+            of the inputs and all outputs of the converter-like object.
+            The components inside the list need to hold all needed attributes.
+        """
+        if group is None:
+            return None
+
+        m = self.parent_block()
+
+        self.EQUAL_STATES = Set(
+            initialize=[g for g in group if g.allow_equal_states]
+        )
+
+        for n in group:
+            n.inflow = list(n.inputs)[0]
+
+            n.output_a, n.output_b = list(n.outputs.keys())
+
+            a1 = n.conversion_factors[n.output_a]
+            b1 = n.conversion_factors[n.output_b]
+            a2 = n.conversion_factors_secondary_state[n.output_a]
+            b2 = n.conversion_factors_secondary_state[n.output_b]
+
+            n.coef_out_b = [b1[t] - b2[t] for t in m.TIMESTEPS]
+            n.coef_out_a = [a2[t] - a1[t] for t in m.TIMESTEPS]
+            n.coef_in = [a2[t] * b1[t] - a1[t] * b2[t] for t in m.TIMESTEPS]
+
+            n.out_b_min = [min(b1[t], b2[t]) for t in m.TIMESTEPS]
+            n.out_b_max = [max(b1[t], b2[t]) for t in m.TIMESTEPS]
+
+            if n.allow_equal_states:
+                n.out_a_min = [min(a1[t], a2[t]) for t in m.TIMESTEPS]
+                n.out_a_max = [max(a1[t], a2[t]) for t in m.TIMESTEPS]
+
+        def _input_output_relation_rule(block):
+            """Line through both given operating points"""
+            for t in m.TIMESTEPS:
+                for g in group:
+                    lhs = (
+                        g.coef_out_b[t] * m.flow[g, g.output_a, t]
+                        + g.coef_out_a[t] * m.flow[g, g.output_b, t]
+                    )
+                    rhs = g.coef_in[t] * m.flow[g.inflow, g, t]
+                    block.input_output_relation.add((g, t), (lhs == rhs))
+
+        self.input_output_relation = Constraint(
+            group, m.TIMESTEPS, noruleinit=True
+        )
+        self.input_output_relation_build = BuildAction(
+            rule=_input_output_relation_rule
+        )
+
+        def _out_b_lower_bound_rule(block):
+            """Restrict output_b to never fall below the smaller of the
+            two given operating points."""
+            for t in m.TIMESTEPS:
+                for g in group:
+                    lhs = g.out_b_min[t] * m.flow[g.inflow, g, t]
+                    rhs = m.flow[g, g.output_b, t]
+                    block.out_b_lower_bound.add((g, t), (lhs <= rhs))
+
+        self.out_b_lower_bound = Constraint(
+            group, m.TIMESTEPS, noruleinit=True
+        )
+        self.out_b_lower_bound_build = BuildAction(
+            rule=_out_b_lower_bound_rule
+        )
+
+        def _out_b_upper_bound_rule(block):
+            """Restrict output_b to never exceed the larger of the two
+            given operating points."""
+            for t in m.TIMESTEPS:
+                for g in group:
+                    lhs = m.flow[g, g.output_b, t]
+                    rhs = g.out_b_max[t] * m.flow[g.inflow, g, t]
+                    block.out_b_upper_bound.add((g, t), (lhs <= rhs))
+
+        self.out_b_upper_bound = Constraint(
+            group, m.TIMESTEPS, noruleinit=True
+        )
+        self.out_b_upper_bound_build = BuildAction(
+            rule=_out_b_upper_bound_rule
+        )
+
+        def _out_a_lower_bound_rule(block):
+            for t in m.TIMESTEPS:
+                for g in self.EQUAL_STATES:
+                    lhs = g.out_a_min[t] * m.flow[g.inflow, g, t]
+                    rhs = m.flow[g, g.output_a, t]
+                    block.out_a_lower_bound.add((g, t), (lhs <= rhs))
+
+        self.out_a_lower_bound = Constraint(
+            self.EQUAL_STATES, m.TIMESTEPS, noruleinit=True
+        )
+        self.out_a_lower_bound_build = BuildAction(
+            rule=_out_a_lower_bound_rule
+        )
+
+        def _out_a_upper_bound_rule(block):
+            for t in m.TIMESTEPS:
+                for g in self.EQUAL_STATES:
+                    lhs = m.flow[g, g.output_a, t]
+                    rhs = g.out_a_max[t] * m.flow[g.inflow, g, t]
+                    block.out_a_upper_bound.add((g, t), (lhs <= rhs))
+
+        self.out_a_upper_bound = Constraint(
+            self.EQUAL_STATES, m.TIMESTEPS, noruleinit=True
+        )
+        self.out_a_upper_bound_build = BuildAction(
+            rule=_out_a_upper_bound_rule
+        )


### PR DESCRIPTION
In the long run, this new component could replace the "ExtractionTurbineCHP" class.

Basically, it follows a more generic approach in which two output flows are dependent on one another. If one changes, the other changes too. The dependencies are defined by two boundary conditions, each of which specifies the ratio of the flows to the input flow and thus to one another.

<img width="1091" height="674" alt="grafik" src="https://github.com/user-attachments/assets/260f654b-43bc-493e-921d-3515cd96072a" />

In the normal state, the two points must be different. If this is not the case, an error is raised. This applies to both individual values and time series. This makes sense, since otherwise the Converter could just as well be used. In that case, only the minimum necessary constraints are created. For the rare case where time series are used and the values happen to be equal at only a few individual points in time, the parameter "allow_equal_states" can be set to "True". In that case, it is checked at every point in time whether the points are equal, and only then are the additional constraints created. However, this check of the individual values is only carried out if "allow_equal_states" is set to "True" to save time in the "normal" run.

* I would suggest replacing ExtractionTurbineCHP and only keeping the Extraction Turbine in the documentation, to help people.
* Of course, we should still discuss the name of the new component.

If you generally like the concept, I will add a FutureWarning, error messages and tests, and finish documenting the component.