### PR TITLE
Enforce minimum_uptime/minimum_downtime over the first time steps

### DIFF
--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -39,9 +39,10 @@ Bug fixes
   step it was free to, and reverse that one time step later, ignoring the
   other of the two minimum times. Both constraints now use ``initial_status``
   as the status preceding the horizon, the same convention the startup and
-  shutdown constraints already used. Note that this can change the result of
-  existing models that combine ``initial_status`` with ``minimum_uptime`` or
-  ``minimum_downtime``.
+  shutdown constraints already used. The rules are now also built for the last
+  time step, so ``minimum_uptime`` is no longer ignored for a startup there.
+  Note that this can change the result of existing models that combine
+  ``initial_status`` with ``minimum_uptime`` or ``minimum_downtime``.
 
 Other changes
 #############

--- a/docs/whatsnew/v0-6-5.rst
+++ b/docs/whatsnew/v0-6-5.rst
@@ -31,6 +31,17 @@ Bug fixes
   find it by the same key regardless of clustering.
 * Fix ``limit_active_flow_count`` and ``limit_active_flow_count_by_keyword ``
   constraints for flows of type ``INVEST_NON_CONVEX_FLOWS``
+* Fix ``NonConvex`` ``minimum_uptime``/``minimum_downtime`` being skipped for
+  the first time steps of the optimisation horizon. The constraints were only
+  built for ``t > first_flexible_timestep``, which is derived from
+  ``minimum_downtime`` if ``initial_status=0`` and from ``minimum_uptime``
+  otherwise. A unit could therefore start up (or shut down) in the first time
+  step it was free to, and reverse that one time step later, ignoring the
+  other of the two minimum times. Both constraints now use ``initial_status``
+  as the status preceding the horizon, the same convention the startup and
+  shutdown constraints already used. Note that this can change the result of
+  existing models that combine ``initial_status`` with ``minimum_uptime`` or
+  ``minimum_downtime``.
 
 Other changes
 #############
@@ -54,6 +65,7 @@ Contributors
 * Jonas Freißmann
 * Uwe Krien
 * Francesco Witte
+* Dylan Pulver
 
 Acknowledgements
 ################

--- a/src/oemof/solph/flows/_shared.py
+++ b/src/oemof/solph/flows/_shared.py
@@ -189,6 +189,19 @@ def variables_for_non_convex_flows(block):
         )
 
 
+def _previous_status(block, i, o, t):
+    """Status of a flow in the time step before `t`.
+
+    Before the first time step of the optimisation horizon, the flow is
+    assumed to have been in its `initial_status`. This is the same
+    convention that the startup and shutdown constraints use.
+    """
+    m = block.parent_block()
+    if t > m.TIMESTEPS.at(1):
+        return block.status[i, o, t - 1]
+    return m.flows[i, o].nonconvex.initial_status
+
+
 def _min_downtime_constraint(block):
     r"""
     .. math::
@@ -197,15 +210,11 @@ def _min_downtime_constraint(block):
         \leq t_{down,minimum} \
         - \sum_{n=0}^{t_{down,minimum}-1} Y_{status}(t+n) \\
         \forall t \in \textrm{TIMESTEPS} | \\
-        t \neq \{0..t_{down,minimum}\} \cup \
-        \{t\_max-t_{down,minimum}..t\_max\} , \\
+        t \neq t\_max , \\
         \forall (i,o) \in \textrm{MINDOWNTIMEFLOWS}.
-        \\ \\
-        Y_{status}(t) = Y_{status,0} \\
-        \forall t \in \textrm{TIMESTEPS} | \\
-        t = \{0..t_{down,minimum}\} \cup \
-        \{t\_max-t_{down,minimum}..t\_max\} , \\
-        \forall (i,o) \in \textrm{MINDOWNTIMEFLOWS}.
+
+    where :math:`Y_{status}(-1) := Y_{status,0}`, the `initial_status`
+    of the flow.
     """
     m = block.parent_block()
 
@@ -213,17 +222,13 @@ def _min_downtime_constraint(block):
         """
         Rule definition for min-downtime constraints of non-convex flows.
         """
-        if (
-            m.flows[i, o].nonconvex.first_flexible_timestep
-            < t
-            < m.TIMESTEPS.at(-1)
-        ):
+        if t < m.TIMESTEPS.at(-1):
             # We have a 2D matrix of constraints,
             # so testing is easier then just calling the rule for valid t.
 
             expr = 0
             expr += (
-                block.status[i, o, t - 1] - block.status[i, o, t]
+                _previous_status(block, i, o, t) - block.status[i, o, t]
             ) * m.flows[i, o].nonconvex.minimum_downtime[t]
             expr += -m.flows[i, o].nonconvex.minimum_downtime[t]
             expr += sum(
@@ -251,15 +256,11 @@ def _min_uptime_constraint(block):
         (Y_{status}(t)-Y_{status}(t-1)) \cdot t_{up,minimum} \\
         \leq \sum_{n=0}^{t_{up,minimum}-1} Y_{status}(t+n) \\
         \forall t \in \textrm{TIMESTEPS} | \\
-        t \neq \{0..t_{up,minimum}\} \cup \
-        \{t\_max-t_{up,minimum}..t\_max\} , \\
+        t \neq t\_max , \\
         \forall (i,o) \in \textrm{MINUPTIMEFLOWS}.
-        \\ \\
-        Y_{status}(t) = Y_{status,0} \\
-        \forall t \in \textrm{TIMESTEPS} | \\
-        t = \{0..t_{up,minimum}\} \cup \
-        \{t\_max-t_{up,minimum}..t\_max\} , \\
-        \forall (i,o) \in \textrm{MINUPTIMEFLOWS}.
+
+    where :math:`Y_{status}(-1) := Y_{status,0}`, the `initial_status`
+    of the flow.
     """
     m = block.parent_block()
 
@@ -267,16 +268,12 @@ def _min_uptime_constraint(block):
         """
         Rule definition for min-uptime constraints of non-convex flows.
         """
-        if (
-            m.flows[i, o].nonconvex.first_flexible_timestep
-            < t
-            < m.TIMESTEPS.at(-1)
-        ):
+        if t < m.TIMESTEPS.at(-1):
             # We have a 2D matrix of constraints,
             # so testing is easier then just calling the rule for valid t.
             expr = 0
             expr += (
-                block.status[i, o, t] - block.status[i, o, t - 1]
+                block.status[i, o, t] - _previous_status(block, i, o, t)
             ) * m.flows[i, o].nonconvex.minimum_uptime[t]
             expr += -sum(
                 block.status[i, o, u]
@@ -306,18 +303,8 @@ def _shutdown_constraint(block):
 
     def _shutdown_rule(_, i, o, t):
         """Rule definition for shutdown constraints of non-convex flows."""
-        if t > m.TIMESTEPS.at(1):
-            expr = (
-                block.shutdown[i, o, t]
-                >= block.status[i, o, t - 1] - block.status[i, o, t]
-            )
-        else:
-            expr = (
-                block.shutdown[i, o, t]
-                >= m.flows[i, o].nonconvex.initial_status
-                - block.status[i, o, t]
-            )
-        return expr
+        previous = _previous_status(block, i, o, t)
+        return block.shutdown[i, o, t] >= previous - block.status[i, o, t]
 
     return Constraint(block.SHUTDOWNFLOWS, m.TIMESTEPS, rule=_shutdown_rule)
 
@@ -333,18 +320,8 @@ def _startup_constraint(block):
 
     def _startup_rule(_, i, o, t):
         """Rule definition for startup constraint of nonconvex flows."""
-        if t > m.TIMESTEPS.at(1):
-            expr = (
-                block.startup[i, o, t]
-                >= block.status[i, o, t] - block.status[i, o, t - 1]
-            )
-        else:
-            expr = (
-                block.startup[i, o, t]
-                >= block.status[i, o, t]
-                - m.flows[i, o].nonconvex.initial_status
-            )
-        return expr
+        previous = _previous_status(block, i, o, t)
+        return block.startup[i, o, t] >= block.status[i, o, t] - previous
 
     return Constraint(block.STARTUPFLOWS, m.TIMESTEPS, rule=_startup_rule)
 

--- a/src/oemof/solph/flows/_shared.py
+++ b/src/oemof/solph/flows/_shared.py
@@ -11,6 +11,7 @@ SPDX-FileCopyrightText: Birgit Schachler
 SPDX-FileCopyrightText: jnnr
 SPDX-FileCopyrightText: jmloenneberga
 SPDX-FileCopyrightText: Johannes Kochems
+SPDX-FileCopyrightText: Dylan Pulver
 
 SPDX-License-Identifier: MIT
 
@@ -209,8 +210,7 @@ def _min_downtime_constraint(block):
         \cdot t_{down,minimum} \\
         \leq t_{down,minimum} \
         - \sum_{n=0}^{t_{down,minimum}-1} Y_{status}(t+n) \\
-        \forall t \in \textrm{TIMESTEPS} | \\
-        t \neq t\_max , \\
+        \forall t \in \textrm{TIMESTEPS}, \\
         \forall (i,o) \in \textrm{MINDOWNTIMEFLOWS}.
 
     where :math:`Y_{status}(-1) := Y_{status,0}`, the `initial_status`
@@ -222,28 +222,22 @@ def _min_downtime_constraint(block):
         """
         Rule definition for min-downtime constraints of non-convex flows.
         """
-        if t < m.TIMESTEPS.at(-1):
-            # We have a 2D matrix of constraints,
-            # so testing is easier then just calling the rule for valid t.
-
-            expr = 0
-            expr += (
-                _previous_status(block, i, o, t) - block.status[i, o, t]
-            ) * m.flows[i, o].nonconvex.minimum_downtime[t]
-            expr += -m.flows[i, o].nonconvex.minimum_downtime[t]
-            expr += sum(
-                block.status[i, o, d]
-                for d in range(
-                    t,
-                    min(
-                        t + m.flows[i, o].nonconvex.minimum_downtime[t],
-                        len(m.TIMESTEPS),
-                    ),
-                )
+        expr = 0
+        expr += (
+            _previous_status(block, i, o, t) - block.status[i, o, t]
+        ) * m.flows[i, o].nonconvex.minimum_downtime[t]
+        expr += -m.flows[i, o].nonconvex.minimum_downtime[t]
+        expr += sum(
+            block.status[i, o, d]
+            for d in range(
+                t,
+                min(
+                    t + m.flows[i, o].nonconvex.minimum_downtime[t],
+                    len(m.TIMESTEPS),
+                ),
             )
-            return expr <= 0
-        else:
-            return Constraint.Skip
+        )
+        return expr <= 0
 
     return Constraint(
         block.MINDOWNTIMEFLOWS, m.TIMESTEPS, rule=min_downtime_rule
@@ -255,8 +249,7 @@ def _min_uptime_constraint(block):
     .. math::
         (Y_{status}(t)-Y_{status}(t-1)) \cdot t_{up,minimum} \\
         \leq \sum_{n=0}^{t_{up,minimum}-1} Y_{status}(t+n) \\
-        \forall t \in \textrm{TIMESTEPS} | \\
-        t \neq t\_max , \\
+        \forall t \in \textrm{TIMESTEPS}, \\
         \forall (i,o) \in \textrm{MINUPTIMEFLOWS}.
 
     where :math:`Y_{status}(-1) := Y_{status,0}`, the `initial_status`
@@ -268,26 +261,21 @@ def _min_uptime_constraint(block):
         """
         Rule definition for min-uptime constraints of non-convex flows.
         """
-        if t < m.TIMESTEPS.at(-1):
-            # We have a 2D matrix of constraints,
-            # so testing is easier then just calling the rule for valid t.
-            expr = 0
-            expr += (
-                block.status[i, o, t] - _previous_status(block, i, o, t)
-            ) * m.flows[i, o].nonconvex.minimum_uptime[t]
-            expr += -sum(
-                block.status[i, o, u]
-                for u in range(
-                    t,
-                    min(
-                        t + m.flows[i, o].nonconvex.minimum_uptime[t],
-                        len(m.TIMESTEPS),
-                    ),
-                )
+        expr = 0
+        expr += (
+            block.status[i, o, t] - _previous_status(block, i, o, t)
+        ) * m.flows[i, o].nonconvex.minimum_uptime[t]
+        expr += -sum(
+            block.status[i, o, u]
+            for u in range(
+                t,
+                min(
+                    t + m.flows[i, o].nonconvex.minimum_uptime[t],
+                    len(m.TIMESTEPS),
+                ),
             )
-            return expr <= 0
-        else:
-            return Constraint.Skip
+        )
+        return expr <= 0
 
     return Constraint(block.MINUPTIMEFLOWS, m.TIMESTEPS, rule=_min_uptime_rule)
 

--- a/tests/test_flows/test_non_convex_flow.py
+++ b/tests/test_flows/test_non_convex_flow.py
@@ -4,6 +4,7 @@
 
 SPDX-FileCopyrightText: Deutsches Zentrum für Luft- und Raumfahrt e.V.
 SPDX-FileCopyrightText: Patrik Schönfeldt
+SPDX-FileCopyrightText: Dylan Pulver
 
 SPDX-License-Identifier: MIT
 """

--- a/tests/test_flows/test_non_convex_flow.py
+++ b/tests/test_flows/test_non_convex_flow.py
@@ -132,3 +132,66 @@ def test_shutdown_costs_start_on():
     flow_result = _run_flow_model(flow)
 
     assert (flow_result["flow"][:-1] == [1, 1, 1, 10, 1, 1, 1, 10, 1, 1]).all()
+
+
+def test_minimum_uptime_after_initial_downtime():
+    # The unit is off initially, so `status` is fixed to 0 for the first
+    # `minimum_downtime` steps. Starting up in the first free time step
+    # still has to respect `minimum_uptime`.
+    flow = solph.flows.Flow(
+        nominal_capacity=10,
+        minimum=0.5,
+        nonconvex=solph.NonConvex(
+            initial_status=0, minimum_downtime=2, minimum_uptime=4
+        ),
+        variable_costs=[1, 1, -10, 1, 1, 1, 1, 1, 1, 1],
+    )
+    flow_result = _run_flow_model(flow)
+
+    assert (flow_result["flow"][:-1] == [0, 0, 10, 5, 5, 5, 0, 0, 0, 0]).all()
+
+
+def test_minimum_downtime_after_initial_uptime():
+    # The unit is on initially, so `status` is fixed to 1 for the first
+    # `minimum_uptime` steps. Shutting down in the first free time step
+    # still has to respect `minimum_downtime`.
+    flow = solph.flows.Flow(
+        nominal_capacity=10,
+        minimum=0.5,
+        nonconvex=solph.NonConvex(
+            initial_status=1, minimum_uptime=2, minimum_downtime=4
+        ),
+        variable_costs=[1, 1, 10, -10, 1, 1, 1, 1, 1, 1],
+    )
+    flow_result = _run_flow_model(flow)
+
+    assert (flow_result["flow"][:-1] == [5, 5, 5, 10, 0, 0, 0, 0, 0, 0]).all()
+
+
+def test_minimum_uptime_at_first_timestep():
+    # Starting up in the very first time step is a startup relative to
+    # `initial_status=0` and thus has to respect `minimum_uptime`.
+    flow = solph.flows.Flow(
+        nominal_capacity=10,
+        minimum=0.5,
+        nonconvex=solph.NonConvex(initial_status=0, minimum_uptime=4),
+        variable_costs=[-10, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+    )
+    flow_result = _run_flow_model(flow)
+
+    assert (flow_result["flow"][:-1] == [10, 5, 5, 5, 0, 0, 0, 0, 0, 0]).all()
+
+
+def test_minimum_downtime_at_first_timestep():
+    # Shutting down in the very first time step is a shutdown relative to
+    # `initial_status=1` and thus has to respect `minimum_downtime`:
+    # the cheap time step 2 is out of reach, so the unit stays off.
+    flow = solph.flows.Flow(
+        nominal_capacity=10,
+        minimum=0.5,
+        nonconvex=solph.NonConvex(initial_status=1, minimum_downtime=4),
+        variable_costs=[20, 20, -10, 1, 1, 1, 1, 1, 1, 1],
+    )
+    flow_result = _run_flow_model(flow)
+
+    assert (flow_result["flow"][:-1] == 10 * [0]).all()


### PR DESCRIPTION
`minimum_uptime` / `minimum_downtime` are silently not enforced over the first time
steps, so the solver returns schedules that violate them. Both rules in
`src/oemof/solph/flows/_shared.py` were built only for `t > first_flexible_timestep`
(`_shared.py:217` and `:271`). That value is not a property of either constraint:
`NonConvex.__init__`
(`_options.py:317-320`) sets it to `minimum_downtime[0]` when `initial_status == 0`
and to `minimum_uptime[0]` otherwise. It says how many initial `status` values
`NonConvexFlowBlock` fixes, and it comes from only one of the two minimum times — so
when they differ, the rule for the *other* one is skipped over time steps where a
real transition can happen. Neither rule covered `t = 0` at all, although
`initial_status` already supplies the pre-horizon status to the startup and shutdown
rules just below (`_shared.py:317` and `:345`).

Two runs on current `dev` (10 h, `nominal_capacity=10`, `minimum=0.5`, CBC 2.10.13):

| `NonConvex` | `variable_costs` | `dev` status / obj. | patched |
|---|---|---|---|
| `initial_status=0, minimum_downtime=2, minimum_uptime=4` | `[1,1,-10,1,...]` | `[0,0,1,0,...]`, -100.0 | `[0,0,1,1,1,1,0,...]`, -85.0 |
| `initial_status=1, minimum_uptime=2, minimum_downtime=4` | `[1,1,10,-10,1,...]` | `[1,1,0,1,1,0,...]`, -85.0 | `[1,1,1,1,0,...]`, -40.0 |

One time step of uptime against `minimum_uptime=4`, and one of downtime against
`minimum_downtime=4`.

### The change

Build both rules for every time step and take the status before the horizon from
`initial_status`, the convention the startup/shutdown rules already used. That is
factored into `_previous_status()` and reused in all four rules, so the constraint
rules no longer read `first_flexible_timestep`. Over the fixed time steps the added
rows hold for any binary `status`, so the documented `initial_status` behaviour is
unchanged. Both docstrings are updated to match.

Worth noting: the obvious smaller fix does not hold. Relaxing the guard to
`first_flexible_timestep <= t` raises `KeyError: status[..., -1]` at `t = 0`, and
guarding that as `max(1, first_flexible_timestep) <= t` closes the mismatched-minimums
hole but still leaves `t = 0` unconstrained.

Partly overlaps #1102 — a `minimum_uptime`-only flow with `initial_status=0` now
honours the uptime when it starts in the first time step, without changing any
default. Not #1318, which asks for optional cyclical wrap-around; this is only about
the start of the horizon.

Four tests in `tests/test_flows/test_non_convex_flow.py` asserting literal flow
series. All four fail on unpatched `dev`; the two `t = 0` ones still fail against the
guard-only variant above. Full suite 286 passed / 2 skipped before, 290 /
2 after, nothing else changed. `flake8 src tests`, `isort --check-only --profile
black`, `black --check` on the touched files and `sphinx-build -W -b html` are clean.

Changelog note and name added to `docs/whatsnew/v0-6-5.rst` — CONTRIBUTING points at
`next_version.rst`, which no longer exists, so please redirect me if that is wrong.
This can change results for existing models combining `initial_status` with
`minimum_uptime`/`minimum_downtime`, in the direction of the documented behaviour;
flagged as such in the changelog.

Written with AI assistance; the schedules above are solver output, not inference.
